### PR TITLE
feature: Kafka Consumer 멱등성 처리를 위한 공통 모듈 #66

### DIFF
--- a/backend/common/build.gradle.kts
+++ b/backend/common/build.gradle.kts
@@ -29,10 +29,12 @@ dependencies {
     api(libs.spring.boot.starter.validation)
     compileOnly(libs.spring.boot.starter.security)
     compileOnly(libs.spring.cloud.starter.openfeign)
+    compileOnly(libs.spring.kafka)
 
     // Database
     runtimeOnly(libs.postgresql)
 
     // Test
     testImplementation(libs.bundles.test.base)
+    testImplementation(libs.spring.kafka)
 }

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/kafka/ExceptionClassifier.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/kafka/ExceptionClassifier.kt
@@ -1,0 +1,43 @@
+package com.ticketqueue.common.kafka
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.dao.PessimisticLockingFailureException
+import org.springframework.dao.QueryTimeoutException
+import org.springframework.kafka.KafkaException
+import java.util.concurrent.TimeoutException
+
+object ExceptionClassifier {
+
+    private val nonRetryableExceptions: Set<Class<out Exception>> = setOf(
+        IllegalArgumentException::class.java,
+        IllegalStateException::class.java,
+        JsonProcessingException::class.java,
+        DataIntegrityViolationException::class.java,
+        NullPointerException::class.java,
+        ClassCastException::class.java,
+    )
+
+    private val retryableExceptions: Set<Class<out Throwable>> = setOf(
+        TimeoutException::class.java,
+        QueryTimeoutException::class.java,
+        KafkaException::class.java,
+        PessimisticLockingFailureException::class.java,
+    )
+
+    fun isRetryable(e: Throwable): Boolean {
+        var current: Throwable? = e
+        while (current != null) {
+            if (nonRetryableExceptions.any { it.isInstance(current) }) {
+                return false
+            }
+            if (retryableExceptions.any { it.isInstance(current) }) {
+                return true
+            }
+            current = current.cause
+        }
+        return true
+    }
+
+    fun nonRetryableExceptions(): Set<Class<out Exception>> = nonRetryableExceptions
+}

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/kafka/IdempotentConsumerTemplate.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/kafka/IdempotentConsumerTemplate.kt
@@ -1,0 +1,64 @@
+package com.ticketqueue.common.kafka
+
+import com.ticketqueue.common.event.BaseEvent
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+
+@Component
+class IdempotentConsumerTemplate(
+    private val processedEventService: ProcessedEventService,
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun <T : BaseEvent> process(
+        event: T,
+        consumerService: String,
+        acknowledgment: Acknowledgment,
+        businessLogic: (T) -> Unit,
+    ) {
+        val eventId = event.eventId
+        val eventType = event.eventType
+        val aggregateId = event.aggregateId
+
+        log.debug(
+            "Processing event: eventId={}, type={}, consumer={}",
+            eventId, eventType, consumerService,
+        )
+
+        val isNew = processedEventService.tryRecord(
+            eventId = eventId,
+            consumerService = consumerService,
+            aggregateId = aggregateId,
+            eventType = eventType,
+        )
+
+        if (!isNew) {
+            log.info("Skipping duplicate event: eventId={}, consumer={}", eventId, consumerService)
+            acknowledgment.acknowledge()
+            return
+        }
+
+        try {
+            businessLogic(event)
+            acknowledgment.acknowledge()
+            log.debug("Event processed successfully: eventId={}, consumer={}", eventId, consumerService)
+        } catch (e: Exception) {
+            if (ExceptionClassifier.isRetryable(e)) {
+                log.warn(
+                    "Retryable error processing event: eventId={}, consumer={}, error={}",
+                    eventId, consumerService, e.message,
+                )
+                processedEventService.deleteRecord(eventId, consumerService)
+                throw e
+            } else {
+                log.error(
+                    "Non-retryable error processing event: eventId={}, consumer={}, error={}",
+                    eventId, consumerService, e.message, e,
+                )
+                throw e
+            }
+        }
+    }
+}

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/kafka/KafkaErrorHandlerConfig.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/kafka/KafkaErrorHandlerConfig.kt
@@ -1,0 +1,83 @@
+package com.ticketqueue.common.kafka
+
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.StringSerializer
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.listener.CommonErrorHandler
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer
+import org.springframework.kafka.listener.DefaultErrorHandler
+import org.springframework.kafka.support.serializer.JacksonJsonSerializer
+import org.springframework.util.backoff.ExponentialBackOff
+
+@Configuration
+@ConditionalOnClass(KafkaTemplate::class)
+class KafkaErrorHandlerConfig {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Value("\${spring.kafka.bootstrap-servers:localhost:9092}")
+    private lateinit var bootstrapServers: String
+
+    companion object {
+        private val DLQ_TOPIC_MAP = mapOf(
+            "reservation.events" to "dlq.reservation",
+            "payment.events" to "dlq.payment",
+        )
+    }
+
+    @Bean
+    fun dlqKafkaTemplate(): KafkaTemplate<String, Any> {
+        val producerProps = mutableMapOf<String, Any>(
+            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to bootstrapServers,
+            ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
+            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to JacksonJsonSerializer::class.java,
+            ProducerConfig.ACKS_CONFIG to "all",
+            ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG to true,
+        )
+        val producerFactory = DefaultKafkaProducerFactory<String, Any>(producerProps)
+        return KafkaTemplate(producerFactory)
+    }
+
+    @Bean
+    fun deadLetterPublishingRecoverer(
+        dlqKafkaTemplate: KafkaTemplate<String, Any>,
+    ): DeadLetterPublishingRecoverer {
+        return DeadLetterPublishingRecoverer(dlqKafkaTemplate) { record, _ ->
+            val originalTopic = record.topic()
+            val dlqTopic = DLQ_TOPIC_MAP[originalTopic] ?: "dlq.$originalTopic"
+            log.warn("Sending failed record to DLQ: {} -> {}", originalTopic, dlqTopic)
+            org.apache.kafka.common.TopicPartition(dlqTopic, -1)
+        }
+    }
+
+    @Bean
+    fun kafkaErrorHandler(
+        deadLetterPublishingRecoverer: DeadLetterPublishingRecoverer,
+    ): CommonErrorHandler {
+        val backOff = ExponentialBackOff().apply {
+            initialInterval = 1_000L
+            multiplier = 2.0
+            maxInterval = 10_000L
+            maxElapsedTime = 15_000L
+        }
+
+        val errorHandler = DefaultErrorHandler(deadLetterPublishingRecoverer, backOff)
+
+        ExceptionClassifier.nonRetryableExceptions().forEach { exceptionClass ->
+            errorHandler.addNotRetryableExceptions(exceptionClass)
+        }
+
+        log.info(
+            "Kafka error handler configured: backoff=exponential(1s/2x/10s), maxRetries=3, nonRetryable={}",
+            ExceptionClassifier.nonRetryableExceptions().map { it.simpleName },
+        )
+
+        return errorHandler
+    }
+}

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/kafka/ProcessedEventService.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/kafka/ProcessedEventService.kt
@@ -1,0 +1,57 @@
+package com.ticketqueue.common.kafka
+
+import com.ticketqueue.common.outbox.ProcessedEvent
+import com.ticketqueue.common.outbox.ProcessedEventId
+import com.ticketqueue.common.outbox.ProcessedEventRepository
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Service
+class ProcessedEventService(
+    private val processedEventRepository: ProcessedEventRepository,
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun tryRecord(
+        eventId: UUID,
+        consumerService: String,
+        aggregateId: UUID,
+        eventType: String,
+    ): Boolean {
+        return try {
+            processedEventRepository.save(
+                ProcessedEvent(
+                    eventId = eventId,
+                    consumerService = consumerService,
+                    aggregateId = aggregateId,
+                    eventType = eventType,
+                )
+            )
+            true
+        } catch (e: DataIntegrityViolationException) {
+            log.debug("Event already processed: eventId={}, consumer={}", eventId, consumerService)
+            false
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun deleteRecord(eventId: UUID, consumerService: String) {
+        processedEventRepository.deleteById(ProcessedEventId(eventId, consumerService))
+        log.debug("Deleted processed event record for retry: eventId={}, consumer={}", eventId, consumerService)
+    }
+
+    @Transactional
+    fun cleanupOldEvents(retentionDays: Long = 7): Int {
+        val cutoff = LocalDateTime.now().minusDays(retentionDays)
+        val deletedCount = processedEventRepository.deleteByProcessedAtBefore(cutoff)
+        log.info("Cleaned up {} processed events older than {} days", deletedCount, retentionDays)
+        return deletedCount
+    }
+}


### PR DESCRIPTION
## Summary

* Kafka Consumer 멱등성 처리를 위한 **공통 모듈 도입**
* INSERT-first 전략 기반 **중복 방지 + 재시도/DLQ 분기 표준화**

## Key Changes

* **IdempotentConsumerTemplate**

  * Template Method 기반 공통 Consumer 처리 흐름 제공
  * 중복 이벤트 ack+skip, 성공 ack, 실패 시 재시도/DLQ 분기

* **ProcessedEventService**

  * INSERT-first 멱등성 체크 (`REQUIRES_NEW`)
  * 재시도 가능 예외 시 레코드 삭제 후 재처리 허용
  * 7일 초과 처리 이력 정리

* **ExceptionClassifier**

  * 재시도 가능/불가 예외 분류
  * cause chain 기준 판단

* **KafkaErrorHandlerConfig**

  * Kafka 사용 서비스에서만 활성화
  * 3회 지수 백오프 재시도 후 DLQ 전송
  * 토픽별 DLQ 라우팅 규칙 적용

## Processing Flow

```
KafkaListener
 → tryRecord (중복 시 ack + skip)
 → businessLogic
 → 성공: ack
 → 재시도 가능 예외: record 삭제 + 재시도
 → 재시도 불가 예외: 즉시 DLQ
```

## Test

* common / reservation / payment / event 서비스 컴파일 성공