### PR TITLE
feat: 회원가입 구현 (AES-256/HMAC 보안 유틸 및 reCAPTCHA 추가) #22

### DIFF
--- a/backend/common/build.gradle.kts
+++ b/backend/common/build.gradle.kts
@@ -29,6 +29,9 @@ dependencies {
     api(libs.spring.boot.starter.validation)
     api(libs.spring.boot.starter.actuator)
 
+    // Spring Cloud
+    api(platform(libs.spring.cloud.dependencies))
+
     // Spring Cloud AWS
     api(platform(libs.spring.cloud.aws.dependencies))
     api(libs.spring.cloud.aws.starter.secrets.manager)

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/config/ExternalApiLoggingInterceptor.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/config/ExternalApiLoggingInterceptor.kt
@@ -1,0 +1,32 @@
+package com.ticketqueue.common.config
+
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpRequest
+import org.springframework.http.client.ClientHttpRequestExecution
+import org.springframework.http.client.ClientHttpRequestInterceptor
+import org.springframework.http.client.ClientHttpResponse
+import java.nio.charset.StandardCharsets
+
+class ExternalApiLoggingInterceptor : ClientHttpRequestInterceptor {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun intercept(
+        request: HttpRequest,
+        body: ByteArray,
+        execution: ClientHttpRequestExecution
+    ): ClientHttpResponse {
+        logRequest(request, body)
+        val response = execution.execute(request, body)
+        logResponse(response)
+        return response
+    }
+
+    private fun logRequest(request: HttpRequest, body: ByteArray) {
+        log.info(">>> External Request: [{} {}] Body: {}",
+            request.method, request.uri, String(body, StandardCharsets.UTF_8))
+    }
+
+    private fun logResponse(response: ClientHttpResponse) {
+        log.info("<<< External Response: [{}]", response.statusCode)
+    }
+}

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/config/InternalApiFeignConfig.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/config/InternalApiFeignConfig.kt
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 @ConditionalOnClass(RequestInterceptor::class)
 class InternalApiFeignConfig(
-    @Value("\${internal_api_key:}")
+    @Value("\${internal_api_key}")
     private val internalApiKey: String
 ) {
 

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/config/RestClientConfig.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/config/RestClientConfig.kt
@@ -1,0 +1,37 @@
+package com.ticketqueue.common.config
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.web.client.RestClient
+
+/**
+ * 외부 API 통신을 위한 공통 RestClient 설정
+ */
+@Configuration
+class RestClientConfig {
+
+    /**
+     * 모든 마이크로서비스에서 공통으로 사용할 RestClient.Builder 빈 생성
+     * 
+     * [ConditionalOnMissingBean] 설정 이유:
+     * 각 서비스(예: payment-service)에서 특정 목적(긴 타임아웃, 추가 인터셉터 등)을 위해 
+     * 자체적으로 RestClient.Builder를 빈으로 등록하면, 이 공통 빈은 등록되지 않고 
+     * 서비스에서 정의한 빈이 우선권을 갖게 됨 (Overriding 허용)
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    fun restClientBuilder(): RestClient.Builder {
+        val requestFactory = SimpleClientHttpRequestFactory()
+        
+        // 기본 타임아웃 설정 (필요 시 각 서비스에서 덮어쓰기 가능)
+        requestFactory.setReadTimeout(5000)
+        requestFactory.setConnectTimeout(2000)
+
+        return RestClient.builder()
+            .requestFactory(requestFactory)
+            // 외부 API 호출 시 요청/응답 로그를 남기는 인터셉터 추가
+            .requestInterceptor(ExternalApiLoggingInterceptor())
+    }
+}

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
@@ -19,6 +19,9 @@ enum class ErrorCode(
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_TOKEN", "토큰이 만료되었습니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    ALREADY_EXISTS_EMAIL(HttpStatus.CONFLICT, "ALREADY_EXISTS_EMAIL", "이미 사용 중인 이메일입니다."),
+    ALREADY_EXISTS_USER(HttpStatus.CONFLICT, "ALREADY_EXISTS_USER", "이미 가입된 사용자입니다."),
+    RECAPTCHA_FAILED(HttpStatus.BAD_REQUEST, "RECAPTCHA_FAILED", "reCAPTCHA 검증에 실패했습니다."),
 
     // Queue
     QUEUE_FULL(HttpStatus.SERVICE_UNAVAILABLE, "QUEUE_FULL", "대기열이 가득 찼습니다. 잠시 후 다시 시도해주세요."),

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/util/EncryptionUtils.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/util/EncryptionUtils.kt
@@ -1,0 +1,77 @@
+package com.ticketqueue.common.util
+
+import java.nio.ByteBuffer
+import java.security.SecureRandom
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import javax.crypto.Mac
+
+object EncryptionUtils {
+    private const val ALGORITHM = "AES/GCM/NoPadding"
+    private const val TAG_LENGTH_BIT = 128
+    private const val IV_LENGTH_BYTE = 12
+    private val secureRandom = SecureRandom()
+
+    /**
+     * AES-256-GCM 암호화
+     * 결과: Base64(IV + CipherText)
+     */
+    fun encrypt(plainText: String, secretKey: String): String {
+        val keyBytes = Base64.getDecoder().decode(secretKey)
+        val key = SecretKeySpec(keyBytes, "AES")
+        val iv = ByteArray(IV_LENGTH_BYTE)
+        secureRandom.nextBytes(iv)
+
+        val cipher = Cipher.getInstance(ALGORITHM)
+        cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(TAG_LENGTH_BIT, iv))
+        
+        val cipherText = cipher.doFinal(plainText.toByteArray(Charsets.UTF_8))
+        
+        val byteBuffer = ByteBuffer.allocate(iv.size + cipherText.size)
+        byteBuffer.put(iv)
+        byteBuffer.put(cipherText)
+        
+        return Base64.getEncoder().encodeToString(byteBuffer.array())
+    }
+
+    /**
+     * AES-256-GCM 복호화
+     */
+    fun decrypt(encryptedText: String, secretKey: String): String {
+        val keyBytes = Base64.getDecoder().decode(secretKey)
+        val key = SecretKeySpec(keyBytes, "AES")
+        val decoded = Base64.getDecoder().decode(encryptedText)
+        
+        val byteBuffer = ByteBuffer.wrap(decoded)
+        val iv = ByteArray(IV_LENGTH_BYTE)
+        byteBuffer.get(iv)
+        
+        val cipherText = ByteArray(byteBuffer.remaining())
+        byteBuffer.get(cipherText)
+
+        val cipher = Cipher.getInstance(ALGORITHM)
+        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(TAG_LENGTH_BIT, iv))
+        
+        return String(cipher.doFinal(cipherText), Charsets.UTF_8)
+    }
+}
+
+object HashUtils {
+    private const val HMAC_ALGORITHM = "HmacSHA256"
+
+    /**
+     * HMAC-SHA256 해싱 (검색용)
+     */
+    fun hash(text: String, salt: String): String {
+        val saltBytes = Base64.getDecoder().decode(salt)
+        val secretKey = SecretKeySpec(saltBytes, HMAC_ALGORITHM)
+        val mac = Mac.getInstance(HMAC_ALGORITHM)
+        mac.init(secretKey)
+        
+        val hashBytes = mac.doFinal(text.toByteArray(Charsets.UTF_8))
+        return Base64.getEncoder().encodeToString(hashBytes)
+    }
+}

--- a/backend/common/src/main/resources/application-common-local.yml
+++ b/backend/common/src/main/resources/application-common-local.yml
@@ -2,9 +2,14 @@ spring:
   config:
     activate:
       on-profile: local
-
+    import:
+      - "optional:aws-secretsmanager:common/secure-config"
   data:
     redis:
       host: 192.168.50.2
       port: 6379
       password: ${valkey_password}
+
+encryption:
+  secret-key: ${secret_key}
+  hash-salt: ${hash_salt}

--- a/backend/common/src/main/resources/application-common-local.yml
+++ b/backend/common/src/main/resources/application-common-local.yml
@@ -11,5 +11,5 @@ spring:
       password: ${valkey_password}
 
 encryption:
-  secret-key: ${secret_key}
-  hash-salt: ${hash_salt}
+  secret-key: ${enc_secret_key}
+  hash-salt: ${enc_hash_salt}

--- a/backend/common/src/main/resources/application.yml
+++ b/backend/common/src/main/resources/application.yml
@@ -1,2 +1,0 @@
-# Common module configuration
-# This module is a library and does not run standalone

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
 
 # Spring Cloud
+spring-cloud-dependencies = { module = "org.springframework.cloud:spring-cloud-dependencies", version.ref = "springCloud" }
 spring-cloud-starter-gateway = { module = "org.springframework.cloud:spring-cloud-starter-gateway-server-webflux" }
 spring-cloud-starter-openfeign = { module = "org.springframework.cloud:spring-cloud-starter-openfeign" }
 spring-cloud-starter-circuitbreaker-resilience4j = { module = "org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j" }

--- a/backend/user-service/build.gradle.kts
+++ b/backend/user-service/build.gradle.kts
@@ -12,6 +12,8 @@ dependencies {
 
     // Spring Boot & Security
     implementation(libs.spring.boot.starter.security)
+    implementation(libs.spring.boot.starter.validation)
+    implementation(libs.spring.cloud.starter.openfeign)
     implementation(libs.spring.boot.starter.data.redis)
 
     // JWT

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/UserServiceApplication.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/UserServiceApplication.kt
@@ -1,9 +1,15 @@
 package com.ticketqueue.user
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
 @SpringBootApplication(scanBasePackages = ["com.ticketqueue.user", "com.ticketqueue.common"])
+@EnableJpaRepositories(basePackages = ["com.ticketqueue.user.repository"])
+@EntityScan(basePackages = ["com.ticketqueue.user.entity"])
+@EnableFeignClients
 class UserServiceApplication
 
 fun main(args: Array<String>) {

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/AuthController.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/AuthController.kt
@@ -1,0 +1,24 @@
+package com.ticketqueue.user.controller
+
+import com.ticketqueue.user.dto.AuthDto
+import com.ticketqueue.user.service.AuthService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/auth")
+class AuthController(
+    private val authService: AuthService
+) {
+
+    @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun signup(@Valid @RequestBody request: AuthDto.SignupRequest): AuthDto.SignupResponse {
+        return authService.signup(request)
+    }
+}

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/dto/AuthDto.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/dto/AuthDto.kt
@@ -1,0 +1,37 @@
+package com.ticketqueue.user.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import java.util.UUID
+
+class AuthDto {
+    data class SignupRequest(
+        @field:NotBlank(message = "이메일은 필수입니다.")
+        @field:Email(message = "유효한 이메일 형식이 아닙니다.")
+        val email: String,
+
+        @field:NotBlank(message = "비밀번호는 필수입니다.")
+        val password: String,
+
+        @field:NotBlank(message = "이름은 필수입니다.")
+        val name: String,
+
+        @field:NotBlank(message = "전화번호는 필수입니다.")
+        val phone: String,
+
+        @field:NotBlank(message = "CI 정보는 필수입니다.")
+        val ci: String,
+
+        @field:NotBlank(message = "DI 정보는 필수입니다.")
+        val di: String,
+
+        @field:NotBlank(message = "reCAPTCHA 토큰은 필수입니다.")
+        val recaptchaToken: String
+    )
+
+    data class SignupResponse(
+        val id: UUID,
+        val email: String,
+        val name: String
+    )
+}

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/UserRepository.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/UserRepository.kt
@@ -2,8 +2,12 @@ package com.ticketqueue.user.repository
 
 import com.ticketqueue.user.entity.User
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 import java.util.Optional
 import java.util.UUID
 
+@Repository
 interface UserRepository : JpaRepository<User, UUID> {
+    fun existsByEmailHash(emailHash: String): Boolean
+    fun existsByCiHash(ciHash: String): Boolean
 }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthService.kt
@@ -1,0 +1,69 @@
+package com.ticketqueue.user.service
+
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.user.dto.AuthDto
+import com.ticketqueue.user.entity.User
+import com.ticketqueue.user.exception.UserException
+import com.ticketqueue.user.repository.UserRepository
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AuthService(
+    private val userRepository: UserRepository,
+    private val passwordEncoder: PasswordEncoder,
+    private val recaptchaService: RecaptchaService,
+    private val encryptionService: EncryptionService
+) {
+
+    @Transactional
+    fun signup(request: AuthDto.SignupRequest): AuthDto.SignupResponse {
+        // 1. reCAPTCHA 검증
+        if (!recaptchaService.verify(request.recaptchaToken)) {
+            throw UserException(ErrorCode.RECAPTCHA_FAILED)
+        }
+
+        // 2. 이메일 중복 체크 (hash 사용)
+        val emailHash = encryptionService.hash(request.email)
+        if (userRepository.existsByEmailHash(emailHash)) {
+            throw UserException(ErrorCode.ALREADY_EXISTS_EMAIL)
+        }
+
+        // 3. CI 중복 체크 (hash 사용 - 1인 1계정)
+        val ciHash = encryptionService.hash(request.ci)
+        if (userRepository.existsByCiHash(ciHash)) {
+            throw UserException(ErrorCode.ALREADY_EXISTS_USER)
+        }
+
+        // 4. 데이터 암호화 및 해싱
+        val encryptedEmail = encryptionService.encrypt(request.email)
+        val encryptedName = encryptionService.encrypt(request.name)
+        val encryptedPhone = encryptionService.encrypt(request.phone)
+        val encryptedCi = encryptionService.encrypt(request.ci)
+        
+        val phoneHash = encryptionService.hash(request.phone)
+        val passwordHash = passwordEncoder.encode(request.password)
+
+        // 5. 엔티티 생성 및 저장
+        val user = User(
+            email = encryptedEmail,
+            emailHash = emailHash,
+            passwordHash = passwordHash,
+            name = encryptedName,
+            phone = encryptedPhone,
+            phoneHash = phoneHash,
+            ci = encryptedCi,
+            ciHash = ciHash,
+            di = request.di
+        )
+
+        val savedUser = userRepository.save(user)
+
+        return AuthDto.SignupResponse(
+            id = savedUser.id!!,
+            email = request.email,
+            name = request.name
+        )
+    }
+}

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/EncryptionService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/EncryptionService.kt
@@ -1,0 +1,24 @@
+package com.ticketqueue.user.service
+
+import com.ticketqueue.common.util.EncryptionUtils
+import com.ticketqueue.common.util.HashUtils
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+
+@Service
+class EncryptionService(
+    @Value("\${encryption.secret-key}") private val secretKey: String,
+    @Value("\${encryption.hash-salt}") private val hashSalt: String
+) {
+    fun encrypt(plainText: String): String {
+        return EncryptionUtils.encrypt(plainText, secretKey)
+    }
+
+    fun decrypt(encryptedText: String): String {
+        return EncryptionUtils.decrypt(encryptedText, secretKey)
+    }
+
+    fun hash(text: String): String {
+        return HashUtils.hash(text, hashSalt)
+    }
+}

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/RecaptchaService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/RecaptchaService.kt
@@ -1,0 +1,39 @@
+package com.ticketqueue.user.service
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClient
+import org.springframework.web.util.UriComponentsBuilder
+
+@Service
+class RecaptchaService(
+    @Value("\${recaptcha.url}") private val recaptchaUrl: String,
+    @Value("\${recaptcha.secret}") private val recaptchaSecret: String
+) {
+    private val restClient = RestClient.create()
+
+    fun verify(token: String): Boolean {
+
+        val uri = UriComponentsBuilder.fromUriString(recaptchaUrl)
+            .queryParam("secret", recaptchaSecret)
+            .queryParam("response", token)
+            .build()
+            .toUri()
+
+        val response = restClient.post()
+            .uri(uri)
+            .retrieve()
+            .body(RecaptchaResponse::class.java)
+
+        return response?.success ?: false
+    }
+
+    private data class RecaptchaResponse(
+        val success: Boolean,
+        val challengeTs: String? = null,
+        val hostname: String? = null,
+        val score: Float? = null,
+        val action: String? = null,
+        val errorCodes: List<String>? = null
+    )
+}

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/RecaptchaService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/RecaptchaService.kt
@@ -1,16 +1,20 @@
 package com.ticketqueue.user.service
 
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.user.exception.UserException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestClient
+import org.springframework.web.client.body
 import org.springframework.web.util.UriComponentsBuilder
 
 @Service
 class RecaptchaService(
+    restClientBuilder: RestClient.Builder,
     @Value("\${recaptcha.url}") private val recaptchaUrl: String,
     @Value("\${recaptcha.secret}") private val recaptchaSecret: String
 ) {
-    private val restClient = RestClient.create()
+    private val restClient = restClientBuilder.build()
 
     fun verify(token: String): Boolean {
 
@@ -20,12 +24,16 @@ class RecaptchaService(
             .build()
             .toUri()
 
-        val response = restClient.post()
-            .uri(uri)
-            .retrieve()
-            .body(RecaptchaResponse::class.java)
+        return try {
+            val response = restClient.post()
+                .uri(uri)
+                .retrieve()
+                .body<RecaptchaResponse>()
 
-        return response?.success ?: false
+            response?.success ?: false
+        } catch (e: Exception) {
+            throw UserException(ErrorCode.RECAPTCHA_FAILED)
+        }
     }
 
     private data class RecaptchaResponse(

--- a/backend/user-service/src/main/resources/application.yml
+++ b/backend/user-service/src/main/resources/application.yml
@@ -8,8 +8,6 @@ spring:
     import:
       - "optional:classpath:/application-common-${spring.profiles.active}.yml"
       - "optional:aws-secretsmanager:user-svc/secure-config"
-      - "optional:aws-secretsmanager:common/secure-config"
-
   jpa:
     hibernate:
       ddl-auto: validate
@@ -43,3 +41,7 @@ logging:
   level:
     com.ticketqueue.user: DEBUG
     org.hibernate.SQL: DEBUG
+
+recaptcha:
+  url: https://www.google.com/recaptcha/api/siteverify
+  secret: ${recaptcha_secret:6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe}

--- a/backend/user-service/src/main/resources/application.yml
+++ b/backend/user-service/src/main/resources/application.yml
@@ -39,9 +39,8 @@ management:
 
 logging:
   level:
-    com.ticketqueue.user: DEBUG
     org.hibernate.SQL: DEBUG
 
 recaptcha:
   url: https://www.google.com/recaptcha/api/siteverify
-  secret: ${recaptcha_secret:6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe}
+  secret: ${recaptcha_secret}


### PR DESCRIPTION
## Summary
- user-service의 기본 회원가입 및 reCAPTCHA 검증 로직 구현
- 보안 유틸리티(EncryptionUtils, HashUtils) 추가를 통한 개인정보 보호 로직 강화

## Changes
- **보안 및 유틸리티 (common)**
   - EncryptionUtils: AES-256-GCM 알고리즘을 사용한 데이터 암호화/복호화 로직 구현
   - HashUtils: 개인정보 검색을 위한 HMAC-SHA256 기반의 해싱 기능 추가
   - ErrorCode: ALREADY_EXISTS_EMAIL, RECAPTCHA_FAILED 등 회원가입 관련 커스텀 예외 코드 정의
- **user-service 핵심 로직 구현**
   - AuthService: 사용자 회원가입 프로세스 구현 (이메일/CI 암호화 및 해싱 처리 포함)
   - RecaptchaService: Google reCAPTCHA 검증 로직 및 외부 API 연동
   - UserRepository: 이메일/CI 해시를 이용한 중복 가입 방지 쿼리 추가
   - UserServiceApplication: JPA 리포지토리/엔티티 스캔 및 Feign Client 활성화
- **환경 설정**
   - application.yml: reCAPTCHA 검증 URL 및 시크릿 키 설정 추가

## Test plan
- [x] (수동 테스트) Postman을 이용한 회원가입 API 호출 및 DB 저장 데이터 확인
- [x] (수동 테스트) DB 내 이메일/CI 데이터의 암호화 및 해시값 정상 저장 여부 확인
- [x] (로그 확인) reCAPTCHA 검증 시 외부 API와의 통신 로그 및 응답 결과 확인
- [ ] (향후 과제) 현재 발생 중인 테스트 코드 오류 해결 및 단위/통합 테스트 코드 추가 푸시 예정

Ref #22 