### PR TITLE
feat: 서비스 간 내부 API 인증 구현 #65

### DIFF
--- a/backend/common/build.gradle.kts
+++ b/backend/common/build.gradle.kts
@@ -11,6 +11,12 @@ plugins {
 tasks.bootJar { enabled = false }
 tasks.jar { enabled = true }
 
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:${libs.versions.springCloud.get()}")
+    }
+}
+
 dependencies {
     // Kotlin
     api(libs.bundles.kotlin)
@@ -22,6 +28,7 @@ dependencies {
     api(libs.spring.boot.starter.data.jpa)
     api(libs.spring.boot.starter.validation)
     compileOnly(libs.spring.boot.starter.security)
+    compileOnly(libs.spring.cloud.starter.openfeign)
 
     // Database
     runtimeOnly(libs.postgresql)

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/config/InternalApiFeignConfig.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/config/InternalApiFeignConfig.kt
@@ -1,0 +1,23 @@
+package com.ticketqueue.common.config
+
+import com.ticketqueue.common.security.InternalApiKeyValidator
+import feign.RequestInterceptor
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConditionalOnClass(RequestInterceptor::class)
+class InternalApiFeignConfig(
+    @Value("\${internal.api.key:}")
+    private val internalApiKey: String
+) {
+
+    @Bean
+    fun internalApiKeyRequestInterceptor(): RequestInterceptor {
+        return RequestInterceptor { template ->
+            template.header(InternalApiKeyValidator.HEADER_NAME, internalApiKey)
+        }
+    }
+}

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/config/InternalApiWebConfig.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/config/InternalApiWebConfig.kt
@@ -1,0 +1,17 @@
+package com.ticketqueue.common.config
+
+import com.ticketqueue.common.security.InternalApiAuthInterceptor
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class InternalApiWebConfig(
+    private val internalApiAuthInterceptor: InternalApiAuthInterceptor
+) : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(internalApiAuthInterceptor)
+            .addPathPatterns("/internal/**")
+    }
+}

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
@@ -39,6 +39,9 @@ enum class ErrorCode(
     PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "PAYMENT_AMOUNT_MISMATCH", "결제 금액이 일치하지 않습니다."),
     REFUND_FAILED(HttpStatus.BAD_REQUEST, "REFUND_FAILED", "환불에 실패했습니다."),
 
+    // Internal API
+    INTERNAL_API_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "INTERNAL_API_UNAUTHORIZED", "내부 API 인증에 실패했습니다."),
+
     // Event
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT_NOT_FOUND", "존재하지 않는 공연입니다."),
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE_NOT_FOUND", "존재하지 않는 공연 회차입니다."),

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/security/InternalApiAuthInterceptor.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/security/InternalApiAuthInterceptor.kt
@@ -1,0 +1,21 @@
+package com.ticketqueue.common.security
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+@Component
+class InternalApiAuthInterceptor(
+    private val internalApiKeyValidator: InternalApiKeyValidator
+) : HandlerInterceptor {
+
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any
+    ): Boolean {
+        internalApiKeyValidator.validate(request)
+        return true
+    }
+}

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/security/InternalApiKeyValidator.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/security/InternalApiKeyValidator.kt
@@ -2,6 +2,8 @@ package com.ticketqueue.common.security
 
 import com.ticketqueue.common.exception.BusinessException
 import com.ticketqueue.common.exception.ErrorCode
+import jakarta.servlet.http.HttpServletRequest
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
@@ -10,17 +12,29 @@ class InternalApiKeyValidator(
     @Value("\${internal.api.key:}")
     private val internalApiKey: String
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     companion object {
         const val HEADER_NAME = "X-Service-Api-Key"
     }
 
-    fun validate(apiKey: String?) {
+    fun validate(request: HttpServletRequest) {
         if (internalApiKey.isBlank()) {
             throw IllegalStateException("Internal API key is not configured")
         }
 
+        val apiKey = request.getHeader(HEADER_NAME)
+
         if (apiKey.isNullOrBlank() || apiKey != internalApiKey) {
-            throw BusinessException(ErrorCode.FORBIDDEN, "Invalid internal API key")
+            log.warn(
+                "[INTERNAL_API_AUTH_FAILED] uri={}, method={}, remoteAddr={}, forwardedFor={}, keyPresent={}",
+                request.requestURI,
+                request.method,
+                request.remoteAddr,
+                request.getHeader("X-Forwarded-For"),
+                !apiKey.isNullOrBlank()
+            )
+            throw BusinessException(ErrorCode.INTERNAL_API_UNAUTHORIZED)
         }
     }
 }


### PR DESCRIPTION
## Summary                                                                                                      
- `/internal/**` 경로에 대한 API Key 기반 서비스 간 인증을 common 모듈에 구현                                   
- `X-Service-Api-Key` 헤더를 통한 요청 검증 및 인증 실패 시 401 응답 반환                                       
- Feign 요청 시 자동으로 API Key 헤더를 주입하는 인터셉터 추가                                                  
                                                                                                                
## Changes                                                                                                      
- `ErrorCode`: `INTERNAL_API_UNAUTHORIZED` (401) 추가                                                           
- `InternalApiKeyValidator`: `HttpServletRequest` 기반 검증 + 감사 로그                                         
- `InternalApiAuthInterceptor`: `/internal/**` 경로용 HandlerInterceptor                                        
- `InternalApiWebConfig`: 인터셉터 등록 (WebMvcConfigurer)                                                      
- `InternalApiFeignConfig`: `@ConditionalOnClass` 기반 Feign RequestInterceptor                                 
- `build.gradle.kts`: Spring Cloud BOM + OpenFeign compileOnly 의존성                                           
                                                                                                                
## Test plan                                                                                                    
- [x] `./gradlew :common:build` 성공 확인                                                                       
- [x] `./gradlew build` 전체 빌드 성공 확인                                                                     
- [x] InternalApiKeyValidator 단위 테스트 (유효/무효/누락 키)                                                   
- [x] InternalApiAuthInterceptor 단위 테스트                                