### PR TITLE
chore: event service 프로젝트 초기 설정 완료 #30

### DIFF
--- a/backend/event-service/build.gradle.kts
+++ b/backend/event-service/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
 
     // Spring Boot
     implementation(libs.spring.boot.starter.data.redis)
+    implementation(libs.spring.boot.starter.security)
 
     // Kafka
     implementation(libs.spring.kafka)

--- a/backend/event-service/src/main/resources/application-local.yml
+++ b/backend/event-service/src/main/resources/application-local.yml
@@ -2,15 +2,28 @@
 # Usage: Run with --spring.profiles.active=local
 
 spring:
-  datasource:
-    url: jdbc:postgresql://192.168.50.2:5432/ticket_queue
+  config:
+    activate:
+      on-profile: local
 
-  data:
-    redis:
-      host: 192.168.50.2
+  datasource:
+    url: jdbc:postgresql://192.168.50.2:5432/ticket_queue?currentSchema=event_service,common
+    username: event_svc_user
+    password: ${db_password}
+    driver-class-name: org.postgresql.Driver
 
   kafka:
     bootstrap-servers: 192.168.50.2:9092
+    consumer:
+      group-id: event-service
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: com.ticketqueue.*
+    listener:
+      ack-mode: MANUAL_IMMEDIATE
 
 logging:
   level:

--- a/backend/event-service/src/main/resources/application-local.yml
+++ b/backend/event-service/src/main/resources/application-local.yml
@@ -1,0 +1,19 @@
+# Local Development Environment Configuration
+# Usage: Run with --spring.profiles.active=local
+
+spring:
+  datasource:
+    url: jdbc:postgresql://192.168.50.2:5432/ticket_queue
+
+  data:
+    redis:
+      host: 192.168.50.2
+
+  kafka:
+    bootstrap-servers: 192.168.50.2:9092
+
+logging:
+  level:
+    com.ticketqueue.event: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE

--- a/backend/event-service/src/main/resources/application.yml
+++ b/backend/event-service/src/main/resources/application.yml
@@ -4,12 +4,11 @@ server:
 spring:
   application:
     name: event-service
-
-  datasource:
-    url: jdbc:postgresql://192.168.50.2:5432/ticket_queue
-    username: event_svc_user
-    password: ${DB_PASSWORD:password}
-    driver-class-name: org.postgresql.Driver
+  config:
+    import:
+      - "optional:classpath:/application-common-${spring.profiles.active}.yml"
+      - "optional:aws-secretsmanager:event-svc/secure-config"
+      - "optional:aws-secretsmanager:common/secure-config"
 
   jpa:
     hibernate:
@@ -26,19 +25,6 @@ spring:
     redis:
       host: 192.168.50.2
       port: 6379
-
-  kafka:
-    bootstrap-servers: 192.168.50.2:9092
-    consumer:
-      group-id: event-service
-      auto-offset-reset: earliest
-      enable-auto-commit: false
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      properties:
-        spring.json.trusted.packages: com.ticketqueue.*
-    listener:
-      ack-mode: MANUAL_IMMEDIATE
 
 cache:
   event:

--- a/backend/event-service/src/main/resources/application.yml
+++ b/backend/event-service/src/main/resources/application.yml
@@ -21,11 +21,6 @@ spring:
     show-sql: true
     open-in-view: false
 
-  data:
-    redis:
-      host: 192.168.50.2
-      port: 6379
-
 cache:
   event:
     ttl: 300  # 5 minutes in seconds

--- a/backend/event-service/src/main/resources/application.yml
+++ b/backend/event-service/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: event-service
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/ticketing
+    url: jdbc:postgresql://192.168.50.2:5432/ticket_queue
     username: event_svc_user
     password: ${DB_PASSWORD:password}
     driver-class-name: org.postgresql.Driver
@@ -24,11 +24,11 @@ spring:
 
   data:
     redis:
-      host: localhost
+      host: 192.168.50.2
       port: 6379
 
   kafka:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: 192.168.50.2:9092
     consumer:
       group-id: event-service
       auto-offset-reset: earliest


### PR DESCRIPTION
## Summary
  - Event Service 프로젝트 초기 설정 완료 (#30)
  - Spring Boot 3.5.10 기반 마이크로서비스 구성
  - PostgreSQL, Redis, Kafka 연동 설정

## Changes
  - **프로젝트 구조**
    - Spring Boot 3.5.10, Kotlin, Gradle Kotlin DSL 기반 프로젝트 생성
    - `backend/event-service` 디렉토리 구조 설정

  - **의존성 추가**
    - Spring Data JPA (PostgreSQL 연동)
    - Spring Data Redis (캐싱)
    - Spring Kafka (이벤트 스트리밍)
    - Spring Security (GlobalExceptionHandler 호환성)
    - Common 모듈 의존성

  - **환경 설정**
    - `application.yml`: 기본 환경 설정 (192.168.50.2)
      - PostgreSQL: event_service 스키마, HikariCP 연결 풀
      - Redis: 캐싱 (event, schedule, seats TTL 5분)
      - Kafka: Consumer 설정 (수동 커밋, 멱등성)
    - `application-local.yml`: 로컬 개발 환경 설정 (192.168.50.2)

  - **애플리케이션 설정**
    - Component Scan: `com.ticketqueue.event`, `com.ticketqueue.common`
    - JPA: Hibernate DDL 검증 모드, PostgreSQL 방언
    - Kafka: 수동 오프셋 커밋, JSON 역직렬화

## Test plan
  - [x] Docker 인프라 실행 확인 (PostgreSQL, Redis, Kafka)
  - [x] PostgreSQL 연결 테스트 (`event_svc_user`, `event_service` 스키마)
  - [x] HikariCP 연결 풀 초기화 확인
  - [x] Hibernate 초기화 확인 (Database version: 18.1)
  - [x] 애플리케이션 빌드 성공 (`./gradlew :event-service:build`)
  - [x] 애플리케이션 실행 테스트 (ProcessedEventRepository Bean 등록 필요함을 확인)
  - [ ] 완전 실행 테스트 (Issue #85 완료 후 가능)