### PR TITLE
feat: Outbox 패턴 이벤트 엔티티 및 Repository 구현 #10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ out/
 
 # Kotlin
 *.kotlin_module
+.kotlin/
 
 # OS
 .DS_Store

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/outbox/OutboxEvent.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/outbox/OutboxEvent.kt
@@ -12,13 +12,13 @@ class OutboxEvent(
     @Column(name = "id")
     val id: UUID? = null,
 
-    @Column(name = "aggregate_type", nullable = false)
+    @Column(name = "aggregate_type", nullable = false, length = 50)
     val aggregateType: String,
 
     @Column(name = "aggregate_id", nullable = false)
     val aggregateId: UUID,
 
-    @Column(name = "event_type", nullable = false)
+    @Column(name = "event_type", nullable = false, length = 100)
     val eventType: String,
 
     @Column(name = "payload", nullable = false, columnDefinition = "jsonb")
@@ -33,9 +33,17 @@ class OutboxEvent(
     @Column(name = "retry_count", nullable = false)
     var retryCount: Int = 0,
 
-    @Column(name = "last_error")
+    @Column(name = "last_error", columnDefinition = "text")
     var lastError: String? = null,
 
     @Column(name = "created_at", nullable = false)
     val createdAt: LocalDateTime = LocalDateTime.now()
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is OutboxEvent) return false
+        return id != null && id == other.id
+    }
+
+    override fun hashCode(): Int = id?.hashCode() ?: 0
+}

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/outbox/OutboxEventRepository.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/outbox/OutboxEventRepository.kt
@@ -1,0 +1,21 @@
+package com.ticketqueue.common.outbox
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import java.time.LocalDateTime
+import java.util.UUID
+
+interface OutboxEventRepository : JpaRepository<OutboxEvent, UUID> {
+
+    fun findByPublishedFalseAndRetryCountLessThanOrderByCreatedAtAsc(
+        maxRetryCount: Int
+    ): List<OutboxEvent>
+
+    fun findByAggregateTypeAndAggregateId(
+        aggregateType: String,
+        aggregateId: UUID
+    ): List<OutboxEvent>
+
+    @Modifying
+    fun deleteByPublishedTrueAndPublishedAtBefore(before: LocalDateTime): Int
+}

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/outbox/ProcessedEvent.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/outbox/ProcessedEvent.kt
@@ -1,19 +1,45 @@
 package com.ticketqueue.common.outbox
 
 import jakarta.persistence.*
+import java.io.Serializable
 import java.time.LocalDateTime
 import java.util.UUID
 
+data class ProcessedEventId(
+    val eventId: UUID = UUID.randomUUID(),
+    val consumerService: String = ""
+) : Serializable
+
 @Entity
 @Table(name = "processed_events", schema = "common")
+@IdClass(ProcessedEventId::class)
 class ProcessedEvent(
     @Id
     @Column(name = "event_id")
     val eventId: UUID,
 
-    @Column(name = "consumer_group", nullable = false)
-    val consumerGroup: String,
+    @Id
+    @Column(name = "consumer_service", nullable = false, length = 50)
+    val consumerService: String,
+
+    @Column(name = "aggregate_id", nullable = false)
+    val aggregateId: UUID,
+
+    @Column(name = "event_type", nullable = false, length = 100)
+    val eventType: String,
 
     @Column(name = "processed_at", nullable = false)
     val processedAt: LocalDateTime = LocalDateTime.now()
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ProcessedEvent) return false
+        return eventId == other.eventId && consumerService == other.consumerService
+    }
+
+    override fun hashCode(): Int {
+        var result = eventId.hashCode()
+        result = 31 * result + consumerService.hashCode()
+        return result
+    }
+}

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/outbox/ProcessedEventRepository.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/outbox/ProcessedEventRepository.kt
@@ -1,0 +1,14 @@
+package com.ticketqueue.common.outbox
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import java.time.LocalDateTime
+import java.util.UUID
+
+interface ProcessedEventRepository : JpaRepository<ProcessedEvent, ProcessedEventId> {
+
+    fun existsByEventIdAndConsumerService(eventId: UUID, consumerService: String): Boolean
+
+    @Modifying
+    fun deleteByProcessedAtBefore(before: LocalDateTime): Int
+}


### PR DESCRIPTION
## 작업 내용
- OutboxEvents JPA 엔티티 구현
- ProcessedEvents JPA 엔티티 구현
- JPA Repository 인터페이스 추가

## 변경 이유
- Outbox 패턴 기반 이벤트 발행을 위한 공통 이벤트 저장소 구성

## 영향 범위
- Common 모듈
- 이벤트 발행/처리 로직에서 참조 예정