### PR TITLE
feature: common 모듈 JPA Reposiutory 설정 추가

### DIFF
--- a/backend/common/src/main/kotlin/com/ticketqueue/common/config/CommonJpaConfig.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/config/CommonJpaConfig.kt
@@ -11,9 +11,22 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories
  *
  * ProcessedEvent, OutboxEvent Entity와 Repository를 Spring Bean으로 등록합니다.
  *
- * @ConditionalOnClass: JPA 의존성이 있는 서비스에서만 활성화
- * @EnableJpaRepositories: Repository 인터페이스 스캔 및 Bean 등록
- * @EntityScan: Entity 클래스 탐색
+ * ## Repository 사용처
+ *
+ * ### OutboxEventRepository (Transactional Outbox Pattern)
+ * - **Reservation Service**: ReservationCancelled 이벤트 발행 (Producer)
+ * - **Payment Service**: PaymentSuccess, PaymentFailed 이벤트 발행 (Producer)
+ * - **Event Service**: 사용하지 않음 (Producer가 아님, Consumer 전용)
+ *
+ * ### ProcessedEventRepository (Consumer 멱등성 보장)
+ * - **Reservation Service**: payment.events 구독 (Consumer)
+ * - **Event Service**: payment.events, reservation.events 구독 (Consumer)
+ * - **Payment Service**: 사용하지 않음 (Producer 전용, Consumer 아님)
+ *
+ * ## 어노테이션
+ * - @ConditionalOnClass: JPA 의존성이 있는 서비스에서만 활성화
+ * - @EnableJpaRepositories: Repository 인터페이스 스캔 및 Bean 등록
+ * - @EntityScan: Entity 클래스 탐색
  */
 @Configuration
 @ConditionalOnClass(EntityManagerFactory::class)

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/config/CommonJpaConfig.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/config/CommonJpaConfig.kt
@@ -1,0 +1,22 @@
+package com.ticketqueue.common.config
+
+import jakarta.persistence.EntityManagerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+
+/**
+ * Common 모듈의 JPA Repository 설정
+ *
+ * ProcessedEvent, OutboxEvent Entity와 Repository를 Spring Bean으로 등록합니다.
+ *
+ * @ConditionalOnClass: JPA 의존성이 있는 서비스에서만 활성화
+ * @EnableJpaRepositories: Repository 인터페이스 스캔 및 Bean 등록
+ * @EntityScan: Entity 클래스 탐색
+ */
+@Configuration
+@ConditionalOnClass(EntityManagerFactory::class)
+@EnableJpaRepositories(basePackages = ["com.ticketqueue.common.outbox"])
+@EntityScan(basePackages = ["com.ticketqueue.common.outbox"])
+class CommonJpaConfig


### PR DESCRIPTION
## Summary                                                                                           
  - Common 모듈에 JPA Repository 설정을 추가하여 `ProcessedEventRepository`와 `OutboxEventRepository`  
   Spring Bean으로 등록되도록 구현                                                                     
  - Issue #85 해결: Event Service와 User Service에서 발생하던 Bean 주입 실패 문제 해결
                                                              
  ## Changes
  - `backend/common/src/main/kotlin/com/ticketqueue/common/config/CommonJpaConfig.kt` 파일 생성
    - `@EnableJpaRepositories`: `com.ticketqueue.common.outbox` 패키지의 Repository 인터페이스 스캔 및
  Bean 등록
    - `@EntityScan`: 동일 패키지의 Entity 클래스(`ProcessedEvent`, `OutboxEvent`) 탐색
    - `@ConditionalOnClass(EntityManagerFactory::class)`: JPA 의존성이 있는 서비스에서만 자동 활성화
  (API Gateway 제외)

  ## Test plan
  - [x] Common 모듈 빌드 성공 확인 (`./gradlew :common:build -x test`)
  - [x] Event Service 빌드 성공 확인 (`./gradlew :event-service:build -x test`)
  - [x] User Service 빌드 성공 확인 (`./gradlew :user-service:build -x test`)
  - [x] Event Service 실행 시 Repository Bean 등록 로그 확인 ("Finished Spring Data repository scanning
   in 117 ms. Found 2 JPA repository interfaces.")
  - [x] Kafka Consumer의 멱등성 보장 메커니즘(ProcessedEvent) 사용 가능 확인
  - [x] Transactional Outbox Pattern(OutboxEvent) 구현 기반 마련 확인