### PR TITLE
chore: 디자인 시스템 토큰 및 TailwindCSS 설정 #105

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,54 +1,40 @@
 @import "tailwindcss";
+@import "../styles/tokens.css";
 
-@theme {
-  /* Colors - 티켓팅 서비스 컬러 팔레트 */
-  --color-primary-50: oklch(0.97 0.01 250);
-  --color-primary-100: oklch(0.93 0.03 250);
-  --color-primary-500: oklch(0.55 0.15 250);
-  --color-primary-600: oklch(0.48 0.15 250);
-  --color-primary-700: oklch(0.40 0.13 250);
-
-  --color-secondary-500: oklch(0.65 0.15 330);
-
-  --color-success: oklch(0.72 0.15 155);
-  --color-warning: oklch(0.80 0.15 85);
-  --color-error: oklch(0.63 0.20 25);
-
-  --color-gray-50: oklch(0.98 0 0);
-  --color-gray-100: oklch(0.96 0 0);
-  --color-gray-200: oklch(0.92 0 0);
-  --color-gray-300: oklch(0.87 0 0);
-  --color-gray-400: oklch(0.71 0 0);
-  --color-gray-500: oklch(0.55 0 0);
-  --color-gray-600: oklch(0.45 0 0);
-  --color-gray-700: oklch(0.37 0 0);
-  --color-gray-800: oklch(0.27 0 0);
-  --color-gray-900: oklch(0.20 0 0);
-
-  /* Fonts */
-  --font-sans: "Pretendard", "Apple SD Gothic Neo", sans-serif;
-
-  /* Breakpoints - 커스텀 브레이크포인트 */
-  --breakpoint-xs: 480px;
-  --breakpoint-sm: 640px;
-  --breakpoint-md: 768px;
-  --breakpoint-lg: 1024px;
-  --breakpoint-xl: 1280px;
-  --breakpoint-2xl: 1440px;
-
-  /* Spacing */
-  --spacing-header: 64px;
-  --spacing-sidebar: 280px;
-
-  /* Border Radius */
-  --radius-sm: 0.375rem;
-  --radius-md: 0.5rem;
-  --radius-lg: 0.75rem;
-  --radius-xl: 1rem;
-}
-
+/* Base Styles */
 body {
   font-family: var(--font-sans);
-  background: var(--color-gray-50);
-  color: var(--color-gray-900);
+  background: var(--color-background);
+  color: var(--color-text);
+}
+
+/* Typography Utilities */
+@utility text-h1 {
+  font-size: 2.5rem;
+  line-height: 1.2;
+  font-weight: 700;
+}
+
+@utility text-h2 {
+  font-size: 2rem;
+  line-height: 1.3;
+  font-weight: 600;
+}
+
+@utility text-h3 {
+  font-size: 1.5rem;
+  line-height: 1.4;
+  font-weight: 600;
+}
+
+@utility text-body {
+  font-size: 1rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+@utility text-caption {
+  font-size: 0.875rem;
+  line-height: 1.4;
+  font-weight: 400;
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,0 +1,97 @@
+@theme {
+  /* ============================================
+     색상 팔레트 (Color Palette)
+     ============================================ */
+
+  /* Primary Colors - 주요 액션, 링크 (#3B82F6 기준) */
+  --color-primary-50: oklch(0.97 0.01 250);
+  --color-primary-100: oklch(0.93 0.03 250);
+  --color-primary-200: oklch(0.85 0.07 250);
+  --color-primary-300: oklch(0.74 0.11 250);
+  --color-primary-400: oklch(0.63 0.13 250);
+  --color-primary-500: oklch(0.55 0.15 250);
+  --color-primary-600: oklch(0.48 0.15 250);
+  --color-primary-700: oklch(0.40 0.13 250);
+  --color-primary-800: oklch(0.33 0.11 250);
+  --color-primary-900: oklch(0.27 0.09 250);
+
+  /* Secondary Colors - 보조 텍스트, 비활성 상태 (#6B7280 기준) */
+  --color-secondary-50: oklch(0.97 0.005 265);
+  --color-secondary-100: oklch(0.94 0.01 265);
+  --color-secondary-200: oklch(0.88 0.015 265);
+  --color-secondary-300: oklch(0.78 0.02 265);
+  --color-secondary-400: oklch(0.66 0.025 265);
+  --color-secondary-500: oklch(0.56 0.03 265);
+  --color-secondary-600: oklch(0.48 0.03 265);
+  --color-secondary-700: oklch(0.40 0.025 265);
+  --color-secondary-800: oklch(0.32 0.02 265);
+  --color-secondary-900: oklch(0.25 0.015 265);
+
+  /* Semantic Colors - 의미론적 색상 */
+  --color-success: oklch(0.72 0.15 155);        /* 성공 메시지, 확인 (#10B981) */
+  --color-warning: oklch(0.80 0.15 85);         /* 경고 메시지 (#F59E0B) */
+  --color-error: oklch(0.63 0.20 25);           /* 에러, 삭제 액션 (#EF4444) */
+  --color-danger: oklch(0.63 0.20 25);          /* error 별칭 */
+  --color-background: oklch(0.99 0 0);          /* 배경색 (#F9FAFB) */
+  --color-text: oklch(0.20 0 0);                /* 기본 텍스트 (#111827) */
+
+  /* Gray Scale - 중성 회색 */
+  --color-gray-50: oklch(0.98 0 0);
+  --color-gray-100: oklch(0.96 0 0);
+  --color-gray-200: oklch(0.92 0 0);
+  --color-gray-300: oklch(0.87 0 0);
+  --color-gray-400: oklch(0.71 0 0);
+  --color-gray-500: oklch(0.55 0 0);
+  --color-gray-600: oklch(0.45 0 0);
+  --color-gray-700: oklch(0.37 0 0);
+  --color-gray-800: oklch(0.27 0 0);
+  --color-gray-900: oklch(0.20 0 0);
+
+  /* ============================================
+     타이포그래피 (Typography)
+     ============================================ */
+
+  --text-h1: 2.5rem / 1.2 700;              /* 40px, Bold */
+  --text-h2: 2rem / 1.3 600;                /* 32px, SemiBold */
+  --text-h3: 1.5rem / 1.4 600;              /* 24px, SemiBold */
+  --text-body: 1rem / 1.5 400;              /* 16px, Regular */
+  --text-caption: 0.875rem / 1.4 400;       /* 14px, Regular */
+
+  /* ============================================
+     간격 (Spacing)
+     ============================================ */
+
+  --spacing-xs: 0.25rem;                    /* 4px - 아이콘-텍스트 간격 */
+  --spacing-sm: 0.5rem;                     /* 8px - 컴포넌트 내부 간격 */
+  --spacing-md: 1rem;                       /* 16px - 컴포넌트 간 간격 */
+  --spacing-lg: 1.5rem;                     /* 24px - 섹션 간 간격 */
+  --spacing-xl: 2rem;                       /* 32px - 페이지 레벨 간격 */
+  --spacing-header: 64px;                   /* 헤더 높이 */
+  --spacing-sidebar: 280px;                 /* 사이드바 너비 */
+
+  /* ============================================
+     Border Radius
+     ============================================ */
+
+  --radius-sm: 0.25rem;                     /* 4px - Badge, Tag */
+  --radius-md: 0.5rem;                      /* 8px - Button, Input, Card */
+  --radius-lg: 1rem;                        /* 16px - Modal, Dialog */
+  --radius-full: 9999px;                    /* Avatar, Pill Button */
+
+  /* ============================================
+     폰트 (Fonts)
+     ============================================ */
+
+  --font-sans: "Pretendard", "Apple SD Gothic Neo", sans-serif;
+
+  /* ============================================
+     브레이크포인트 (Breakpoints)
+     ============================================ */
+
+  --breakpoint-xs: 480px;
+  --breakpoint-sm: 640px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 1024px;
+  --breakpoint-xl: 1280px;
+  --breakpoint-2xl: 1440px;
+}


### PR DESCRIPTION
## Summary
- Tailwind v4 CSS-first 방식으로 디자인 시스템 토큰 정의
- 색상, 타이포그래피, 간격, Border Radius 등 전체 디자인 토큰 구현

## Changes
- `frontend/src/styles/tokens.css` 생성: @theme 블록에 전체 디자인 토큰 정의
  - Primary/Secondary 색상 50-900 스케일 (oklch 포맷)
  - Semantic 색상 (success, warning, error, danger, background, text)
  - Typography 토큰 (H1, H2, H3, Body, Caption)
  - Spacing 토큰 (xs, sm, md, lg, xl, header, sidebar)
  - Border Radius 토큰 (sm: 4px, md: 8px, lg: 16px, full: 9999px)
- `frontend/src/app/globals.css` 수정
  - tokens.css import 추가
  - @utility 타이포그래피 헬퍼 추가 (text-h1, text-h2, text-h3, text-body, text-caption)
- `frontend/src/styles/.gitkeep` 삭제

## Test plan
- [x] pnpm run build 성공
- [x] pnpm run type-check 통과
- [x] 디자인 토큰 Tailwind 유틸리티 클래스 생성 확인 (bg-primary-500, text-h1 등)

Closes #105