### PR TITLE
refactor: Spring Boot 4.0.2 -> 3.5.10 다운그레이드 #76

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,96 @@
+############################
+# 1. 기본 정책
+############################
+
+# 모든 텍스트 파일은 LF로 통일
+* text=auto eol=lf
+
+
+############################
+# 2. 소스 코드
+############################
+
+# Java / Kotlin
+*.java           text eol=lf
+*.kt             text eol=lf
+*.kts            text eol=lf
+
+# Spring / Gradle
+*.gradle         text eol=lf
+*.gradle.kts     text eol=lf
+gradlew          text eol=lf
+
+# JavaScript / TypeScript
+*.js             text eol=lf
+*.ts             text eol=lf
+*.jsx            text eol=lf
+*.tsx            text eol=lf
+
+
+############################
+# 3. 설정 파일
+############################
+
+# YAML / JSON / Properties
+*.yml            text eol=lf
+*.yaml           text eol=lf
+*.json           text eol=lf
+*.properties     text eol=lf
+
+# Env / Config
+.env             text eol=lf
+*.env            text eol=lf
+
+
+############################
+# 4. Shell / Script
+############################
+
+# Shell (Linux/Mac)
+*.sh             text eol=lf
+
+# SQL
+*.sql            text eol=lf
+
+
+############################
+# 5. 문서
+############################
+
+# Markdown / Text
+*.md             text eol=lf
+*.txt            text eol=lf
+
+
+############################
+# 6. Docker / Infra
+############################
+
+Dockerfile       text eol=lf
+*.dockerfile     text eol=lf
+docker-compose.yml text eol=lf
+
+
+############################
+# 7. Binary files (절대 변환 금지)
+############################
+
+# Images
+*.png            binary
+*.jpg            binary
+*.jpeg           binary
+*.gif            binary
+*.webp           binary
+*.svg            binary
+
+# Archives
+*.zip            binary
+*.tar            binary
+*.gz             binary
+*.jar            binary
+*.war            binary
+
+# Executables
+*.exe            binary
+*.dll            binary
+*.so             binary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## 기술 스택
 
 ### Backend
-- Java, Spring Boot 4.0.2, Spring Cloud Gateway
+- Java, spring boot 4.0.2 3.5.10, Spring Cloud Gateway
 - PostgreSQL 18 (단일 인스턴스, 스키마 분리)
 - Redis 7.x (캐시, 대기열, 분산 락)
 - Apache Kafka 4.x KRaft 모드 (이벤트 스트리밍, Zookeeper 불필요)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -20,7 +20,7 @@
 
 ### 인프라 및 기술 스택
 *   **Frontend:** Next.js 16+ (Vercel), React.
-*   **Backend:** Java 25, Spring Boot 4.0.2, Spring Cloud.
+*   **Backend:** Java 25, spring boot 4.0.2 3.5.10, Spring Cloud.
 *   **Database:** PostgreSQL 18 (단일 인스턴스, 서비스별 스키마 분리), Redis 7.x (캐시, 대기열, 락).
 *   **Messaging:** Apache Kafka 4.x (이벤트 기반 아키텍처).
 *   **Cloud/DevOps:** AWS (Free Tier 최적화: RDS t3.micro, EC2 t2.micro), LocalStack (로컬 개발), Docker Compose.

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/kafka/KafkaErrorHandlerConfig.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/kafka/KafkaErrorHandlerConfig.kt
@@ -12,7 +12,7 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.listener.CommonErrorHandler
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer
 import org.springframework.kafka.listener.DefaultErrorHandler
-import org.springframework.kafka.support.serializer.JacksonJsonSerializer
+import org.springframework.kafka.support.serializer.JsonSerializer
 import org.springframework.util.backoff.ExponentialBackOff
 
 @Configuration
@@ -36,7 +36,7 @@ class KafkaErrorHandlerConfig {
         val producerProps = mutableMapOf<String, Any>(
             ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to bootstrapServers,
             ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
-            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to JacksonJsonSerializer::class.java,
+            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to JsonSerializer::class.java,
             ProducerConfig.ACKS_CONFIG to "all",
             ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG to true,
         )

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -3,9 +3,8 @@
 kotlin = "2.1.0"
 
 # Spring
-spring-boot = "4.0.2"
+spring-boot = "3.5.10"
 springCloud = "2025.0.1"
-spring-cloud-gateway = "4.1.1"
 spring-dependency-management = "1.1.7"
 
 # Database
@@ -49,7 +48,7 @@ spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
 
 # Spring Cloud
-spring-cloud-starter-gateway = { module = "org.springframework.cloud:spring-cloud-starter-gateway", version.ref = "spring-cloud-gateway" }
+spring-cloud-starter-gateway = { module = "org.springframework.cloud:spring-cloud-starter-gateway" }
 spring-cloud-starter-openfeign = { module = "org.springframework.cloud:spring-cloud-starter-openfeign" }
 spring-cloud-starter-circuitbreaker-resilience4j = { module = "org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j" }
 

--- a/docs/architecture/00_overview.md
+++ b/docs/architecture/00_overview.md
@@ -69,7 +69,7 @@
 | **Frontend** | Next.js 16+ | React 기반 SSR/CSR |
 |  | Vercel | 프론트엔드 배포 플랫폼 |
 | **API Gateway** | Spring Cloud Gateway | 통합 진입점, 라우팅, 인증 |
-| **Backend** | Spring Boot 4.0.2 | 마이크로서비스 프레임워크 |
+| **Backend** | spring boot 4.0.2 3.5.10 | 마이크로서비스 프레임워크 |
 |  | Java 25+ | 백엔드 언어 |
 | **Database** | PostgreSQL 18 | RDB (단일 인스턴스, 스키마 분리) |
 |  | Redis 7.x | 캐시, 대기열, 분산 락 |


### PR DESCRIPTION
## 진행 사항
- Spring Boot 4.0.2 -> 3.5.10 다운그레이드
- Spring Cloud 2025.0.1 유지
- Spring Cloud Gateway BOM 자동 관리로 전환 (명시적 버전 제거)
- Kafka JsonSerializer로 변경 (JacksonJsonSerializer는 Spring Boot 4.x 전용)

## 검증 내용
- 전체 프로젝트 빌드 및 테스트 성공 확인 ✓
- Spring Boot: 3.5.10 ✓
- Spring Cloud: 2025.0.1 ✓
- Spring Cloud Gateway: 4.3.3 (BOM 관리) ✓
- Redisson: 3.40.2 ✓
- Resilience4j: 2.2.0 ✓