### PR TITLE
chore: JPA Entity 구현 #31

### DIFF
--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/EventServiceApplication.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/EventServiceApplication.kt
@@ -1,9 +1,13 @@
 package com.ticketqueue.event
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
 @SpringBootApplication(scanBasePackages = ["com.ticketqueue.event", "com.ticketqueue.common"])
+@EnableJpaRepositories(basePackages = ["com.ticketqueue.event.repository"])
+@EntityScan(basePackages = ["com.ticketqueue.event.entity"])
 class EventServiceApplication
 
 fun main(args: Array<String>) {

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Event.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Event.kt
@@ -51,4 +51,12 @@ class Event(
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime? = null
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Event) return false
+        return id != null && id == other.id
+    }
+
+    override fun hashCode(): Int = id?.hashCode() ?: 0
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Event.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Event.kt
@@ -1,0 +1,54 @@
+package com.ticketqueue.event.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "events", schema = "event_service")
+class Event(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @Column(nullable = false)
+    val title: String,
+
+    @Column(nullable = false)
+    val artist: String,
+
+    @Column(columnDefinition = "TEXT")
+    val description: String? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "venue_id", nullable = false)
+    val venue: Venue,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hall_id", nullable = false)
+    val hall: Hall,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val status: EventStatus = EventStatus.PREPARING,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime? = null,
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime? = null
+)

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/EventSchedule.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/EventSchedule.kt
@@ -1,0 +1,56 @@
+package com.ticketqueue.event.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "event_schedules", schema = "event_service")
+class EventSchedule(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    val event: Event,
+
+    @Column(name = "play_sequence", nullable = false)
+    val playSequence: Int,
+
+    @Column(name = "event_start_at", nullable = false)
+    val eventStartAt: LocalDateTime,
+
+    @Column(name = "event_end_at", nullable = false)
+    val eventEndAt: LocalDateTime,
+
+    @Column(name = "sale_start_at", nullable = false)
+    val saleStartAt: LocalDateTime,
+
+    @Column(name = "sale_end_at", nullable = false)
+    val saleEndAt: LocalDateTime,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val status: ScheduleStatus = ScheduleStatus.UPCOMING,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime? = null,
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime? = null
+)

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/EventSchedule.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/EventSchedule.kt
@@ -53,4 +53,12 @@ class EventSchedule(
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime? = null
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is EventSchedule) return false
+        return id != null && id == other.id
+    }
+
+    override fun hashCode(): Int = id?.hashCode() ?: 0
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Hall.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Hall.kt
@@ -1,0 +1,44 @@
+package com.ticketqueue.event.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "halls", schema = "event_service")
+class Hall(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "venue_id", nullable = false)
+    val venue: Venue,
+
+    @Column(nullable = false)
+    val name: String,
+
+    @Column(nullable = false)
+    val capacity: Int,
+
+    @Column(name = "seat_template", columnDefinition = "jsonb", nullable = false)
+    val seatTemplate: String,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime? = null,
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime? = null
+)

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Hall.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Hall.kt
@@ -41,4 +41,12 @@ class Hall(
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime? = null
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Hall) return false
+        return id != null && id == other.id
+    }
+
+    override fun hashCode(): Int = id?.hashCode() ?: 0
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Seat.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Seat.kt
@@ -49,4 +49,12 @@ class Seat(
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime? = null
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Seat) return false
+        return id != null && id == other.id
+    }
+
+    override fun hashCode(): Int = id?.hashCode() ?: 0
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Seat.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Seat.kt
@@ -1,0 +1,52 @@
+package com.ticketqueue.event.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "seats", schema = "event_service")
+class Seat(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_schedule_id", nullable = false)
+    val eventSchedule: EventSchedule,
+
+    @Column(name = "seat_number", nullable = false)
+    val seatNumber: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val grade: SeatGrade,
+
+    @Column(nullable = false, precision = 10, scale = 0)
+    val price: BigDecimal,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val status: SeatStatus = SeatStatus.AVAILABLE,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime? = null,
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime? = null
+)

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Venue.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Venue.kt
@@ -38,6 +38,14 @@ class Venue(
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime? = null,
 
-    @OneToMany(mappedBy = "venue", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "venue", cascade = [CascadeType.PERSIST, CascadeType.MERGE], fetch = FetchType.LAZY)
     val halls: MutableList<Hall> = mutableListOf()
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Venue) return false
+        return id != null && id == other.id
+    }
+
+    override fun hashCode(): Int = id?.hashCode() ?: 0
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Venue.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Venue.kt
@@ -1,0 +1,43 @@
+package com.ticketqueue.event.entity
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "venues", schema = "event_service")
+class Venue(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @Column(nullable = false)
+    val name: String,
+
+    @Column(nullable = false)
+    val address: String,
+
+    @Column(nullable = false)
+    val city: String,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime? = null,
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime? = null,
+
+    @OneToMany(mappedBy = "venue", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+    val halls: MutableList<Hall> = mutableListOf()
+)

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/enums.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/enums.kt
@@ -1,0 +1,6 @@
+package com.ticketqueue.event.entity
+
+enum class EventStatus { PREPARING, OPEN, ENDED, CANCELLED }
+enum class ScheduleStatus { UPCOMING, ONGOING, ENDED, CANCELLED }
+enum class SeatGrade { VIP, S, A, B }
+enum class SeatStatus { AVAILABLE, SOLD }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepository.kt
@@ -1,0 +1,9 @@
+package com.ticketqueue.event.repository
+
+import com.ticketqueue.event.entity.Event
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface EventRepository : JpaRepository<Event, UUID>

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepository.kt
@@ -1,0 +1,9 @@
+package com.ticketqueue.event.repository
+
+import com.ticketqueue.event.entity.EventSchedule
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface EventScheduleRepository : JpaRepository<EventSchedule, UUID>

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/HallRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/HallRepository.kt
@@ -1,0 +1,9 @@
+package com.ticketqueue.event.repository
+
+import com.ticketqueue.event.entity.Hall
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface HallRepository : JpaRepository<Hall, UUID>

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepository.kt
@@ -1,0 +1,9 @@
+package com.ticketqueue.event.repository
+
+import com.ticketqueue.event.entity.Seat
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface SeatRepository : JpaRepository<Seat, UUID>

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/VenueRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/VenueRepository.kt
@@ -1,0 +1,9 @@
+package com.ticketqueue.event.repository
+
+import com.ticketqueue.event.entity.Venue
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface VenueRepository : JpaRepository<Venue, UUID>

--- a/docker/db_init/3_event_service_ddl.sql
+++ b/docker/db_init/3_event_service_ddl.sql
@@ -1,0 +1,199 @@
+-- Event Service DDL
+
+-- updated_at 자동 업데이트 트리거 함수 (Event Service 전용)
+CREATE OR REPLACE FUNCTION event_service.update_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- 1. venues Table
+CREATE TABLE event_service.venues (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(200) NOT NULL,
+    address TEXT NOT NULL,
+    city VARCHAR(100),
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+-- 인덱스
+CREATE INDEX idx_venues_city ON event_service.venues(city);
+CREATE INDEX idx_venues_name ON event_service.venues(name);
+
+-- updated_at Trigger
+CREATE TRIGGER trg_venues_updated_at
+BEFORE UPDATE ON event_service.venues
+FOR EACH ROW EXECUTE FUNCTION event_service.update_timestamp();
+
+COMMENT ON TABLE event_service.venues IS '공연장 정보. 위치 기반 검색 지원.';
+COMMENT ON COLUMN event_service.venues.id IS '공연장 UUID';
+COMMENT ON COLUMN event_service.venues.name IS '공연장명';
+COMMENT ON COLUMN event_service.venues.address IS '공연장 주소';
+COMMENT ON COLUMN event_service.venues.city IS '도시명 (지역 필터용)';
+COMMENT ON COLUMN event_service.venues.created_at IS '생성일시';
+COMMENT ON COLUMN event_service.venues.updated_at IS '수정일시';
+
+
+-- 2. halls Table
+CREATE TABLE event_service.halls (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    venue_id UUID NOT NULL REFERENCES event_service.venues(id) ON DELETE RESTRICT,
+    name VARCHAR(200) NOT NULL,
+    capacity INT NOT NULL,
+    seat_template JSONB NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP NOT NULL DEFAULT now(),
+
+    CONSTRAINT chk_halls_capacity CHECK (capacity > 0),
+    CONSTRAINT uk_halls_venue_name UNIQUE (venue_id, name)
+);
+
+-- 인덱스
+CREATE INDEX idx_halls_venue ON event_service.halls(venue_id);
+CREATE INDEX idx_halls_seat_template ON event_service.halls USING GIN (seat_template);
+
+-- updated_at Trigger
+CREATE TRIGGER trg_halls_updated_at
+BEFORE UPDATE ON event_service.halls
+FOR EACH ROW EXECUTE FUNCTION event_service.update_timestamp();
+
+COMMENT ON TABLE event_service.halls IS '공연장 홀 정보. JSONB 좌석 템플릿 사용.';
+COMMENT ON COLUMN event_service.halls.id IS '홀 UUID';
+COMMENT ON COLUMN event_service.halls.venue_id IS '공연장 UUID';
+COMMENT ON COLUMN event_service.halls.name IS '홀명';
+COMMENT ON COLUMN event_service.halls.capacity IS '최대 수용 인원';
+COMMENT ON COLUMN event_service.halls.seat_template IS '좌석 배치 템플릿: {"rows": ["A","B"], "seatsPerRow": 20, "gradeMapping": {"A": "VIP"}}';
+COMMENT ON COLUMN event_service.halls.created_at IS '생성일시';
+COMMENT ON COLUMN event_service.halls.updated_at IS '수정일시';
+
+
+-- 3. events Table
+CREATE TABLE event_service.events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    title VARCHAR(300) NOT NULL,
+    artist VARCHAR(200) NOT NULL,
+    description TEXT,
+    venue_id UUID NOT NULL REFERENCES event_service.venues(id) ON DELETE RESTRICT,
+    hall_id UUID NOT NULL REFERENCES event_service.halls(id) ON DELETE RESTRICT,
+    status VARCHAR(20) NOT NULL DEFAULT 'PREPARING',
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP NOT NULL DEFAULT now(),
+
+    CONSTRAINT chk_events_status CHECK (status IN ('PREPARING', 'OPEN', 'ENDED', 'CANCELLED'))
+);
+
+-- 인덱스
+CREATE INDEX idx_events_status ON event_service.events(status);
+CREATE INDEX idx_events_artist ON event_service.events(artist);
+CREATE INDEX idx_events_venue ON event_service.events(venue_id);
+
+-- 전문 검색 인덱스 (선택)
+CREATE INDEX idx_events_fts ON event_service.events
+    USING gin(to_tsvector('simple', title || ' ' || artist));
+
+-- updated_at Trigger
+CREATE TRIGGER trg_events_updated_at
+BEFORE UPDATE ON event_service.events
+FOR EACH ROW EXECUTE FUNCTION event_service.update_timestamp();
+
+COMMENT ON TABLE event_service.events IS '공연 메타 정보. status는 공연 전체의 생명주기(노출 여부 등)를 관리.';
+COMMENT ON COLUMN event_service.events.id IS '공연 UUID';
+COMMENT ON COLUMN event_service.events.title IS '공연 제목';
+COMMENT ON COLUMN event_service.events.artist IS '아티스트/출연진';
+COMMENT ON COLUMN event_service.events.description IS '공연 설명';
+COMMENT ON COLUMN event_service.events.venue_id IS '공연장 UUID';
+COMMENT ON COLUMN event_service.events.hall_id IS '홀 UUID';
+COMMENT ON COLUMN event_service.events.status IS 'PREPARING: 준비중(미노출), OPEN: 공개됨, ENDED: 전체 종료, CANCELLED: 전체 취소';
+COMMENT ON COLUMN event_service.events.created_at IS '생성일시';
+COMMENT ON COLUMN event_service.events.updated_at IS '수정일시';
+
+
+-- 4. event_schedules Table
+CREATE TABLE event_service.event_schedules (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_id UUID NOT NULL REFERENCES event_service.events(id) ON DELETE CASCADE,
+    play_sequence INT NOT NULL DEFAULT 1,
+    event_start_at TIMESTAMP NOT NULL,
+    event_end_at TIMESTAMP NOT NULL,
+    sale_start_at TIMESTAMP NOT NULL,
+    sale_end_at TIMESTAMP NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'UPCOMING',
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP NOT NULL DEFAULT now(),
+
+    CONSTRAINT chk_schedules_status CHECK (status IN ('UPCOMING', 'ONGOING', 'ENDED', 'CANCELLED')),
+    CONSTRAINT chk_schedules_time CHECK (event_start_at < event_end_at),
+    CONSTRAINT chk_schedules_sale_time CHECK (sale_start_at < sale_end_at),
+    CONSTRAINT uk_schedules_event_seq UNIQUE (event_id, play_sequence)
+);
+
+-- 인덱스
+CREATE INDEX idx_schedules_status_sale_start ON event_service.event_schedules(status, sale_start_at);
+CREATE INDEX idx_schedules_event_date ON event_service.event_schedules(event_id, event_start_at);
+CREATE INDEX idx_schedules_sale_start ON event_service.event_schedules(sale_start_at) WHERE status = 'UPCOMING';
+
+-- updated_at Trigger
+CREATE TRIGGER trg_schedules_updated_at
+BEFORE UPDATE ON event_service.event_schedules
+FOR EACH ROW EXECUTE FUNCTION event_service.update_timestamp();
+
+COMMENT ON TABLE event_service.event_schedules IS '공연 회차 및 판매 일정 정보. status는 회차별 티켓 판매 상태 관리.';
+COMMENT ON COLUMN event_service.event_schedules.id IS '회차 UUID';
+COMMENT ON COLUMN event_service.event_schedules.event_id IS '공연 UUID';
+COMMENT ON COLUMN event_service.event_schedules.play_sequence IS '회차 순번 (1회차, 2회차...)';
+COMMENT ON COLUMN event_service.event_schedules.event_start_at IS '공연 시작 일시';
+COMMENT ON COLUMN event_service.event_schedules.event_end_at IS '공연 종료 일시';
+COMMENT ON COLUMN event_service.event_schedules.sale_start_at IS '티켓 판매 시작 일시';
+COMMENT ON COLUMN event_service.event_schedules.sale_end_at IS '티켓 판매 종료 일시';
+COMMENT ON COLUMN event_service.event_schedules.status IS 'UPCOMING: 판매 전, ONGOING: 판매 중, ENDED: 종료, CANCELLED: 취소';
+COMMENT ON COLUMN event_service.event_schedules.created_at IS '생성일시';
+COMMENT ON COLUMN event_service.event_schedules.updated_at IS '수정일시';
+
+
+-- 5. seats Table
+CREATE TABLE event_service.seats (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_schedule_id UUID NOT NULL REFERENCES event_service.event_schedules(id) ON DELETE CASCADE,
+    seat_number VARCHAR(10) NOT NULL,
+    grade VARCHAR(10) NOT NULL,
+    price DECIMAL(10, 0) NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'AVAILABLE',
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP NOT NULL DEFAULT now(),
+
+    CONSTRAINT chk_seats_grade CHECK (grade IN ('VIP', 'S', 'A', 'B')),
+    CONSTRAINT chk_seats_status CHECK (status IN ('AVAILABLE', 'SOLD')),
+    CONSTRAINT chk_seats_price CHECK (price >= 0),
+    CONSTRAINT uk_seats_schedule_number UNIQUE (event_schedule_id, seat_number)
+);
+
+-- 핵심 인덱스 (조회 성능 최적화)
+CREATE INDEX idx_seats_schedule_status ON event_service.seats(event_schedule_id, status);
+CREATE INDEX idx_seats_grade_price ON event_service.seats(grade, price);
+
+-- updated_at Trigger
+CREATE TRIGGER trg_seats_updated_at
+BEFORE UPDATE ON event_service.seats
+FOR EACH ROW EXECUTE FUNCTION event_service.update_timestamp();
+
+COMMENT ON TABLE event_service.seats IS '회차별 좌석 재고. HOLD 상태는 Redis로 관리 (seat:hold:{scheduleId}:{seatId}).';
+COMMENT ON COLUMN event_service.seats.id IS '좌석 UUID';
+COMMENT ON COLUMN event_service.seats.event_schedule_id IS '회차 UUID';
+COMMENT ON COLUMN event_service.seats.seat_number IS '좌석 번호 (예: A-1, B-10)';
+COMMENT ON COLUMN event_service.seats.grade IS '좌석 등급 (VIP/S/A/B)';
+COMMENT ON COLUMN event_service.seats.price IS '좌석 가격';
+COMMENT ON COLUMN event_service.seats.status IS 'AVAILABLE: 판매 가능, SOLD: 판매 완료';
+COMMENT ON COLUMN event_service.seats.created_at IS '생성일시';
+COMMENT ON COLUMN event_service.seats.updated_at IS '수정일시';
+
+
+-- Ownership Transfer
+ALTER TABLE event_service.venues OWNER TO event_svc_user;
+ALTER TABLE event_service.halls OWNER TO event_svc_user;
+ALTER TABLE event_service.events OWNER TO event_svc_user;
+ALTER TABLE event_service.event_schedules OWNER TO event_svc_user;
+ALTER TABLE event_service.seats OWNER TO event_svc_user;

--- a/docker/db_init/3_event_service_ddl.sql
+++ b/docker/db_init/3_event_service_ddl.sql
@@ -1,15 +1,5 @@
 -- Event Service DDL
 
--- updated_at 자동 업데이트 트리거 함수 (Event Service 전용)
-CREATE OR REPLACE FUNCTION event_service.update_timestamp()
-RETURNS TRIGGER AS $$
-BEGIN
-    NEW.updated_at = now();
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-
 -- 1. venues Table
 CREATE TABLE event_service.venues (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/docker/db_init/3_event_service_ddl.sql
+++ b/docker/db_init/3_event_service_ddl.sql
@@ -15,7 +15,7 @@ CREATE TABLE event_service.venues (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(200) NOT NULL,
     address TEXT NOT NULL,
-    city VARCHAR(100),
+    city VARCHAR(100) NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT now(),
     updated_at TIMESTAMP NOT NULL DEFAULT now()
 );

--- a/docs/architecture/04_data.md
+++ b/docs/architecture/04_data.md
@@ -412,7 +412,7 @@ CREATE TABLE event_service.venues (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(200) NOT NULL,
     address TEXT NOT NULL,
-    city VARCHAR(100),
+    city VARCHAR(100) NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT now(),
     updated_at TIMESTAMP NOT NULL DEFAULT now()
 );


### PR DESCRIPTION
## Summary                                                                                                                         
                                                                                                                                  
  - Event Service의 핵심 도메인 엔티티(venues, halls, events, event_schedules, seats) JPA Entity 구현                             
  - PostgreSQL DDL 스키마 생성 및 아키텍처 문서 정합성 확보
  - 코드 품질 개선 (CascadeType 최적화, equals/hashCode 구현)

## Changes

  1. DDL 및 데이터베이스 스키마

  - 추가: docker/db_init/3_event_service_ddl.sql
    - 5개 테이블 생성 (venues, halls, events, event_schedules, seats)
    - 인덱스, 트리거, 제약조건, COMMENT 포함
    - FK 의존성 순서 준수 (ON DELETE RESTRICT/CASCADE)
  - 수정: docs/architecture/04_data.md
    - venues 테이블 DDL SQL 수정 (city NOT NULL 추가)

  2. JPA Entity 구현

  - 추가: backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/
    - enums.kt: 4개 Enum 정의 (EventStatus, ScheduleStatus, SeatGrade, SeatStatus)
    - Venue.kt: 공연장 Entity
    - Hall.kt: 홀 Entity (JSONB seat_template)
    - Event.kt: 공연 Entity
    - EventSchedule.kt: 회차 Entity
    - Seat.kt: 좌석 Entity

  3. Repository 구현

  - 추가: backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/
    - VenueRepository, HallRepository, EventRepository, EventScheduleRepository, SeatRepository
    - 모두 JpaRepository<Entity, UUID> 상속

  4. Spring Boot 설정

  - 수정: backend/event-service/src/main/kotlin/com/ticketqueue/event/EventServiceApplication.kt
    - @EnableJpaRepositories(basePackages = ["com.ticketqueue.event.repository"]) 추가
    - @EntityScan(basePackages = ["com.ticketqueue.event.entity"]) 추가
  
  5. 코드 품질 개선

  - Venue.kt CascadeType 최적화
    - CascadeType.ALL → [CascadeType.PERSIST, CascadeType.MERGE]
    - DDL의 ON DELETE RESTRICT와 일치, 실수 삭제 방지
  - 5개 Entity에 equals()/hashCode() 구현
    - OutboxEvent 패턴 참조 (id 기반 비교)
    - Set/Map 사용 시 올바른 동작 보장
  - Venue.city null 허용 정책 통일
    - DDL: city VARCHAR(100) → city VARCHAR(100) NOT NULL
    - Entity와 DDL 정합성 확보

## Test plan

  - [x] DDL 검증: Docker Compose 재시작 후 PostgreSQL 테이블 5개 생성 확인
  docker exec ticket-postgres psql -U ticket -d ticket_queue -c "\dt event_service.*"
  - [x] Gradle 빌드: event-service 빌드 성공 확인
  ./gradlew :event-service:clean :event-service:build
  - [x] Hibernate Validate: JPA Entity-DDL 매핑 정합성 자동 검증
    - application.yml: ddl-auto: validate
    - 애플리케이션 시작 시 에러 없이 완료

## Related Issue
Closes #31 