### PR TITLE
feat: App Router 레이아웃 및 Provider 설정 #108

### DIFF
--- a/docs/architecture/06_api_security.md
+++ b/docs/architecture/06_api_security.md
@@ -67,10 +67,10 @@
 
 #### 1.2.3 대기열 API (Queue Service)
 
-| Method | Endpoint | 설명 | 인증 | Rate Limit |
-|--------|----------|------|------|-----------|
+| Method | Endpoint | 설명 | 인증 | Rate Limit  |
+|--------|----------|------|------|-------------|
 | POST | `/queue/enter` | 대기열 진입 | 필수 | 100/분 (사용자) |
-| GET | `/queue/status` | 대기열 상태 조회 | 필수 | 60/분 (사용자) |
+| GET | `/queue/status` | 대기열 상태 조회 | 필수 | 15/분 (사용자)   |
 | DELETE | `/queue/leave` | 대기열 이탈 | 필수 | 100/분 (사용자) |
 
 **관련 요구사항:** REQ-QUEUE-001, REQ-QUEUE-002, REQ-QUEUE-008

--- a/docs/frontend-issues.md
+++ b/docs/frontend-issues.md
@@ -1,0 +1,821 @@
+# 프론트엔드 GitHub Issue 사전 계획
+
+> **목적**: 프론트엔드 개발에 필요한 GitHub Issue들을 사전 계획하여, 개발 순서와 의존성을 명확히 합니다.
+> **기반 문서**: `docs/frontend/00_overview.md` ~ `docs/frontend/07_performance.md` (8개 설계 문서)
+> **Issue 양식**: `.github/ISSUE_TEMPLATE/feature_request.md`
+
+---
+
+## 전체 개발 플로우
+
+```mermaid
+graph TD
+    Phase1[Phase 1: Foundation] --> Phase2[Phase 2: Design System]
+    Phase2 --> Phase3[Phase 3: Infrastructure]
+    Phase3 --> Phase4[Phase 4: Auth]
+    Phase3 --> Phase5[Phase 5: Event]
+    Phase4 --> Phase6[Phase 6: Queue]
+    Phase6 --> Phase7[Phase 7: Reservation & Payment]
+    Phase5 --> Phase7
+    Phase4 --> Phase8[Phase 8: MyPage]
+    Phase7 --> Phase9[Phase 9: Polish]
+    Phase8 --> Phase9
+```
+
+**총 Issue 개수**: 20개
+**Phase 개수**: 9개
+**사용 Label**: `frontend`, `feature`, `enhancement`, `infra`, `user`, `event`, `queue`, `reservation`, `payment`
+
+---
+
+## 개발 순서 및 의존성 체인
+
+```
+#1 → #2 → #3 → #4 → #5 → #6 → #7 → #8 → #10 → #11
+                                  ↘ #9 → #10       ↘
+                                  ↘ #12 → #13 → #14 → #15 → #16 → #17 → #18 → #20
+                                                 #8 → #19 ──────────────────────↗
+```
+
+**병렬 가능한 작업**:
+- #9, #12는 #6 완료 후 #7~#8과 병렬 가능
+- #19(마이페이지)는 #8 완료 후 #15~#18과 병렬 가능
+
+---
+
+## Phase 1: Foundation (프로젝트 초기화)
+
+### Issue #1: 프로젝트 초기화 및 기본 설정
+
+**Labels**: `frontend`, `infra`
+
+#### 🚀 기능
+Next.js 16+ 프로젝트를 초기화하고, TypeScript, TailwindCSS 4.0, pnpm을 기반으로 한 개발 환경을 구축합니다.
+
+#### ✅ 작업내용
+- [ ] Next.js 16+ 프로젝트 생성 (`npx create-next-app@latest`)
+  - App Router 사용
+  - TypeScript 활성화
+  - TailwindCSS 4.0 설정
+  - pnpm 패키지 매니저 사용
+- [ ] `tsconfig.json` 설정
+  - Path Alias 설정 (`@/` → `src/`)
+  - Strict 모드 활성화
+- [ ] `tailwind.config.ts` 설정
+  - 디자인 토큰 정의 (색상, 간격, 폰트)
+  - 커스텀 브레이크포인트 설정
+- [ ] `next.config.mjs` 설정
+  - 이미지 도메인 설정
+  - 환경 변수 설정
+- [ ] `.env.local` 템플릿 파일 생성
+  - `NEXT_PUBLIC_API_BASE_URL`
+  - `NEXT_PUBLIC_RECAPTCHA_SITE_KEY`
+  - `NEXT_PUBLIC_PORTONE_IMP_CODE`
+- [ ] 디렉토리 구조 생성
+  - `src/app/`, `src/components/`, `src/hooks/`, `src/lib/`, `src/stores/`, `src/types/`, `src/styles/`
+- [ ] `package.json` 스크립트 설정
+  - `dev`, `build`, `start`, `lint`, `type-check`
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/00_overview.md` (2. 기술 스택, 4. 프로젝트 구조)
+- 문서: `docs/frontend/00_overview.md` (5. 환경 변수 설정)
+
+---
+
+### Issue #2: 개발 도구 및 코드 품질 설정
+
+**Labels**: `frontend`, `infra`
+
+#### 🚀 기능
+ESLint, Prettier, Husky를 설정하여 코드 품질을 관리하고, Jest/Playwright로 테스트 환경을 구축합니다.
+
+#### ✅ 작업내용
+- [ ] ESLint 설정
+  - Next.js 권장 규칙 적용
+  - TypeScript 린팅 규칙
+  - 커스텀 규칙 추가 (React Hooks, a11y)
+- [ ] Prettier 설정
+  - 코드 포맷팅 규칙 정의
+  - `.prettierrc.json` 파일 생성
+  - `.prettierignore` 파일 생성
+- [ ] Husky 설정
+  - Git Hooks 설정 (pre-commit, pre-push)
+  - `lint-staged` 설정으로 커밋 전 자동 린팅
+- [ ] Jest 설정 (단위 테스트)
+  - `jest.config.ts` 파일 생성
+  - 테스트 헬퍼 함수 작성
+- [ ] Playwright 설정 (E2E 테스트)
+  - `playwright.config.ts` 파일 생성
+  - 테스트 시나리오 템플릿 작성
+- [ ] CI/CD 준비
+  - GitHub Actions 워크플로우 (선택)
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/00_overview.md` (2.4 개발 도구)
+
+---
+
+## Phase 2: Design System (디자인 시스템)
+
+### Issue #3: 디자인 시스템 토큰 및 TailwindCSS 설정
+
+**Labels**: `frontend`, `feature`
+
+#### 🚀 기능
+디자인 시스템의 기반이 되는 색상 팔레트, 타이포그래피, 간격, Border Radius 등 디자인 토큰을 TailwindCSS로 정의합니다.
+
+#### ✅ 작업내용
+- [ ] `tailwind.config.ts`에 색상 팔레트 정의
+  - Primary, Secondary, Success, Warning, Danger, Background, Text
+- [ ] 타이포그래피 설정
+  - Font Family, Font Size, Font Weight, Line Height
+  - H1, H2, H3, Body, Caption 스타일
+- [ ] Spacing (간격) 토큰 정의
+  - xs, sm, md, lg, xl
+- [ ] Border Radius 토큰 정의
+  - sm, md, lg, full
+- [ ] 브레이크포인트 설정
+  - Mobile (< 640px), Tablet (640px ~ 1024px), Desktop (1024px ~)
+- [ ] 글로벌 CSS 파일 작성 (`src/styles/globals.css`)
+  - TailwindCSS Base, Components, Utilities
+  - 커스텀 CSS 변수 정의
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/02_components.md` (4. 디자인 시스템 기초)
+
+---
+
+### Issue #4: 공통 UI 프리미티브 컴포넌트 구현
+
+**Labels**: `frontend`, `feature`
+
+#### 🚀 기능
+Button, Input, Modal, Toast, Card, Badge, Spinner 등 재사용 가능한 기본 UI 컴포넌트를 shadcn/ui 기반으로 구축합니다.
+
+#### ✅ 작업내용
+- [ ] `Button` 컴포넌트
+  - variant: primary, secondary, outline, ghost, danger
+  - size: sm, md, lg
+  - loading, disabled 상태 지원
+- [ ] `Input` 컴포넌트
+  - label, error 메시지 표시
+  - type: text, email, password, tel
+- [ ] `Modal` 컴포넌트
+  - Radix UI Dialog 기반
+  - 접근성 준수 (ESC 키, Focus Trap)
+- [ ] `Toast` 컴포넌트
+  - type: success, error, info, warning
+  - 자동 닫힘 (duration 설정 가능)
+- [ ] `Card` 컴포넌트
+  - 기본 카드 스타일 (border, shadow)
+- [ ] `Badge` 컴포넌트
+  - variant: default, success, warning, danger
+- [ ] `Spinner` 컴포넌트
+  - 로딩 인디케이터
+- [ ] `Checkbox` 컴포넌트
+  - Radix UI Checkbox 기반
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/02_components.md` (2. 공통 UI 컴포넌트)
+
+---
+
+### Issue #5: 레이아웃 컴포넌트 구현 (Header, Footer, Navigation)
+
+**Labels**: `frontend`, `feature`
+
+#### 🚀 기능
+Header, Footer, Navigation 등 레이아웃 컴포넌트를 구현하여 공통 UI 구조를 제공합니다.
+
+#### ✅ 작업내용
+- [ ] `Header` 컴포넌트
+  - 로고, 네비게이션 메뉴, 사용자 메뉴
+  - 로그인/로그아웃 상태 표시
+  - 반응형 디자인 (모바일 햄버거 메뉴)
+- [ ] `Footer` 컴포넌트
+  - 저작권, 링크, SNS 아이콘
+- [ ] `Navigation` 컴포넌트
+  - 메인 메뉴 (홈, 공연 목록, 마이페이지)
+  - 현재 페이지 강조 표시
+- [ ] `Sidebar` 컴포넌트 (선택)
+  - 모바일 사이드바 메뉴
+- [ ] 접근성 (a11y)
+  - 키보드 네비게이션 지원
+  - ARIA 속성 적용
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/02_components.md` (1. 컴포넌트 분류 - layout)
+
+---
+
+## Phase 3: Infrastructure (인프라 및 공통 기능)
+
+### Issue #6: App Router 레이아웃 및 Provider 설정
+
+**Labels**: `frontend`, `feature`
+
+#### 🚀 기능
+Next.js App Router의 루트 레이아웃, 라우트 그룹 레이아웃(`(auth)`, `(main)`)을 설정하고, React Query Provider, Zustand 초기화를 구성합니다.
+
+#### ✅ 작업내용
+- [ ] 루트 레이아웃 (`app/layout.tsx`)
+  - HTML 구조 (html, body)
+  - 전역 스타일 적용
+  - Provider 컴포넌트 래핑
+- [ ] Providers 컴포넌트 작성 (`src/providers.tsx`)
+  - React Query QueryClientProvider
+  - Zustand 스토어 초기화
+  - Toast Provider
+- [ ] 인증 레이아웃 (`app/(auth)/layout.tsx`)
+  - 로고 중앙 배치, 심플한 레이아웃
+- [ ] 메인 레이아웃 (`app/(main)/layout.tsx`)
+  - Header, Footer 포함
+- [ ] 페이지 구조 생성
+  - `app/page.tsx` (홈 페이지)
+  - `app/(auth)/login/page.tsx`, `app/(auth)/signup/page.tsx`
+  - `app/(main)/events/page.tsx`, 기타 페이지 플레이스홀더
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/01_pages.md` (2. App Router 구조, 3. 라우트 그룹별 레이아웃 계층)
+
+---
+
+### Issue #7: Axios 인스턴스 및 API 인프라 구축
+
+**Labels**: `frontend`, `feature`
+
+#### 🚀 기능
+Axios 인스턴스를 설정하고, Request/Response Interceptor를 구현하여 Access Token 자동 추가, Refresh Token 자동 갱신, 에러 처리를 표준화합니다.
+
+#### ✅ 작업내용
+- [ ] Axios 인스턴스 생성 (`lib/api/axios.ts`)
+  - baseURL: `NEXT_PUBLIC_API_BASE_URL`
+  - timeout: 30초
+  - 기본 헤더 설정
+- [ ] Request Interceptor
+  - Access Token 자동 추가 (Authorization 헤더)
+  - Queue Token 자동 추가 (X-Queue-Token 헤더)
+- [ ] Response Interceptor
+  - 401 에러 시 Refresh Token 자동 갱신
+  - 에러 타입별 처리 (400, 403, 404, 409, 429, 503)
+  - Toast 알림 표시
+- [ ] API 함수 작성 (`lib/api/`)
+  - `auth.ts`: 로그인, 회원가입, 로그아웃, 토큰 갱신
+  - `events.ts`: 공연 목록, 상세, 좌석 정보
+  - `queue.ts`: 대기열 진입, 상태 조회, 이탈
+  - `reservations.ts`: 좌석 선점, 예매 내역, 취소
+  - `payments.ts`: 결제 요청, 결제 승인
+- [ ] React Query 설정 (`lib/react-query/queryClient.ts`)
+  - QueryClient 생성 (retry, staleTime, gcTime 설정)
+  - Query Keys 정의 (`lib/react-query/queryKeys.ts`)
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/03_state_data.md` (2. Server State 관리, 4. API 호출 패턴)
+- API 명세: `docs/specification/00_overview.md`, `01_user_service.md` ~ `05_payment_service.md`
+
+---
+
+### Issue #8: 인증 스토어, 쿠키 유틸, 미들웨어 구현
+
+**Labels**: `frontend`, `feature`, `user`
+
+#### 🚀 기능
+Zustand 인증 스토어, 쿠키 유틸리티, Next.js 미들웨어를 구현하여 JWT 토큰 관리 및 인증 가드 기능을 제공합니다.
+
+#### ✅ 작업내용
+- [ ] Zustand 인증 스토어 (`stores/authStore.ts`)
+  - user, accessToken, isAuthenticated 상태 관리
+  - setUser, setAccessToken, logout 액션
+  - persist 미들웨어 (localStorage에 user만 저장)
+- [ ] Zustand 대기열 스토어 (`stores/queueStore.ts`)
+  - queueToken, scheduleId, position 상태 관리
+- [ ] Zustand 예매 스토어 (`stores/reservationStore.ts`)
+  - selectedSeats, totalPrice 상태 관리
+  - addSeat, removeSeat, clearSeats 액션
+- [ ] 쿠키 유틸리티 (`lib/auth/cookies.ts`)
+  - setAccessToken, setRefreshToken, setQueueToken
+  - clearTokens
+  - httpOnly, Secure, SameSite=Strict 설정
+- [ ] JWT 검증 유틸 (`lib/auth/jwt.ts`)
+  - verifyAccessToken, verifyQueueToken
+- [ ] Next.js 미들웨어 (`src/middleware.ts`)
+  - 공개 경로 vs 인증 필요 경로 분리
+  - Access Token 검증
+  - Queue Token 검증 (예매/결제 페이지)
+  - 401 리디렉션 (로그인 페이지 또는 대기열 페이지)
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/03_state_data.md` (3. Client State 관리)
+- 문서: `docs/frontend/04_auth_security.md` (1. JWT 토큰 저장 전략, 5. Next.js 미들웨어 기반 인증 가드)
+- 문서: `docs/frontend/01_pages.md` (4. 미들웨어)
+
+---
+
+### Issue #9: 에러 바운더리, 404 페이지, 로딩 UI 구현
+
+**Labels**: `frontend`, `feature`
+
+#### 🚀 기능
+전역 에러 바운더리, 404 페이지, 로딩 Spinner/Skeleton UI를 구현하여 안정적인 사용자 경험을 제공합니다.
+
+#### ✅ 작업내용
+- [ ] 전역 에러 바운더리 (`app/error.tsx`)
+  - React Error Boundary 적용
+  - 에러 메시지 표시
+  - "다시 시도" 버튼
+- [ ] React Query 에러 바운더리 (`components/ErrorBoundary.tsx`)
+  - QueryErrorResetBoundary 적용
+- [ ] 404 페이지 (`app/not-found.tsx`)
+  - "페이지를 찾을 수 없습니다" 메시지
+  - "홈으로 돌아가기" 버튼
+- [ ] 로딩 UI (`app/loading.tsx`)
+  - 전역 로딩 Spinner
+- [ ] Skeleton UI 컴포넌트
+  - EventListSkeleton, EventDetailSkeleton
+  - QueueSkeleton, SeatMapSkeleton
+  - PaymentSummarySkeleton
+- [ ] 에러 핸들러 유틸 (`lib/errors/errorHandler.ts`)
+  - 에러 타입별 메시지 매핑
+  - Toast 알림 표시
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/01_pages.md` (7. 에러 페이지 전략)
+- 문서: `docs/frontend/03_state_data.md` (5. 에러/로딩 상태 처리 전략)
+
+---
+
+## Phase 4: Auth (인증 및 회원가입)
+
+### Issue #10: 로그인 페이지 및 인증 Hooks 구현
+
+**Labels**: `frontend`, `feature`, `user`
+
+#### 🚀 기능
+로그인 페이지, reCAPTCHA 연동, 로그인 Mutation을 구현하여 사용자 인증 기능을 제공합니다.
+
+#### ✅ 작업내용
+- [ ] 로그인 페이지 (`app/(auth)/login/page.tsx`)
+- [ ] LoginForm 컴포넌트 (`components/domain/auth/LoginForm.tsx`)
+  - React Hook Form + Zod 스키마 검증
+  - 이메일, 비밀번호 입력 필드
+  - reCAPTCHA 위젯 통합
+  - 로그인 버튼 (로딩 상태 표시)
+- [ ] reCAPTCHA 위젯 컴포넌트 (`components/domain/auth/RecaptchaWidget.tsx`)
+  - `react-google-recaptcha` 라이브러리 사용
+  - NEXT_PUBLIC_RECAPTCHA_SITE_KEY 환경 변수
+- [ ] Zod 스키마 (`lib/validation/authSchemas.ts`)
+  - loginSchema, signupSchema
+- [ ] useLogin Hook (`hooks/useLogin.ts`)
+  - useMutation으로 로그인 API 호출
+  - 성공 시: Cookie에 토큰 저장, Zustand에 사용자 정보 저장, 홈 페이지 리디렉트
+  - 실패 시: 에러 메시지 Toast 표시
+- [ ] useLogout Hook (`hooks/useLogout.ts`)
+  - 로그아웃 API 호출
+  - Cookie 삭제, Zustand 상태 초기화
+  - 로그인 페이지로 리디렉트
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/04_auth_security.md` (2.1 로그인 플로우, 3. reCAPTCHA 연동, 7. 로그아웃)
+- API 명세: `docs/specification/01_user_service.md` (1.1 로그인, 1.3 로그아웃)
+
+---
+
+### Issue #11: 회원가입 4단계 위저드 및 PortOne 본인인증
+
+**Labels**: `frontend`, `feature`, `user`
+
+#### 🚀 기능
+회원가입 4단계 위저드 (약관동의 → CAPTCHA → 본인인증 → 정보입력)를 구현하고, PortOne SDK를 연동하여 본인인증(CI/DI) 기능을 제공합니다.
+
+#### ✅ 작업내용
+- [ ] 회원가입 페이지 (`app/(auth)/signup/page.tsx`)
+  - 4단계 위저드 상태 관리 (useState)
+  - 진행 상황 표시 (ProgressBar)
+- [ ] TermsStep 컴포넌트 (`components/domain/auth/signup/TermsStep.tsx`)
+  - 서비스 이용약관, 개인정보 수집 동의 체크박스
+  - "다음" 버튼
+- [ ] CaptchaStep 컴포넌트 (`components/domain/auth/signup/CaptchaStep.tsx`)
+  - reCAPTCHA 위젯
+  - 검증 토큰 저장 후 다음 단계
+- [ ] VerifyStep 컴포넌트 (`components/domain/auth/signup/VerifyStep.tsx`)
+  - PortOne 본인인증 버튼
+  - CI/DI 수집 후 다음 단계
+- [ ] InfoStep 컴포넌트 (`components/domain/auth/signup/InfoStep.tsx`)
+  - React Hook Form + Zod 스키마 검증
+  - 이메일, 비밀번호, 비밀번호 확인, 이름, 전화번호 입력
+  - 회원가입 완료 버튼
+- [ ] PortOne SDK 초기화 (`lib/portone/init.ts`)
+  - 스크립트 로딩 (https://cdn.iamport.kr/v1/iamport.js)
+- [ ] usePortOne Hook (`hooks/usePortOne.ts`)
+  - requestCertification 함수 (본인인증 요청)
+  - imp_uid를 백엔드로 전송하여 CI/DI 수집
+- [ ] useSignup Hook (`hooks/useSignup.ts`)
+  - useMutation으로 회원가입 API 호출
+  - 성공 시: 로그인 페이지로 리디렉트
+  - 실패 시: 에러 메시지 Toast 표시
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/04_auth_security.md` (2.2 회원가입 플로우, 4. 본인인증 연동 흐름)
+- 문서: `docs/frontend/02_components.md` (3.2 회원가입 페이지)
+- API 명세: `docs/specification/01_user_service.md` (1.2 회원가입, 1.4 본인인증 검증)
+
+---
+
+## Phase 5: Event (공연 관련 페이지)
+
+### Issue #12: 홈 페이지 (SSR) 구현
+
+**Labels**: `frontend`, `feature`, `event`
+
+#### 🚀 기능
+홈 페이지를 SSR로 구현하여 공연 목록 및 검색 기능을 제공하고, SEO를 최적화합니다.
+
+#### ✅ 작업내용
+- [ ] 홈 페이지 (`app/page.tsx`)
+  - Server Component로 구현
+  - 공연 목록 SSR 데이터 페칭
+  - 메타 태그 설정 (title, description)
+- [ ] EventList 컴포넌트 (`components/domain/event/EventList.tsx`)
+  - Server Component
+  - 공연 카드 그리드 레이아웃
+- [ ] EventCard 컴포넌트 (`components/domain/event/EventCard.tsx`)
+  - 공연 포스터 이미지 (next/image)
+  - 공연 제목, 날짜, 장소
+  - 클릭 시 공연 상세 페이지로 이동
+- [ ] Hero Banner 섹션 (선택)
+  - 메인 배너 이미지, 슬로건
+- [ ] SEO 최적화
+  - 메타 태그 (title, description, keywords)
+  - OG 태그 (og:title, og:description, og:image)
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/01_pages.md` (5. 페이지별 SSR/CSR 전략)
+- 문서: `docs/frontend/07_performance.md` (1. 페이지별 렌더링 전략, 5. SEO 메타 태그 전략)
+- API 명세: `docs/specification/02_event_service.md` (1.1 공연 목록 조회)
+
+---
+
+### Issue #13: 공연 목록 페이지 (SSR + 필터/페이지네이션)
+
+**Labels**: `frontend`, `feature`, `event`
+
+#### 🚀 기능
+공연 목록 페이지를 SSR로 구현하고, 필터링, 정렬, 검색, 페이지네이션 기능을 제공합니다.
+
+#### ✅ 작업내용
+- [ ] 공연 목록 페이지 (`app/(main)/events/page.tsx`)
+  - Server Component로 구현
+  - searchParams로 페이지, 검색어, 정렬 기준 받기
+  - SSR 데이터 페칭
+- [ ] EventFilter 컴포넌트 (`components/domain/event/EventFilter.tsx`)
+  - Client Component
+  - 검색 입력 필드 (키워드)
+  - 정렬 기준 Select (최신순, 인기순)
+  - 적용 버튼 (URL 쿼리 파라미터 업데이트)
+- [ ] Pagination 컴포넌트 (`components/ui/Pagination.tsx`)
+  - 이전/다음 페이지 버튼
+  - 페이지 번호 표시
+  - URL 쿼리 파라미터 업데이트
+- [ ] EventList, EventCard 재사용
+- [ ] SEO 최적화
+  - 메타 태그, OG 태그
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/02_components.md` (3.3 공연 목록 페이지)
+- API 명세: `docs/specification/02_event_service.md` (1.1 공연 목록 조회)
+
+---
+
+### Issue #14: 공연 상세 페이지 (SSR + SEO + JSON-LD)
+
+**Labels**: `frontend`, `feature`, `event`
+
+#### 🚀 기능
+공연 상세 페이지를 SSR로 구현하고, 회차 목록, 좌석 정보를 표시하며, SEO를 위한 OG 태그 및 JSON-LD Structured Data를 추가합니다.
+
+#### ✅ 작업내용
+- [ ] 공연 상세 페이지 (`app/(main)/events/[id]/page.tsx`)
+  - Server Component로 구현
+  - generateMetadata 함수로 동적 메타 태그 생성
+  - SSR 데이터 페칭 (공연 상세, 회차 목록, 좌석 정보)
+- [ ] EventDetail 컴포넌트 (`components/domain/event/EventDetail.tsx`)
+  - 공연 포스터 이미지 (next/image, priority)
+  - 공연 제목, 설명, 장르, 러닝타임
+  - 공연장 정보
+- [ ] ScheduleList 컴포넌트 (`components/domain/event/ScheduleList.tsx`)
+  - 회차 카드 목록
+  - 회차별 날짜, 시간, 잔여석, "예매하기" 버튼
+- [ ] SeatInfo 컴포넌트 (`components/domain/event/SeatInfo.tsx`)
+  - 좌석 등급별 가격 표시
+- [ ] EventStructuredData 컴포넌트 (`components/domain/event/EventStructuredData.tsx`)
+  - JSON-LD 스키마 생성 (Event, Place, Offer)
+  - <script type="application/ld+json"> 태그 삽입
+- [ ] SEO 최적화
+  - 메타 태그, OG 태그, Twitter 카드
+  - Canonical URL
+  - JSON-LD Structured Data
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/02_components.md` (3.4 공연 상세 페이지)
+- 문서: `docs/frontend/07_performance.md` (1.3 SSR + OG 태그, 5.3 Structured Data)
+- API 명세: `docs/specification/02_event_service.md` (1.2 공연 상세 조회, 1.3 좌석 정보 조회)
+
+---
+
+## Phase 6: Queue (대기열)
+
+### Issue #15: 대기열 페이지 (폴링, 타이머, 자동 리디렉트)
+
+**Labels**: `frontend`, `feature`, `queue`
+
+#### 🚀 기능
+대기열 페이지를 CSR로 구현하고, 5초 폴링, 대기 순서/예상 시간 표시, Queue Token 발급 시 자동 리디렉트, 10분 TTL 타이머를 제공합니다.
+
+#### ✅ 작업내용
+- [ ] 대기열 페이지 (`app/(main)/queue/[scheduleId]/page.tsx`)
+  - Client Component
+  - useQueueStatus Hook으로 5초 폴링
+- [ ] QueueStatus 컴포넌트 (`components/domain/queue/QueueStatus.tsx`)
+  - 대기 상태에 따른 UI 표시 (WAITING, APPROVED, EXPIRED)
+  - APPROVED 시 좌석 선택 페이지로 자동 리디렉트
+  - EXPIRED 시 공연 상세 페이지로 리디렉트
+- [ ] QueuePosition 컴포넌트 (`components/domain/queue/QueuePosition.tsx`)
+  - 현재 대기 순서 숫자 표시 (예: 1,234번째)
+- [ ] EstimatedTime 컴포넌트 (`components/domain/queue/EstimatedTime.tsx`)
+  - 예상 대기 시간 (분/시간 단위)
+- [ ] QueueProgress 컴포넌트 (`components/domain/queue/QueueProgress.tsx`)
+  - 진행 바 (Progress Bar)
+  - 진행률 퍼센트 표시
+- [ ] QueueTimer 컴포넌트 (`components/domain/queue/QueueTimer.tsx`)
+  - 10분 타이머 (MM:SS 형식)
+  - 2분 미만 시 경고 색상/깜빡임
+  - 타이머 만료 시 공연 상세 페이지로 리디렉트
+- [ ] QueueInfo 컴포넌트 (안내 메시지)
+- [ ] LeaveQueueButton 컴포넌트 (`components/domain/queue/LeaveQueueButton.tsx`)
+  - "대기열 나가기" 버튼
+  - 확인 다이얼로그
+- [ ] useQueueStatus Hook (`hooks/useQueueStatus.ts`)
+  - useQuery로 5초 폴링 (refetchInterval: 5000)
+  - staleTime: 0 (항상 최신 데이터 요청)
+- [ ] useLeaveQueue Hook (`hooks/useLeaveQueue.ts`)
+  - useMutation으로 대기열 이탈 API 호출
+- [ ] 에러 처리
+  - QueueError 컴포넌트 (QUEUE_FULL, ALREADY_IN_QUEUE 등)
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/05_queue_ux.md` (1. 대기열 진입 → 대기 → 승인 화면 전환 흐름, 2. 폴링 전략, 3. 대기 순서/예상 시간 UI, 5. 타이머 UI)
+- 문서: `docs/frontend/02_components.md` (3.5 대기열 페이지)
+- API 명세: `docs/specification/03_queue_service.md` (1.1 대기열 진입, 1.2 대기열 상태 조회, 1.3 대기열 이탈)
+
+---
+
+## Phase 7: Reservation & Payment (좌석 선택 및 결제)
+
+### Issue #16: 좌석 선택 페이지 (SeatMap, 선점, Hold 타이머)
+
+**Labels**: `frontend`, `feature`, `reservation`
+
+#### 🚀 기능
+좌석 선택 페이지를 CSR로 구현하고, 실시간 좌석 상태 조회, 좌석 선점 (최대 4장), 선점 5분 타이머를 제공합니다.
+
+#### ✅ 작업내용
+- [ ] 좌석 선택 페이지 (`app/(main)/reservation/[scheduleId]/page.tsx`)
+  - Client Component
+  - Queue Token 필수 (미들웨어로 검증)
+  - useSeats Hook으로 좌석 상태 조회 (10초 폴링)
+- [ ] SeatMap 컴포넌트 (`components/domain/reservation/SeatMap.tsx`)
+  - 좌석 그리드 레이아웃
+  - 무대 표시
+  - 좌석 클릭 이벤트 핸들러
+- [ ] SeatButton 컴포넌트 (`components/domain/reservation/SeatButton.tsx`)
+  - 좌석 상태별 색상 (AVAILABLE, HOLD, SOLD)
+  - 선택된 좌석 강조 표시
+  - 클릭 시 선택/해제
+- [ ] SeatLegend 컴포넌트 (`components/domain/reservation/SeatLegend.tsx`)
+  - 좌석 상태 범례 (선택 가능, 선택됨, 임시 선점, 판매 완료)
+- [ ] ReservationSummary 컴포넌트 (`components/domain/reservation/ReservationSummary.tsx`)
+  - 선택한 좌석 목록 표시
+  - 총 금액 계산
+  - "결제하기" 버튼 (좌석 선점 API 호출)
+- [ ] HoldTimer 컴포넌트 (`components/domain/reservation/HoldTimer.tsx`)
+  - 5분 타이머 (MM:SS 형식)
+  - 1분 미만 시 경고 색상
+  - 타이머 만료 시 좌석 선택 페이지로 리디렉트
+- [ ] useSeats Hook (`hooks/useSeats.ts`)
+  - useQuery로 좌석 상태 조회 (refetchInterval: 10000)
+- [ ] useHoldSeat Hook (`hooks/useHoldSeat.ts`)
+  - useMutation으로 좌석 선점 API 호출
+  - 성공 시: 결제 페이지로 리디렉트
+  - 실패 시: 에러 메시지 Toast (SEAT_ALREADY_HELD, MAX_SEATS_EXCEEDED)
+- [ ] Zustand 예매 스토어 활용
+  - selectedSeats, totalPrice 상태 관리
+- [ ] 에러 처리
+  - 좌석 선점 실패 시 좌석 선택 초기화
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/06_payment_ux.md` (2. 좌석 선택 페이지, 4. 좌석 선점 타이머)
+- 문서: `docs/frontend/02_components.md` (3.6 좌석 선택 페이지)
+- API 명세: `docs/specification/04_reservation_service.md` (1.1 실시간 좌석 상태 조회, 1.2 좌석 선점)
+
+---
+
+### Issue #17: 결제 페이지 (PortOne SDK, 3단계 결제 플로우)
+
+**Labels**: `frontend`, `feature`, `payment`
+
+#### 🚀 기능
+결제 페이지를 CSR로 구현하고, PortOne SDK를 연동하여 3단계 결제 플로우 (결제 요청 → PortOne 위젯 → 결제 승인)를 제공합니다.
+
+#### ✅ 작업내용
+- [ ] 결제 페이지 (`app/(main)/payment/[reservationId]/page.tsx`)
+  - Client Component
+  - Queue Token 필수 (미들웨어로 검증)
+  - useReservationDetail Hook으로 예매 정보 조회
+- [ ] PaymentSummary 컴포넌트 (`components/domain/payment/PaymentSummary.tsx`)
+  - 공연 정보 (제목, 날짜, 시간)
+  - 좌석 정보 (좌석 번호, 등급)
+  - 총 결제 금액
+  - HoldTimer 표시 (5분 타이머)
+- [ ] PaymentWidget 컴포넌트 (`components/domain/payment/PaymentWidget.tsx`)
+  - "결제하기" 버튼
+  - 클릭 시 3단계 플로우 실행:
+    1. 결제 요청 생성 (백엔드)
+    2. PortOne 결제 위젯 열기
+    3. 결제 승인 (백엔드)
+  - 성공 시: 결제 완료 페이지로 리디렉트
+  - 실패 시: 에러 메시지 Toast
+- [ ] usePayment Hook (`hooks/usePayment.ts`)
+  - useMutation으로 결제 요청 API 호출
+- [ ] useConfirmPayment Hook (`hooks/useConfirmPayment.ts`)
+  - useMutation으로 결제 승인 API 호출
+- [ ] usePortOne Hook 확장 (결제 위젯)
+  - requestPayment 함수 (결제 위젯 열기)
+  - imp_uid 반환
+- [ ] 에러 처리
+  - PAYMENT_FAILED, RESERVATION_EXPIRED 에러 케이스별 UX
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/06_payment_ux.md` (5. 결제 페이지, 6. PortOne SDK 연동, 7. 결제 상태 처리)
+- 문서: `docs/frontend/02_components.md` (3.7 결제 페이지)
+- API 명세: `docs/specification/05_payment_service.md` (1.1 결제 요청, 1.2 결제 승인)
+
+---
+
+### Issue #18: 결제 완료/실패 페이지
+
+**Labels**: `frontend`, `feature`, `payment`
+
+#### 🚀 기능
+결제 완료 페이지와 결제 실패 페이지를 구현하여, 결제 결과에 따른 안내 메시지 및 다음 액션 버튼을 제공합니다.
+
+#### ✅ 작업내용
+- [ ] 결제 완료 페이지 (`app/(main)/payment/complete/page.tsx`)
+  - Client Component
+  - 성공 아이콘, 메시지
+  - "예매 내역 확인" 버튼 (마이페이지로 이동)
+  - "홈으로 돌아가기" 버튼
+- [ ] PaymentFailed 컴포넌트 (`components/domain/payment/PaymentFailed.tsx`)
+  - 실패 아이콘, 메시지
+  - "다시 시도하기" 버튼 (결제 페이지로 돌아가기)
+- [ ] 사용자 경험 최적화
+  - 명확한 안내 메시지
+  - 다음 액션 버튼 강조
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/06_payment_ux.md` (7. 결제 상태 처리)
+
+---
+
+## Phase 8: MyPage (마이페이지)
+
+### Issue #19: 마이페이지 (프로필, 예매 내역)
+
+**Labels**: `frontend`, `feature`, `user`
+
+#### 🚀 기능
+마이페이지를 CSR로 구현하고, 사용자 프로필 요약, 예매 내역 목록, 프로필 관리 기능을 제공합니다.
+
+#### ✅ 작업내용
+- [ ] 마이페이지 메인 (`app/(main)/mypage/page.tsx`)
+  - Client Component
+  - 사용자 프로필 요약
+  - 예매 내역 목록 (최근 5건)
+  - 네비게이션 메뉴 (프로필 관리, 예매 내역)
+- [ ] UserProfile 컴포넌트 (`components/domain/mypage/UserProfile.tsx`)
+  - 아바타, 이름, 이메일 표시
+- [ ] ReservationList 컴포넌트 (`components/domain/mypage/ReservationList.tsx`)
+  - 예매 카드 목록
+  - 공연 정보, 좌석 정보, 예매 상태 (CONFIRMED, CANCELLED)
+  - "상세 보기" 버튼
+- [ ] ReservationCard 컴포넌트 (`components/domain/mypage/ReservationCard.tsx`)
+  - 예매 카드 UI
+- [ ] 예매 내역 페이지 (`app/(main)/mypage/reservations/page.tsx`)
+  - 전체 예매 내역 목록 (페이지네이션)
+- [ ] 프로필 관리 페이지 (`app/(main)/mypage/profile/page.tsx`)
+  - 정보 수정 폼 (이름, 전화번호)
+  - 비밀번호 변경 폼
+- [ ] useProfile Hook (`hooks/useProfile.ts`)
+  - useQuery로 사용자 프로필 조회
+- [ ] useReservations Hook (`hooks/useReservations.ts`)
+  - useQuery로 예매 내역 조회
+- [ ] useUpdateProfile Hook (`hooks/useUpdateProfile.ts`)
+  - useMutation으로 프로필 수정 API 호출
+- [ ] useChangePassword Hook (`hooks/useChangePassword.ts`)
+  - useMutation으로 비밀번호 변경 API 호출
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/02_components.md` (3.8 마이페이지)
+- API 명세: `docs/specification/01_user_service.md` (2.1 내 프로필 조회, 2.2 프로필 수정)
+- API 명세: `docs/specification/04_reservation_service.md` (1.3 예매 내역 조회)
+
+---
+
+## Phase 9: Polish (성능 최적화 및 마무리)
+
+### Issue #20: 성능 최적화, SEO 마무리, 번들 분석
+
+**Labels**: `frontend`, `enhancement`
+
+#### 🚀 기능
+프론트엔드 성능 최적화 (이미지, 번들 사이즈, Core Web Vitals), SEO 최종 점검, 번들 분석을 수행하여 프로덕션 배포 준비를 완료합니다.
+
+#### ✅ 작업내용
+- [ ] **이미지 최적화**
+  - 모든 이미지를 `next/image`로 교체
+  - WebP/AVIF 포맷 지원 확인
+  - `priority` 속성 LCP 이미지에 적용
+  - `placeholder="blur"` 적용
+- [ ] **코드 스플리팅**
+  - PortOne SDK, 차트 라이브러리 등 무거운 라이브러리 Dynamic Import
+  - React.lazy + Suspense 활용
+- [ ] **번들 사이즈 분석**
+  - `@next/bundle-analyzer` 설치 및 실행
+  - First Load JS < 200KB 목표
+  - 불필요한 의존성 제거
+- [ ] **Core Web Vitals 측정**
+  - Vercel Analytics 설치
+  - LCP < 2.5s, FID < 100ms, CLS < 0.1 목표
+  - Lighthouse CI 설정 (선택)
+- [ ] **SEO 최종 점검**
+  - 모든 페이지 메타 태그 확인
+  - Sitemap 생성 (`public/sitemap.xml`)
+  - robots.txt 설정 (`public/robots.txt`)
+  - Google Search Console 등록 (선택)
+- [ ] **폰트 최적화**
+  - next/font로 폰트 로딩 최적화
+  - font-display: swap 설정
+- [ ] **타입 체크 및 린팅**
+  - `pnpm type-check` 실행 (에러 0개)
+  - `pnpm lint` 실행 (에러 0개)
+- [ ] **E2E 테스트 작성** (선택)
+  - Playwright로 주요 플로우 테스트 (로그인, 예매, 결제)
+- [ ] **Vercel 배포 설정**
+  - 환경 변수 설정 (Production, Preview)
+  - GitHub 연동 확인
+  - PR 프리뷰 URL 자동 생성 확인
+- [ ] **성능 개선 문서 작성**
+  - 최적화 전후 비교 (번들 사이즈, Core Web Vitals)
+
+#### 🔗 참고사항
+- 문서: `docs/frontend/07_performance.md` (2. 이미지 최적화, 3. 번들 사이즈 최적화, 4. Core Web Vitals 목표, 5. SEO 메타 태그 전략, 6. Vercel 배포 최적화, 8. 성능 체크리스트)
+
+---
+
+## 전체 Issue 목록 요약
+
+| # | Issue 제목 | Labels | Phase | 의존성 |
+|---|-----------|--------|-------|--------|
+| 1 | 프로젝트 초기화 및 기본 설정 | `frontend`, `infra` | 1. Foundation | - |
+| 2 | 개발 도구 및 코드 품질 설정 | `frontend`, `infra` | 1. Foundation | #1 |
+| 3 | 디자인 시스템 토큰 및 TailwindCSS 설정 | `frontend`, `feature` | 2. Design System | #2 |
+| 4 | 공통 UI 프리미티브 컴포넌트 구현 | `frontend`, `feature` | 2. Design System | #3 |
+| 5 | 레이아웃 컴포넌트 구현 (Header, Footer, Navigation) | `frontend`, `feature` | 2. Design System | #4 |
+| 6 | App Router 레이아웃 및 Provider 설정 | `frontend`, `feature` | 3. Infrastructure | #5 |
+| 7 | Axios 인스턴스 및 API 인프라 구축 | `frontend`, `feature` | 3. Infrastructure | #6 |
+| 8 | 인증 스토어, 쿠키 유틸, 미들웨어 구현 | `frontend`, `feature`, `user` | 3. Infrastructure | #7 |
+| 9 | 에러 바운더리, 404 페이지, 로딩 UI 구현 | `frontend`, `feature` | 3. Infrastructure | #6 |
+| 10 | 로그인 페이지 및 인증 Hooks 구현 | `frontend`, `feature`, `user` | 4. Auth | #8, #9 |
+| 11 | 회원가입 4단계 위저드 및 PortOne 본인인증 | `frontend`, `feature`, `user` | 4. Auth | #10 |
+| 12 | 홈 페이지 (SSR) 구현 | `frontend`, `feature`, `event` | 5. Event | #6 |
+| 13 | 공연 목록 페이지 (SSR + 필터/페이지네이션) | `frontend`, `feature`, `event` | 5. Event | #12 |
+| 14 | 공연 상세 페이지 (SSR + SEO + JSON-LD) | `frontend`, `feature`, `event` | 5. Event | #13 |
+| 15 | 대기열 페이지 (폴링, 타이머, 자동 리디렉트) | `frontend`, `feature`, `queue` | 6. Queue | #8, #14 |
+| 16 | 좌석 선택 페이지 (SeatMap, 선점, Hold 타이머) | `frontend`, `feature`, `reservation` | 7. Reservation & Payment | #15 |
+| 17 | 결제 페이지 (PortOne SDK, 3단계 결제 플로우) | `frontend`, `feature`, `payment` | 7. Reservation & Payment | #16 |
+| 18 | 결제 완료/실패 페이지 | `frontend`, `feature`, `payment` | 7. Reservation & Payment | #17 |
+| 19 | 마이페이지 (프로필, 예매 내역) | `frontend`, `feature`, `user` | 8. MyPage | #8 |
+| 20 | 성능 최적화, SEO 마무리, 번들 분석 | `frontend`, `enhancement` | 9. Polish | #18, #19 |
+
+---
+
+## 다음 단계
+
+1. **GitHub Issue 생성**: 이 문서를 기반으로 GitHub Issue를 수동으로 생성하거나, 스크립트로 자동 생성합니다.
+2. **개발 시작**: Issue #1부터 순차적으로 진행하며, 병렬 가능한 작업은 동시에 수행합니다.
+3. **검증**: 각 Issue 완료 시 체크리스트를 확인하고, PR을 생성하여 코드 리뷰를 진행합니다.
+4. **배포**: 모든 Issue 완료 후 Vercel에 배포하여 프로덕션 환경에서 테스트합니다.
+
+---
+
+**작성일**: 2026-02-10
+**버전**: Draft 1.0.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "prepare": "cd .. && husky frontend/.husky"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.90.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.563.0",
@@ -29,7 +30,8 @@
     "react-dom": "19.2.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -45,6 +47,7 @@
     "eslint-config-prettier": "^10.1.8",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
+    "prettier": "^3.8.1",
     "tailwindcss": "^4",
     "ts-node": "^10.9.2",
     "typescript": "^5"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.90.20
+        version: 5.90.20(react@19.2.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -41,6 +44,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      zustand:
+        specifier: ^5.0.11
+        version: 5.0.11(@types/react@19.2.13)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -81,6 +87,9 @@ importers:
       jest-environment-jsdom:
         specifier: ^30.2.0
         version: 30.2.0
+      prettier:
+        specifier: ^3.8.1
+        version: 3.8.1
       tailwindcss:
         specifier: ^4
         version: 4.1.18
@@ -1554,6 +1563,14 @@ packages:
 
   '@tailwindcss/postcss@4.1.18':
     resolution: {integrity: sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==}
+
+  '@tanstack/query-core@5.90.20':
+    resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
+
+  '@tanstack/react-query@5.90.20':
+    resolution: {integrity: sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -3388,6 +3405,11 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier@3.8.1:
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -4006,6 +4028,24 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zustand@5.0.11:
+    resolution: {integrity: sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -5562,6 +5602,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.18
       postcss: 8.5.6
       tailwindcss: 4.1.18
+
+  '@tanstack/query-core@5.90.20': {}
+
+  '@tanstack/react-query@5.90.20(react@19.2.3)':
+    dependencies:
+      '@tanstack/query-core': 5.90.20
+      react: 19.2.3
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -7747,6 +7794,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prettier@3.8.1: {}
+
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -8511,3 +8560,9 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zustand@5.0.11(@types/react@19.2.13)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
+    optionalDependencies:
+      '@types/react': 19.2.13
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)

--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -1,0 +1,10 @@
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900">Ticket Queue</h1>
+      </div>
+      <div className="w-full max-w-md">{children}</div>
+    </div>
+  )
+}

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+export default function LoginPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-background">
+      <div className="text-center">
+        <h1 className="text-h1 text-foreground mb-md">로그인</h1>
+        <p className="text-body text-muted-foreground">로그인 페이지입니다</p>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/app/(auth)/signup/page.tsx
+++ b/frontend/src/app/(auth)/signup/page.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+export default function SignupPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-background">
+      <div className="text-center">
+        <h1 className="text-h1 text-foreground mb-md">회원가입</h1>
+        <p className="text-body text-muted-foreground">회원가입 페이지입니다</p>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/app/(main)/events/[id]/page.tsx
+++ b/frontend/src/app/(main)/events/[id]/page.tsx
@@ -1,0 +1,14 @@
+export default async function EventDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-spacing-xl">
+      <div className="max-w-2xl text-center">
+        <h1 className="mb-spacing-lg text-4xl font-bold text-gray-900">공연 상세</h1>
+        <p className="text-gray-600">
+          공연 ID: <span className="font-mono">{id}</span>
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/app/(main)/events/page.tsx
+++ b/frontend/src/app/(main)/events/page.tsx
@@ -1,0 +1,10 @@
+export default function EventsPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-spacing-xl">
+      <div className="max-w-2xl text-center">
+        <h1 className="mb-spacing-lg text-4xl font-bold text-gray-900">공연 목록</h1>
+        <p className="text-gray-600">진행 중인 공연 목록을 확인하고 예매를 시작하세요.</p>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/app/(main)/layout.tsx
+++ b/frontend/src/app/(main)/layout.tsx
@@ -1,0 +1,11 @@
+import { Header, Footer } from '@/components/layout'
+
+export default function MainLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1">{children}</main>
+      <Footer />
+    </div>
+  )
+}

--- a/frontend/src/app/(main)/mypage/page.tsx
+++ b/frontend/src/app/(main)/mypage/page.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+export default function MyPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-spacing-xl">
+      <div className="max-w-2xl text-center">
+        <h1 className="mb-spacing-lg text-4xl font-bold text-gray-900">마이페이지</h1>
+        <p className="text-gray-600">회원 정보와 예매 내역을 관리할 수 있습니다.</p>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/app/(main)/mypage/profile/page.tsx
+++ b/frontend/src/app/(main)/mypage/profile/page.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+export default function ProfilePage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-spacing-xl">
+      <div className="max-w-2xl text-center">
+        <h1 className="mb-spacing-lg text-4xl font-bold text-gray-900">프로필 관리</h1>
+        <p className="text-gray-600">회원 정보를 수정하고 관리할 수 있습니다.</p>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/app/(main)/mypage/reservations/page.tsx
+++ b/frontend/src/app/(main)/mypage/reservations/page.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+export default function MyReservationsPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-spacing-xl">
+      <div className="max-w-2xl text-center">
+        <h1 className="mb-spacing-lg text-4xl font-bold text-gray-900">예매 내역</h1>
+        <p className="text-gray-600">나의 예매 내역을 확인하고 관리할 수 있습니다.</p>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/app/(main)/payment/[reservationId]/page.tsx
+++ b/frontend/src/app/(main)/payment/[reservationId]/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { use } from 'react'
+
+export default function PaymentPage({ params }: { params: Promise<{ reservationId: string }> }) {
+  const { reservationId } = use(params)
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-spacing-xl">
+      <div className="max-w-2xl text-center">
+        <h1 className="mb-spacing-lg text-4xl font-bold text-gray-900">결제</h1>
+        <p className="text-gray-600">
+          예매 ID: <span className="font-mono">{reservationId}</span>
+        </p>
+        <p className="mt-spacing-md text-gray-500">결제를 진행해주세요.</p>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/app/(main)/payment/complete/page.tsx
+++ b/frontend/src/app/(main)/payment/complete/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+export default function PaymentCompletePage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-spacing-xl">
+      <div className="max-w-2xl text-center">
+        <h1 className="mb-spacing-lg text-4xl font-bold text-gray-900">결제 완료</h1>
+        <p className="text-gray-600">결제가 성공적으로 완료되었습니다.</p>
+        <p className="mt-spacing-md text-gray-500">
+          예매 내역은 마이페이지에서 확인하실 수 있습니다.
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/app/(main)/queue/[scheduleId]/page.tsx
+++ b/frontend/src/app/(main)/queue/[scheduleId]/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { use } from 'react'
+
+export default function QueuePage({ params }: { params: Promise<{ scheduleId: string }> }) {
+  const { scheduleId } = use(params)
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-spacing-xl">
+      <div className="max-w-2xl text-center">
+        <h1 className="mb-spacing-lg text-4xl font-bold text-gray-900">대기열</h1>
+        <p className="text-gray-600">
+          회차 ID: <span className="font-mono">{scheduleId}</span>
+        </p>
+        <p className="mt-spacing-md text-gray-500">대기열에서 순서를 기다리는 중입니다.</p>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/app/(main)/reservation/[scheduleId]/page.tsx
+++ b/frontend/src/app/(main)/reservation/[scheduleId]/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { use } from 'react'
+
+export default function ReservationPage({ params }: { params: Promise<{ scheduleId: string }> }) {
+  const { scheduleId } = use(params)
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-spacing-xl">
+      <div className="max-w-2xl text-center">
+        <h1 className="mb-spacing-lg text-4xl font-bold text-gray-900">좌석 선택</h1>
+        <p className="text-gray-600">
+          회차 ID: <span className="font-mono">{scheduleId}</span>
+        </p>
+        <p className="mt-spacing-md text-gray-500">원하는 좌석을 선택해주세요.</p>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,27 +1,23 @@
-"use client";
+'use client'
 
-import { useEffect } from "react";
+import { useEffect } from 'react'
 
 export default function Error({
   error,
   reset,
 }: {
-  error: Error & { digest?: string };
-  reset: () => void;
+  error: Error & { digest?: string }
+  reset: () => void
 }) {
   useEffect(() => {
-    console.error(error);
-  }, [error]);
+    console.error(error)
+  }, [error])
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50">
       <div className="text-center">
-        <h2 className="text-2xl font-bold text-gray-900 mb-4">
-          오류가 발생했습니다
-        </h2>
-        <p className="text-gray-600 mb-6">
-          {error.message || "알 수 없는 오류가 발생했습니다."}
-        </p>
+        <h2 className="text-2xl font-bold text-gray-900 mb-4">오류가 발생했습니다</h2>
+        <p className="text-gray-600 mb-6">{error.message || '알 수 없는 오류가 발생했습니다.'}</p>
         <button
           onClick={reset}
           className="px-6 py-2 bg-primary-500 text-white rounded-md hover:bg-primary-600 transition-colors"
@@ -30,5 +26,5 @@ export default function Error({
         </button>
       </div>
     </div>
-  );
+  )
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,6 +1,6 @@
-@import "tailwindcss";
-@import "tw-animate-css";
-@import "../styles/tokens.css";
+@import 'tailwindcss';
+@import 'tw-animate-css';
+@import '../styles/tokens.css';
 
 /* ============================================
    shadcn/ui Semantic Variables

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,16 +1,16 @@
-import type { Metadata } from "next";
-import "./globals.css";
-import { Toaster } from "@/components/ui/sonner";
+import type { Metadata } from 'next'
+import './globals.css'
+import { Providers } from '@/providers'
 
 export const metadata: Metadata = {
-  title: "Ticket Queue - 콘서트 티켓팅 시스템",
-  description: "대규모 트래픽을 처리하는 공정한 티켓팅 서비스",
-};
+  title: 'Ticket Queue - 콘서트 티켓팅 시스템',
+  description: '대규모 트래픽을 처리하는 공정한 티켓팅 서비스',
+}
 
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: React.ReactNode
 }>) {
   return (
     <html lang="ko">
@@ -23,9 +23,8 @@ export default function RootLayout({
         />
       </head>
       <body className="antialiased">
-        {children}
-        <Toaster />
+        <Providers>{children}</Providers>
       </body>
     </html>
-  );
+  )
 }

--- a/frontend/src/app/loading.tsx
+++ b/frontend/src/app/loading.tsx
@@ -6,5 +6,5 @@ export default function Loading() {
         <p className="mt-4 text-gray-600">로딩 중...</p>
       </div>
     </div>
-  );
+  )
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,14 +1,10 @@
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-gray-50">
+    <main className="flex min-h-screen flex-col items-center justify-center bg-background">
       <div className="text-center">
-        <h1 className="text-4xl font-bold text-gray-900 mb-4">
-          Ticket Queue
-        </h1>
-        <p className="text-lg text-gray-600">
-          콘서트 티켓팅 시스템 프론트엔드 초기화 완료
-        </p>
+        <h1 className="text-h1 text-foreground mb-md">Ticket Queue</h1>
+        <p className="text-body text-muted-foreground">콘서트 티켓팅 시스템 Frontend 초기화 완료</p>
       </div>
     </main>
-  );
+  )
 }

--- a/frontend/src/components/layout/footer.tsx
+++ b/frontend/src/components/layout/footer.tsx
@@ -1,0 +1,7 @@
+export function Footer() {
+  return (
+    <footer data-slot="footer" className="border-t border-border bg-background py-4 px-6">
+      <p className="text-sm text-muted-foreground">© 2026 Ticket Queue</p>
+    </footer>
+  )
+}

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+export function Header() {
+  return (
+    <header
+      data-slot="header"
+      className="h-16 border-b border-border bg-background flex items-center px-6"
+    >
+      <div className="text-lg font-semibold text-foreground">Ticket Queue</div>
+    </header>
+  )
+}

--- a/frontend/src/components/layout/index.ts
+++ b/frontend/src/components/layout/index.ts
@@ -1,0 +1,2 @@
+export { Header } from './header'
+export { Footer } from './footer'

--- a/frontend/src/components/ui/__tests__/badge.test.tsx
+++ b/frontend/src/components/ui/__tests__/badge.test.tsx
@@ -1,39 +1,29 @@
-import { render, screen } from "@testing-library/react";
-import { Badge } from "../badge";
+import { render, screen } from '@testing-library/react'
+import { Badge } from '../badge'
 
-describe("Badge", () => {
-  it("renders children", () => {
-    render(<Badge>New</Badge>);
-    expect(screen.getByText("New")).toBeInTheDocument();
-  });
+describe('Badge', () => {
+  it('renders children', () => {
+    render(<Badge>New</Badge>)
+    expect(screen.getByText('New')).toBeInTheDocument()
+  })
 
-  describe("variants", () => {
-    it.each([
-      "default",
-      "secondary",
-      "outline",
-      "success",
-      "warning",
-      "danger",
-    ] as const)("renders %s variant", (variant) => {
-      render(<Badge variant={variant}>Badge</Badge>);
-      expect(screen.getByText("Badge")).toHaveAttribute(
-        "data-variant",
-        variant,
-      );
-    });
+  describe('variants', () => {
+    it.each(['default', 'secondary', 'outline', 'success', 'warning', 'danger'] as const)(
+      'renders %s variant',
+      (variant) => {
+        render(<Badge variant={variant}>Badge</Badge>)
+        expect(screen.getByText('Badge')).toHaveAttribute('data-variant', variant)
+      },
+    )
 
-    it("defaults to default variant", () => {
-      render(<Badge>Badge</Badge>);
-      expect(screen.getByText("Badge")).toHaveAttribute(
-        "data-variant",
-        "default",
-      );
-    });
-  });
+    it('defaults to default variant', () => {
+      render(<Badge>Badge</Badge>)
+      expect(screen.getByText('Badge')).toHaveAttribute('data-variant', 'default')
+    })
+  })
 
-  it("applies custom className", () => {
-    render(<Badge className="custom">Badge</Badge>);
-    expect(screen.getByText("Badge")).toHaveClass("custom");
-  });
-});
+  it('applies custom className', () => {
+    render(<Badge className="custom">Badge</Badge>)
+    expect(screen.getByText('Badge')).toHaveClass('custom')
+  })
+})

--- a/frontend/src/components/ui/__tests__/button.test.tsx
+++ b/frontend/src/components/ui/__tests__/button.test.tsx
@@ -1,107 +1,102 @@
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { Button } from "../button";
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Button } from '../button'
 
-describe("Button", () => {
-  it("renders children", () => {
-    render(<Button>Click me</Button>);
-    expect(
-      screen.getByRole("button", { name: "Click me" }),
-    ).toBeInTheDocument();
-  });
+describe('Button', () => {
+  it('renders children', () => {
+    render(<Button>Click me</Button>)
+    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument()
+  })
 
-  describe("variants", () => {
-    it.each(["primary", "secondary", "outline", "ghost", "danger"] as const)(
-      "renders %s variant",
+  describe('variants', () => {
+    it.each(['primary', 'secondary', 'outline', 'ghost', 'danger'] as const)(
+      'renders %s variant',
       (variant) => {
-        render(<Button variant={variant}>Button</Button>);
-        const button = screen.getByRole("button");
-        expect(button).toHaveAttribute("data-variant", variant);
+        render(<Button variant={variant}>Button</Button>)
+        const button = screen.getByRole('button')
+        expect(button).toHaveAttribute('data-variant', variant)
       },
-    );
+    )
 
-    it("defaults to primary variant", () => {
-      render(<Button>Button</Button>);
-      expect(screen.getByRole("button")).toHaveAttribute(
-        "data-variant",
-        "primary",
-      );
-    });
-  });
+    it('defaults to primary variant', () => {
+      render(<Button>Button</Button>)
+      expect(screen.getByRole('button')).toHaveAttribute('data-variant', 'primary')
+    })
+  })
 
-  describe("sizes", () => {
-    it.each(["sm", "md", "lg"] as const)("renders %s size", (size) => {
-      render(<Button size={size}>Button</Button>);
-      const button = screen.getByRole("button");
-      expect(button).toHaveAttribute("data-size", size);
-    });
+  describe('sizes', () => {
+    it.each(['sm', 'md', 'lg'] as const)('renders %s size', (size) => {
+      render(<Button size={size}>Button</Button>)
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('data-size', size)
+    })
 
-    it("defaults to md size", () => {
-      render(<Button>Button</Button>);
-      expect(screen.getByRole("button")).toHaveAttribute("data-size", "md");
-    });
-  });
+    it('defaults to md size', () => {
+      render(<Button>Button</Button>)
+      expect(screen.getByRole('button')).toHaveAttribute('data-size', 'md')
+    })
+  })
 
-  describe("loading state", () => {
-    it("shows spinner when loading", () => {
-      render(<Button loading>Submit</Button>);
-      expect(screen.getByRole("status")).toBeInTheDocument();
-    });
+  describe('loading state', () => {
+    it('shows spinner when loading', () => {
+      render(<Button loading>Submit</Button>)
+      expect(screen.getByRole('status')).toBeInTheDocument()
+    })
 
-    it("disables button when loading", () => {
-      render(<Button loading>Submit</Button>);
-      expect(screen.getByRole("button")).toBeDisabled();
-    });
+    it('disables button when loading', () => {
+      render(<Button loading>Submit</Button>)
+      expect(screen.getByRole('button')).toBeDisabled()
+    })
 
-    it("still renders children when loading", () => {
-      render(<Button loading>Submit</Button>);
-      expect(screen.getByRole("button")).toHaveTextContent("Submit");
-    });
-  });
+    it('still renders children when loading', () => {
+      render(<Button loading>Submit</Button>)
+      expect(screen.getByRole('button')).toHaveTextContent('Submit')
+    })
+  })
 
-  describe("disabled state", () => {
-    it("disables button when disabled prop is true", () => {
-      render(<Button disabled>Button</Button>);
-      expect(screen.getByRole("button")).toBeDisabled();
-    });
-  });
+  describe('disabled state', () => {
+    it('disables button when disabled prop is true', () => {
+      render(<Button disabled>Button</Button>)
+      expect(screen.getByRole('button')).toBeDisabled()
+    })
+  })
 
-  describe("onClick", () => {
-    it("calls onClick when clicked", async () => {
-      const user = userEvent.setup();
-      const handleClick = jest.fn();
-      render(<Button onClick={handleClick}>Click</Button>);
-      await user.click(screen.getByRole("button"));
-      expect(handleClick).toHaveBeenCalledTimes(1);
-    });
+  describe('onClick', () => {
+    it('calls onClick when clicked', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<Button onClick={handleClick}>Click</Button>)
+      await user.click(screen.getByRole('button'))
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
 
-    it("does not call onClick when disabled", async () => {
-      const user = userEvent.setup();
-      const handleClick = jest.fn();
+    it('does not call onClick when disabled', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
       render(
         <Button disabled onClick={handleClick}>
           Click
         </Button>,
-      );
-      await user.click(screen.getByRole("button"));
-      expect(handleClick).not.toHaveBeenCalled();
-    });
+      )
+      await user.click(screen.getByRole('button'))
+      expect(handleClick).not.toHaveBeenCalled()
+    })
 
-    it("does not call onClick when loading", async () => {
-      const user = userEvent.setup();
-      const handleClick = jest.fn();
+    it('does not call onClick when loading', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
       render(
         <Button loading onClick={handleClick}>
           Click
         </Button>,
-      );
-      await user.click(screen.getByRole("button"));
-      expect(handleClick).not.toHaveBeenCalled();
-    });
-  });
+      )
+      await user.click(screen.getByRole('button'))
+      expect(handleClick).not.toHaveBeenCalled()
+    })
+  })
 
-  it("accepts custom className", () => {
-    render(<Button className="custom-class">Button</Button>);
-    expect(screen.getByRole("button")).toHaveClass("custom-class");
-  });
-});
+  it('accepts custom className', () => {
+    render(<Button className="custom-class">Button</Button>)
+    expect(screen.getByRole('button')).toHaveClass('custom-class')
+  })
+})

--- a/frontend/src/components/ui/__tests__/card.test.tsx
+++ b/frontend/src/components/ui/__tests__/card.test.tsx
@@ -1,34 +1,27 @@
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-  CardFooter,
-} from "../card";
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '../card'
 
-describe("Card", () => {
-  it("renders children", () => {
+describe('Card', () => {
+  it('renders children', () => {
     render(
       <Card>
         <CardContent>Card body</CardContent>
       </Card>,
-    );
-    expect(screen.getByText("Card body")).toBeInTheDocument();
-  });
+    )
+    expect(screen.getByText('Card body')).toBeInTheDocument()
+  })
 
-  it("applies custom className", () => {
+  it('applies custom className', () => {
     render(
       <Card className="test-class" data-testid="card">
         Content
       </Card>,
-    );
-    expect(screen.getByTestId("card")).toHaveClass("test-class");
-  });
+    )
+    expect(screen.getByTestId('card')).toHaveClass('test-class')
+  })
 
-  it("renders full card structure", () => {
+  it('renders full card structure', () => {
     render(
       <Card>
         <CardHeader>
@@ -38,48 +31,48 @@ describe("Card", () => {
         <CardContent>Body</CardContent>
         <CardFooter>Footer</CardFooter>
       </Card>,
-    );
-    expect(screen.getByText("Title")).toBeInTheDocument();
-    expect(screen.getByText("Description")).toBeInTheDocument();
-    expect(screen.getByText("Body")).toBeInTheDocument();
-    expect(screen.getByText("Footer")).toBeInTheDocument();
-  });
+    )
+    expect(screen.getByText('Title')).toBeInTheDocument()
+    expect(screen.getByText('Description')).toBeInTheDocument()
+    expect(screen.getByText('Body')).toBeInTheDocument()
+    expect(screen.getByText('Footer')).toBeInTheDocument()
+  })
 
-  describe("clickable card", () => {
-    it("calls onClick when clicked", async () => {
-      const user = userEvent.setup();
-      const handleClick = jest.fn();
-      render(<Card onClick={handleClick}>Clickable</Card>);
-      await user.click(screen.getByRole("button"));
-      expect(handleClick).toHaveBeenCalledTimes(1);
-    });
+  describe('clickable card', () => {
+    it('calls onClick when clicked', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<Card onClick={handleClick}>Clickable</Card>)
+      await user.click(screen.getByRole('button'))
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
 
-    it("has role=button when clickable", () => {
-      render(<Card onClick={jest.fn()}>Clickable</Card>);
-      expect(screen.getByRole("button")).toBeInTheDocument();
-    });
+    it('has role=button when clickable', () => {
+      render(<Card onClick={jest.fn()}>Clickable</Card>)
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
 
-    it("does not have role=button when not clickable", () => {
-      render(<Card>Static</Card>);
-      expect(screen.queryByRole("button")).not.toBeInTheDocument();
-    });
+    it('does not have role=button when not clickable', () => {
+      render(<Card>Static</Card>)
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
 
-    it("responds to Enter key", async () => {
-      const user = userEvent.setup();
-      const handleClick = jest.fn();
-      render(<Card onClick={handleClick}>Clickable</Card>);
-      screen.getByRole("button").focus();
-      await user.keyboard("{Enter}");
-      expect(handleClick).toHaveBeenCalledTimes(1);
-    });
+    it('responds to Enter key', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<Card onClick={handleClick}>Clickable</Card>)
+      screen.getByRole('button').focus()
+      await user.keyboard('{Enter}')
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
 
-    it("responds to Space key", async () => {
-      const user = userEvent.setup();
-      const handleClick = jest.fn();
-      render(<Card onClick={handleClick}>Clickable</Card>);
-      screen.getByRole("button").focus();
-      await user.keyboard(" ");
-      expect(handleClick).toHaveBeenCalledTimes(1);
-    });
-  });
-});
+    it('responds to Space key', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<Card onClick={handleClick}>Clickable</Card>)
+      screen.getByRole('button').focus()
+      await user.keyboard(' ')
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/frontend/src/components/ui/__tests__/checkbox.test.tsx
+++ b/frontend/src/components/ui/__tests__/checkbox.test.tsx
@@ -1,39 +1,36 @@
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { Checkbox } from "../checkbox";
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Checkbox } from '../checkbox'
 
-describe("Checkbox", () => {
-  it("renders as checkbox role", () => {
-    render(<Checkbox />);
-    expect(screen.getByRole("checkbox")).toBeInTheDocument();
-  });
+describe('Checkbox', () => {
+  it('renders as checkbox role', () => {
+    render(<Checkbox />)
+    expect(screen.getByRole('checkbox')).toBeInTheDocument()
+  })
 
-  it("toggles checked state on click", async () => {
-    const user = userEvent.setup();
-    const handleChange = jest.fn();
-    render(<Checkbox onCheckedChange={handleChange} />);
-    await user.click(screen.getByRole("checkbox"));
-    expect(handleChange).toHaveBeenCalledWith(true);
-  });
+  it('toggles checked state on click', async () => {
+    const user = userEvent.setup()
+    const handleChange = jest.fn()
+    render(<Checkbox onCheckedChange={handleChange} />)
+    await user.click(screen.getByRole('checkbox'))
+    expect(handleChange).toHaveBeenCalledWith(true)
+  })
 
-  it("can be unchecked", async () => {
-    const user = userEvent.setup();
-    const handleChange = jest.fn();
-    render(<Checkbox defaultChecked onCheckedChange={handleChange} />);
-    await user.click(screen.getByRole("checkbox"));
-    expect(handleChange).toHaveBeenCalledWith(false);
-  });
+  it('can be unchecked', async () => {
+    const user = userEvent.setup()
+    const handleChange = jest.fn()
+    render(<Checkbox defaultChecked onCheckedChange={handleChange} />)
+    await user.click(screen.getByRole('checkbox'))
+    expect(handleChange).toHaveBeenCalledWith(false)
+  })
 
-  it("supports disabled state", () => {
-    render(<Checkbox disabled />);
-    expect(screen.getByRole("checkbox")).toBeDisabled();
-  });
+  it('supports disabled state', () => {
+    render(<Checkbox disabled />)
+    expect(screen.getByRole('checkbox')).toBeDisabled()
+  })
 
-  it("has correct aria-checked state", () => {
-    render(<Checkbox checked={true} />);
-    expect(screen.getByRole("checkbox")).toHaveAttribute(
-      "aria-checked",
-      "true",
-    );
-  });
-});
+  it('has correct aria-checked state', () => {
+    render(<Checkbox checked={true} />)
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-checked', 'true')
+  })
+})

--- a/frontend/src/components/ui/__tests__/form-input.test.tsx
+++ b/frontend/src/components/ui/__tests__/form-input.test.tsx
@@ -1,68 +1,62 @@
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { FormInput } from "../form-input";
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FormInput } from '../form-input'
 
-describe("FormInput", () => {
-  it("renders with label", () => {
-    render(<FormInput label="Email" />);
-    expect(screen.getByLabelText("Email")).toBeInTheDocument();
-  });
+describe('FormInput', () => {
+  it('renders with label', () => {
+    render(<FormInput label="Email" />)
+    expect(screen.getByLabelText('Email')).toBeInTheDocument()
+  })
 
-  it("renders without label", () => {
-    render(<FormInput placeholder="Enter text" />);
-    expect(screen.getByPlaceholderText("Enter text")).toBeInTheDocument();
-  });
+  it('renders without label', () => {
+    render(<FormInput placeholder="Enter text" />)
+    expect(screen.getByPlaceholderText('Enter text')).toBeInTheDocument()
+  })
 
-  it("displays error message", () => {
-    render(<FormInput label="Email" error="Invalid email" />);
-    expect(screen.getByRole("alert")).toHaveTextContent("Invalid email");
-  });
+  it('displays error message', () => {
+    render(<FormInput label="Email" error="Invalid email" />)
+    expect(screen.getByRole('alert')).toHaveTextContent('Invalid email')
+  })
 
-  it("does not display error when not provided", () => {
-    render(<FormInput label="Email" />);
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-  });
+  it('does not display error when not provided', () => {
+    render(<FormInput label="Email" />)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
 
-  it("calls onChange with value string", async () => {
-    const user = userEvent.setup();
-    const handleChange = jest.fn();
-    render(<FormInput label="Name" onChange={handleChange} />);
-    await user.type(screen.getByLabelText("Name"), "hello");
-    expect(handleChange).toHaveBeenCalledTimes(5);
-    expect(handleChange).toHaveBeenNthCalledWith(1, "h");
-    expect(handleChange).toHaveBeenNthCalledWith(2, "he");
-    expect(handleChange).toHaveBeenNthCalledWith(3, "hel");
-    expect(handleChange).toHaveBeenNthCalledWith(4, "hell");
-    expect(handleChange).toHaveBeenNthCalledWith(5, "hello");
-  });
+  it('calls onChange with value string', async () => {
+    const user = userEvent.setup()
+    const handleChange = jest.fn()
+    render(<FormInput label="Name" onChange={handleChange} />)
+    await user.type(screen.getByLabelText('Name'), 'hello')
+    expect(handleChange).toHaveBeenCalledTimes(5)
+    expect(handleChange).toHaveBeenNthCalledWith(1, 'h')
+    expect(handleChange).toHaveBeenNthCalledWith(2, 'he')
+    expect(handleChange).toHaveBeenNthCalledWith(3, 'hel')
+    expect(handleChange).toHaveBeenNthCalledWith(4, 'hell')
+    expect(handleChange).toHaveBeenNthCalledWith(5, 'hello')
+  })
 
-  describe("accessibility", () => {
-    it("sets aria-invalid when error exists", () => {
-      render(<FormInput label="Email" error="Required" />);
-      expect(screen.getByLabelText("Email")).toHaveAttribute(
-        "aria-invalid",
-        "true",
-      );
-    });
+  describe('accessibility', () => {
+    it('sets aria-invalid when error exists', () => {
+      render(<FormInput label="Email" error="Required" />)
+      expect(screen.getByLabelText('Email')).toHaveAttribute('aria-invalid', 'true')
+    })
 
-    it("sets aria-describedby linking to error", () => {
-      render(<FormInput label="Email" error="Required" />);
-      const input = screen.getByLabelText("Email");
-      const errorEl = screen.getByRole("alert");
-      expect(input).toHaveAttribute("aria-describedby", errorEl.id);
-    });
+    it('sets aria-describedby linking to error', () => {
+      render(<FormInput label="Email" error="Required" />)
+      const input = screen.getByLabelText('Email')
+      const errorEl = screen.getByRole('alert')
+      expect(input).toHaveAttribute('aria-describedby', errorEl.id)
+    })
 
-    it("does not set aria-invalid when no error", () => {
-      render(<FormInput label="Email" />);
-      expect(screen.getByLabelText("Email")).not.toHaveAttribute(
-        "aria-invalid",
-        "true",
-      );
-    });
-  });
+    it('does not set aria-invalid when no error', () => {
+      render(<FormInput label="Email" />)
+      expect(screen.getByLabelText('Email')).not.toHaveAttribute('aria-invalid', 'true')
+    })
+  })
 
-  it("supports disabled state", () => {
-    render(<FormInput label="Email" disabled />);
-    expect(screen.getByLabelText("Email")).toBeDisabled();
-  });
-});
+  it('supports disabled state', () => {
+    render(<FormInput label="Email" disabled />)
+    expect(screen.getByLabelText('Email')).toBeDisabled()
+  })
+})

--- a/frontend/src/components/ui/__tests__/modal.test.tsx
+++ b/frontend/src/components/ui/__tests__/modal.test.tsx
@@ -1,74 +1,63 @@
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { Modal } from "../modal";
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Modal } from '../modal'
 
-describe("Modal", () => {
-  it("renders children when open", () => {
+describe('Modal', () => {
+  it('renders children when open', () => {
     render(
       <Modal isOpen={true} onClose={jest.fn()}>
         <p>Modal content</p>
       </Modal>,
-    );
-    expect(screen.getByText("Modal content")).toBeInTheDocument();
-  });
+    )
+    expect(screen.getByText('Modal content')).toBeInTheDocument()
+  })
 
-  it("does not render children when closed", () => {
+  it('does not render children when closed', () => {
     render(
       <Modal isOpen={false} onClose={jest.fn()}>
         <p>Modal content</p>
       </Modal>,
-    );
-    expect(screen.queryByText("Modal content")).not.toBeInTheDocument();
-  });
+    )
+    expect(screen.queryByText('Modal content')).not.toBeInTheDocument()
+  })
 
-  it("renders title", () => {
+  it('renders title', () => {
     render(
       <Modal isOpen={true} onClose={jest.fn()} title="Confirm">
         <p>Content</p>
       </Modal>,
-    );
-    expect(screen.getByText("Confirm")).toBeInTheDocument();
-  });
+    )
+    expect(screen.getByText('Confirm')).toBeInTheDocument()
+  })
 
-  it("renders description", () => {
+  it('renders description', () => {
     render(
-      <Modal
-        isOpen={true}
-        onClose={jest.fn()}
-        title="Title"
-        description="Some description"
-      >
+      <Modal isOpen={true} onClose={jest.fn()} title="Title" description="Some description">
         <p>Content</p>
       </Modal>,
-    );
-    expect(screen.getByText("Some description")).toBeInTheDocument();
-  });
+    )
+    expect(screen.getByText('Some description')).toBeInTheDocument()
+  })
 
-  it("renders footer", () => {
+  it('renders footer', () => {
     render(
-      <Modal
-        isOpen={true}
-        onClose={jest.fn()}
-        footer={<button>Confirm</button>}
-      >
+      <Modal isOpen={true} onClose={jest.fn()} footer={<button>Confirm</button>}>
         <p>Content</p>
       </Modal>,
-    );
-    expect(
-      screen.getByRole("button", { name: "Confirm" }),
-    ).toBeInTheDocument();
-  });
+    )
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument()
+  })
 
-  it("calls onClose when close button is clicked", async () => {
-    const user = userEvent.setup();
-    const handleClose = jest.fn();
+  it('calls onClose when close button is clicked', async () => {
+    const user = userEvent.setup()
+    const handleClose = jest.fn()
     render(
       <Modal isOpen={true} onClose={handleClose} title="Test">
         <p>Content</p>
       </Modal>,
-    );
-    const closeButton = screen.getByRole("button", { name: "Close" });
-    await user.click(closeButton);
-    expect(handleClose).toHaveBeenCalledTimes(1);
-  });
-});
+    )
+    const closeButton = screen.getByRole('button', { name: 'Close' })
+    await user.click(closeButton)
+    expect(handleClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/ui/__tests__/spinner.test.tsx
+++ b/frontend/src/components/ui/__tests__/spinner.test.tsx
@@ -1,42 +1,39 @@
-import { render, screen } from "@testing-library/react";
-import { Spinner } from "../spinner";
+import { render, screen } from '@testing-library/react'
+import { Spinner } from '../spinner'
 
-describe("Spinner", () => {
-  it("renders with status role", () => {
-    render(<Spinner />);
-    expect(screen.getByRole("status")).toBeInTheDocument();
-  });
+describe('Spinner', () => {
+  it('renders with status role', () => {
+    render(<Spinner />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
 
-  it("has accessible label", () => {
-    render(<Spinner />);
-    expect(screen.getByRole("status")).toHaveAttribute(
-      "aria-label",
-      "로딩 중",
-    );
-  });
+  it('has accessible label', () => {
+    render(<Spinner />)
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', '로딩 중')
+  })
 
-  describe("size variants", () => {
-    it("renders sm size", () => {
-      render(<Spinner size="sm" />);
-      const spinner = screen.getByRole("status");
-      expect(spinner).toHaveClass("size-4");
-    });
+  describe('size variants', () => {
+    it('renders sm size', () => {
+      render(<Spinner size="sm" />)
+      const spinner = screen.getByRole('status')
+      expect(spinner).toHaveClass('size-4')
+    })
 
-    it("renders md size (default)", () => {
-      render(<Spinner />);
-      const spinner = screen.getByRole("status");
-      expect(spinner).toHaveClass("size-6");
-    });
+    it('renders md size (default)', () => {
+      render(<Spinner />)
+      const spinner = screen.getByRole('status')
+      expect(spinner).toHaveClass('size-6')
+    })
 
-    it("renders lg size", () => {
-      render(<Spinner size="lg" />);
-      const spinner = screen.getByRole("status");
-      expect(spinner).toHaveClass("size-8");
-    });
-  });
+    it('renders lg size', () => {
+      render(<Spinner size="lg" />)
+      const spinner = screen.getByRole('status')
+      expect(spinner).toHaveClass('size-8')
+    })
+  })
 
-  it("applies custom className", () => {
-    render(<Spinner className="text-primary" />);
-    expect(screen.getByRole("status")).toHaveClass("text-primary");
-  });
-});
+  it('applies custom className', () => {
+    render(<Spinner className="text-primary" />)
+    expect(screen.getByRole('status')).toHaveClass('text-primary')
+  })
+})

--- a/frontend/src/components/ui/__tests__/toast.test.tsx
+++ b/frontend/src/components/ui/__tests__/toast.test.tsx
@@ -1,9 +1,9 @@
-import { render } from "@testing-library/react";
-import { Toaster } from "../sonner";
+import { render } from '@testing-library/react'
+import { Toaster } from '../sonner'
 
-describe("Toaster", () => {
-  it("renders without error", () => {
-    const { container } = render(<Toaster />);
-    expect(container).toBeInTheDocument();
-  });
-});
+describe('Toaster', () => {
+  it('renders without error', () => {
+    const { container } = render(<Toaster />)
+    expect(container).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,41 +1,36 @@
-import * as React from "react";
-import { cva, type VariantProps } from "class-variance-authority";
-import { Slot } from "radix-ui";
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { Slot } from 'radix-ui'
 
-import { cn } from "@/lib/utils";
+import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] transition-[color,box-shadow] overflow-hidden",
+  'inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] transition-[color,box-shadow] overflow-hidden',
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
-        secondary:
-          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        default: 'bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+        secondary: 'bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
         outline:
-          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
-        success:
-          "bg-success text-success-foreground [a&]:hover:bg-success/90",
-        warning:
-          "bg-warning text-warning-foreground [a&]:hover:bg-warning/90",
-        danger:
-          "bg-danger text-danger-foreground [a&]:hover:bg-danger/90",
+          'border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        success: 'bg-success text-success-foreground [a&]:hover:bg-success/90',
+        warning: 'bg-warning text-warning-foreground [a&]:hover:bg-warning/90',
+        danger: 'bg-danger text-danger-foreground [a&]:hover:bg-danger/90',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
   },
-);
+)
 
 function Badge({
   className,
-  variant = "default",
+  variant = 'default',
   asChild = false,
   ...props
-}: React.ComponentProps<"span"> &
-  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot.Root : "span";
+}: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : 'span'
 
   return (
     <Comp
@@ -44,7 +39,7 @@ function Badge({
       className={cn(badgeVariants({ variant }), className)}
       {...props}
     />
-  );
+  )
 }
 
-export { Badge, badgeVariants };
+export { Badge, badgeVariants }

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,55 +1,52 @@
-import * as React from "react";
-import { cva, type VariantProps } from "class-variance-authority";
-import { Slot } from "radix-ui";
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { Slot } from 'radix-ui'
 
-import { cn } from "@/lib/utils";
-import { Spinner } from "@/components/ui/spinner";
+import { cn } from '@/lib/utils'
+import { Spinner } from '@/components/ui/spinner'
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
-        primary: "bg-primary text-primary-foreground hover:bg-primary/90",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        danger:
-          "bg-danger text-danger-foreground hover:bg-danger/90 focus-visible:ring-danger/20",
+        primary: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        outline: 'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        danger: 'bg-danger text-danger-foreground hover:bg-danger/90 focus-visible:ring-danger/20',
       },
       size: {
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        md: "h-9 px-4 py-2 has-[>svg]:px-3",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+        md: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
       },
     },
     defaultVariants: {
-      variant: "primary",
-      size: "md",
+      variant: 'primary',
+      size: 'md',
     },
   },
-);
+)
 
-type ButtonProps = React.ComponentProps<"button"> &
+type ButtonProps = React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
-    loading?: boolean;
-  };
+    asChild?: boolean
+    loading?: boolean
+  }
 
 function Button({
   className,
-  variant = "primary",
-  size = "md",
+  variant = 'primary',
+  size = 'md',
   asChild = false,
   loading = false,
   disabled,
   children,
   ...props
 }: ButtonProps) {
-  const Comp = asChild ? Slot.Root : "button";
-  const isDisabled = disabled || loading;
+  const Comp = asChild ? Slot.Root : 'button'
+  const isDisabled = disabled || loading
 
   return (
     <Comp
@@ -69,8 +66,8 @@ function Button({
         children
       )}
     </Comp>
-  );
+  )
 }
 
-export { Button, buttonVariants };
-export type { ButtonProps };
+export { Button, buttonVariants }
+export type { ButtonProps }

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,113 +1,96 @@
-import * as React from "react";
+import * as React from 'react'
 
-import { cn } from "@/lib/utils";
+import { cn } from '@/lib/utils'
 
-type CardProps = React.ComponentProps<"div"> & {
-  onClick?: () => void;
-};
+type CardProps = React.ComponentProps<'div'> & {
+  onClick?: () => void
+}
 
 function Card({ className, onClick, ...props }: CardProps) {
-  const isClickable = !!onClick;
+  const isClickable = !!onClick
 
   return (
     <div
       data-slot="card"
-      role={isClickable ? "button" : undefined}
+      role={isClickable ? 'button' : undefined}
       tabIndex={isClickable ? 0 : undefined}
       onClick={onClick}
       onKeyDown={
         isClickable
           ? (e: React.KeyboardEvent) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onClick();
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                onClick()
               }
             }
           : undefined
       }
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
         isClickable &&
-          "cursor-pointer transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+          'cursor-pointer transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]',
         className,
       )}
       {...props}
     />
-  );
+  )
 }
 
-function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
         className,
       )}
       {...props}
     />
-  );
+  )
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn('leading-none font-semibold', className)}
       {...props}
     />
-  );
+  )
 }
 
-function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
-  );
+  )
 }
 
-function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-action"
-      className={cn(
-        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className,
-      )}
+      className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
       {...props}
     />
-  );
+  )
 }
 
-function CardContent({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-content"
-      className={cn("px-6", className)}
-      {...props}
-    />
-  );
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-content" className={cn('px-6', className)} {...props} />
 }
 
-function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      className={cn('flex items-center px-6 [.border-t]:pt-6', className)}
       {...props}
     />
-  );
+  )
 }
 
-export {
-  Card,
-  CardHeader,
-  CardFooter,
-  CardTitle,
-  CardAction,
-  CardDescription,
-  CardContent,
-};
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent }

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -1,21 +1,18 @@
-"use client"
+'use client'
 
-import * as React from "react"
-import { CheckIcon } from "lucide-react"
-import { Checkbox as CheckboxPrimitive } from "radix-ui"
+import * as React from 'react'
+import { CheckIcon } from 'lucide-react'
+import { Checkbox as CheckboxPrimitive } from 'radix-ui'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Checkbox({
-  className,
-  ...props
-}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
   return (
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
-        className
+        'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        className,
       )}
       {...props}
     >

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,33 +1,25 @@
-"use client"
+'use client'
 
-import * as React from "react"
-import { XIcon } from "lucide-react"
-import { Dialog as DialogPrimitive } from "radix-ui"
+import * as React from 'react'
+import { XIcon } from 'lucide-react'
+import { Dialog as DialogPrimitive } from 'radix-ui'
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
 
-function Dialog({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
 }
 
-function DialogTrigger({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
 }
 
-function DialogPortal({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
 }
 
-function DialogClose({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
 }
 
@@ -39,8 +31,8 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-        className
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
       )}
       {...props}
     />
@@ -61,8 +53,8 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
-          className
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg',
+          className,
         )}
         {...props}
       >
@@ -81,11 +73,11 @@ function DialogContent({
   )
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
       {...props}
     />
   )
@@ -96,16 +88,13 @@ function DialogFooter({
   showCloseButton = false,
   children,
   ...props
-}: React.ComponentProps<"div"> & {
+}: React.ComponentProps<'div'> & {
   showCloseButton?: boolean
 }) {
   return (
     <div
       data-slot="dialog-footer"
-      className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className
-      )}
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
       {...props}
     >
       {children}
@@ -118,14 +107,11 @@ function DialogFooter({
   )
 }
 
-function DialogTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn('text-lg leading-none font-semibold', className)}
       {...props}
     />
   )
@@ -138,7 +124,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
   )

--- a/frontend/src/components/ui/form-input.tsx
+++ b/frontend/src/components/ui/form-input.tsx
@@ -1,16 +1,15 @@
-"use client";
+'use client'
 
-import * as React from "react";
+import * as React from 'react'
 
-import { cn } from "@/lib/utils";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { cn } from '@/lib/utils'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 
-interface FormInputProps
-  extends Omit<React.ComponentProps<"input">, "onChange"> {
-  label?: string;
-  error?: string;
-  onChange?: (value: string) => void;
+interface FormInputProps extends Omit<React.ComponentProps<'input'>, 'onChange'> {
+  label?: string
+  error?: string
+  onChange?: (value: string) => void
 }
 
 function FormInput({
@@ -21,20 +20,20 @@ function FormInput({
   id: externalId,
   ...props
 }: FormInputProps) {
-  const generatedId = React.useId();
-  const id = externalId ?? generatedId;
-  const errorId = `${id}-error`;
-  const hasError = !!error;
+  const generatedId = React.useId()
+  const id = externalId ?? generatedId
+  const errorId = `${id}-error`
+  const hasError = !!error
 
   const handleChange = React.useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      onChange?.(e.target.value);
+      onChange?.(e.target.value)
     },
     [onChange],
-  );
+  )
 
   return (
-    <div className={cn("grid gap-2", className)}>
+    <div className={cn('grid gap-2', className)}>
       {label && <Label htmlFor={id}>{label}</Label>}
       <Input
         id={id}
@@ -49,8 +48,8 @@ function FormInput({
         </p>
       )}
     </div>
-  );
+  )
 }
 
-export { FormInput };
-export type { FormInputProps };
+export { FormInput }
+export type { FormInputProps }

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,12 +1,12 @@
-export { Button, buttonVariants } from "./button";
-export type { ButtonProps } from "./button";
+export { Button, buttonVariants } from './button'
+export type { ButtonProps } from './button'
 
-export { Input } from "./input";
+export { Input } from './input'
 
-export { FormInput } from "./form-input";
-export type { FormInputProps } from "./form-input";
+export { FormInput } from './form-input'
+export type { FormInputProps } from './form-input'
 
-export { Label } from "./label";
+export { Label } from './label'
 
 export {
   Dialog,
@@ -19,12 +19,12 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-} from "./dialog";
+} from './dialog'
 
-export { Modal } from "./modal";
-export type { ModalProps } from "./modal";
+export { Modal } from './modal'
+export type { ModalProps } from './modal'
 
-export { Toaster } from "./sonner";
+export { Toaster } from './sonner'
 
 export {
   Card,
@@ -34,11 +34,11 @@ export {
   CardAction,
   CardDescription,
   CardContent,
-} from "./card";
+} from './card'
 
-export { Badge, badgeVariants } from "./badge";
+export { Badge, badgeVariants } from './badge'
 
-export { Spinner, spinnerVariants } from "./spinner";
-export type { SpinnerProps } from "./spinner";
+export { Spinner, spinnerVariants } from './spinner'
+export type { SpinnerProps } from './spinner'
 
-export { Checkbox } from "./checkbox";
+export { Checkbox } from './checkbox'

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,17 +1,17 @@
-import * as React from "react"
+import * as React from 'react'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
   return (
     <input
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        className
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className,
       )}
       {...props}
     />

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,20 +1,17 @@
-"use client"
+'use client'
 
-import * as React from "react"
-import { Label as LabelPrimitive } from "radix-ui"
+import * as React from 'react'
+import { Label as LabelPrimitive } from 'radix-ui'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Label({
-  className,
-  ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
   return (
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-        className
+        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        className,
       )}
       {...props}
     />

--- a/frontend/src/components/ui/modal.tsx
+++ b/frontend/src/components/ui/modal.tsx
@@ -1,6 +1,6 @@
-"use client";
+'use client'
 
-import * as React from "react";
+import * as React from 'react'
 
 import {
   Dialog,
@@ -9,44 +9,34 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog";
+} from '@/components/ui/dialog'
 
 interface ModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  title?: string;
-  description?: string;
-  children: React.ReactNode;
-  footer?: React.ReactNode;
-  className?: string;
+  isOpen: boolean
+  onClose: () => void
+  title?: string
+  description?: string
+  children: React.ReactNode
+  footer?: React.ReactNode
+  className?: string
 }
 
-function Modal({
-  isOpen,
-  onClose,
-  title,
-  description,
-  children,
-  footer,
-  className,
-}: ModalProps) {
+function Modal({ isOpen, onClose, title, description, children, footer, className }: ModalProps) {
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <DialogContent className={className}>
         {(title || description) && (
           <DialogHeader>
             {title && <DialogTitle>{title}</DialogTitle>}
-            {description && (
-              <DialogDescription>{description}</DialogDescription>
-            )}
+            {description && <DialogDescription>{description}</DialogDescription>}
           </DialogHeader>
         )}
         {children}
         {footer && <DialogFooter>{footer}</DialogFooter>}
       </DialogContent>
     </Dialog>
-  );
+  )
 }
 
-export { Modal };
-export type { ModalProps };
+export { Modal }
+export type { ModalProps }

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client'
 
 import {
   CircleCheckIcon,
@@ -6,8 +6,8 @@ import {
   Loader2Icon,
   OctagonXIcon,
   TriangleAlertIcon,
-} from "lucide-react";
-import { Toaster as Sonner, type ToasterProps } from "sonner";
+} from 'lucide-react'
+import { Toaster as Sonner, type ToasterProps } from 'sonner'
 
 const Toaster = ({ ...props }: ToasterProps) => {
   return (
@@ -26,14 +26,14 @@ const Toaster = ({ ...props }: ToasterProps) => {
       }}
       style={
         {
-          "--normal-bg": "var(--color-popover)",
-          "--normal-text": "var(--color-popover-foreground)",
-          "--normal-border": "var(--color-border)",
+          '--normal-bg': 'var(--color-popover)',
+          '--normal-text': 'var(--color-popover-foreground)',
+          '--normal-border': 'var(--color-border)',
         } as React.CSSProperties
       }
       {...props}
     />
-  );
-};
+  )
+}
 
-export { Toaster };
+export { Toaster }

--- a/frontend/src/components/ui/spinner.tsx
+++ b/frontend/src/components/ui/spinner.tsx
@@ -1,28 +1,24 @@
-import * as React from "react";
-import { cva, type VariantProps } from "class-variance-authority";
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
 
-import { cn } from "@/lib/utils";
+import { cn } from '@/lib/utils'
 
-const spinnerVariants = cva(
-  "animate-spin text-muted-foreground",
-  {
-    variants: {
-      size: {
-        sm: "size-4",
-        md: "size-6",
-        lg: "size-8",
-      },
-    },
-    defaultVariants: {
-      size: "md",
+const spinnerVariants = cva('animate-spin text-muted-foreground', {
+  variants: {
+    size: {
+      sm: 'size-4',
+      md: 'size-6',
+      lg: 'size-8',
     },
   },
-);
+  defaultVariants: {
+    size: 'md',
+  },
+})
 
-type SpinnerProps = React.ComponentProps<"svg"> &
-  VariantProps<typeof spinnerVariants>;
+type SpinnerProps = React.ComponentProps<'svg'> & VariantProps<typeof spinnerVariants>
 
-function Spinner({ className, size = "md", ...props }: SpinnerProps) {
+function Spinner({ className, size = 'md', ...props }: SpinnerProps) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -40,8 +36,8 @@ function Spinner({ className, size = "md", ...props }: SpinnerProps) {
     >
       <path d="M21 12a9 9 0 1 1-6.219-8.56" />
     </svg>
-  );
+  )
 }
 
-export { Spinner, spinnerVariants };
-export type { SpinnerProps };
+export { Spinner, spinnerVariants }
+export type { SpinnerProps }

--- a/frontend/src/lib/react-query/query-client.ts
+++ b/frontend/src/lib/react-query/query-client.ts
@@ -1,0 +1,32 @@
+import { QueryClient, defaultShouldDehydrateQuery, isServer } from '@tanstack/react-query'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: 2,
+        staleTime: 1000 * 60 * 5, // 5분
+        gcTime: 1000 * 60 * 10, // 10분
+        refetchOnWindowFocus: false,
+      },
+      mutations: {
+        retry: 0,
+      },
+      dehydrate: {
+        shouldDehydrateQuery: (query) =>
+          defaultShouldDehydrateQuery(query) || query.state.status === 'pending',
+      },
+    },
+  })
+}
+
+let browserQueryClient: QueryClient | undefined = undefined
+
+export function getQueryClient() {
+  if (isServer) {
+    return makeQueryClient()
+  } else {
+    if (!browserQueryClient) browserQueryClient = makeQueryClient()
+    return browserQueryClient
+  }
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return twMerge(clsx(inputs))
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,10 +1,10 @@
-import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function middleware(_request: NextRequest) {
   // 향후 인증 미들웨어 로직 추가 예정
-  return NextResponse.next();
+  return NextResponse.next()
 }
 
 // 미들웨어가 실행될 경로 패턴 설정
@@ -17,6 +17,6 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      */
-    "/((?!api|_next/static|_next/image|favicon.ico).*)",
+    '/((?!api|_next/static|_next/image|favicon.ico).*)',
   ],
-};
+}

--- a/frontend/src/providers.tsx
+++ b/frontend/src/providers.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { QueryClientProvider } from '@tanstack/react-query'
+import { getQueryClient } from '@/lib/react-query/query-client'
+import { Toaster } from '@/components/ui/sonner'
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const queryClient = getQueryClient()
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <Toaster />
+    </QueryClientProvider>
+  )
+}

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -11,7 +11,7 @@
   --color-primary-400: oklch(0.63 0.13 250);
   --color-primary-500: oklch(0.55 0.15 250);
   --color-primary-600: oklch(0.48 0.15 250);
-  --color-primary-700: oklch(0.40 0.13 250);
+  --color-primary-700: oklch(0.4 0.13 250);
   --color-primary-800: oklch(0.33 0.11 250);
   --color-primary-900: oklch(0.27 0.09 250);
 
@@ -23,17 +23,17 @@
   --color-secondary-400: oklch(0.66 0.025 265);
   --color-secondary-500: oklch(0.56 0.03 265);
   --color-secondary-600: oklch(0.48 0.03 265);
-  --color-secondary-700: oklch(0.40 0.025 265);
+  --color-secondary-700: oklch(0.4 0.025 265);
   --color-secondary-800: oklch(0.32 0.02 265);
   --color-secondary-900: oklch(0.25 0.015 265);
 
   /* Semantic Colors - 의미론적 색상 */
-  --color-success: oklch(0.72 0.15 155);        /* 성공 메시지, 확인 (#10B981) */
-  --color-warning: oklch(0.80 0.15 85);         /* 경고 메시지 (#F59E0B) */
-  --color-error: oklch(0.63 0.20 25);           /* 에러, 삭제 액션 (#EF4444) */
-  --color-danger: oklch(0.63 0.20 25);          /* error 별칭 */
-  --color-background: oklch(0.99 0 0);          /* 배경색 (#F9FAFB) */
-  --color-text: oklch(0.20 0 0);                /* 기본 텍스트 (#111827) */
+  --color-success: oklch(0.72 0.15 155); /* 성공 메시지, 확인 (#10B981) */
+  --color-warning: oklch(0.8 0.15 85); /* 경고 메시지 (#F59E0B) */
+  --color-error: oklch(0.63 0.2 25); /* 에러, 삭제 액션 (#EF4444) */
+  --color-danger: oklch(0.63 0.2 25); /* error 별칭 */
+  --color-background: oklch(0.99 0 0); /* 배경색 (#F9FAFB) */
+  --color-text: oklch(0.2 0 0); /* 기본 텍스트 (#111827) */
 
   /* Gray Scale - 중성 회색 */
   --color-gray-50: oklch(0.98 0 0);
@@ -45,44 +45,44 @@
   --color-gray-600: oklch(0.45 0 0);
   --color-gray-700: oklch(0.37 0 0);
   --color-gray-800: oklch(0.27 0 0);
-  --color-gray-900: oklch(0.20 0 0);
+  --color-gray-900: oklch(0.2 0 0);
 
   /* ============================================
      타이포그래피 (Typography)
      ============================================ */
 
-  --text-h1: 2.5rem / 1.2 700;              /* 40px, Bold */
-  --text-h2: 2rem / 1.3 600;                /* 32px, SemiBold */
-  --text-h3: 1.5rem / 1.4 600;              /* 24px, SemiBold */
-  --text-body: 1rem / 1.5 400;              /* 16px, Regular */
-  --text-caption: 0.875rem / 1.4 400;       /* 14px, Regular */
+  --text-h1: 2.5rem / 1.2 700; /* 40px, Bold */
+  --text-h2: 2rem / 1.3 600; /* 32px, SemiBold */
+  --text-h3: 1.5rem / 1.4 600; /* 24px, SemiBold */
+  --text-body: 1rem / 1.5 400; /* 16px, Regular */
+  --text-caption: 0.875rem / 1.4 400; /* 14px, Regular */
 
   /* ============================================
      간격 (Spacing)
      ============================================ */
 
-  --spacing-xs: 0.25rem;                    /* 4px - 아이콘-텍스트 간격 */
-  --spacing-sm: 0.5rem;                     /* 8px - 컴포넌트 내부 간격 */
-  --spacing-md: 1rem;                       /* 16px - 컴포넌트 간 간격 */
-  --spacing-lg: 1.5rem;                     /* 24px - 섹션 간 간격 */
-  --spacing-xl: 2rem;                       /* 32px - 페이지 레벨 간격 */
-  --spacing-header: 64px;                   /* 헤더 높이 */
-  --spacing-sidebar: 280px;                 /* 사이드바 너비 */
+  --spacing-xs: 0.25rem; /* 4px - 아이콘-텍스트 간격 */
+  --spacing-sm: 0.5rem; /* 8px - 컴포넌트 내부 간격 */
+  --spacing-md: 1rem; /* 16px - 컴포넌트 간 간격 */
+  --spacing-lg: 1.5rem; /* 24px - 섹션 간 간격 */
+  --spacing-xl: 2rem; /* 32px - 페이지 레벨 간격 */
+  --spacing-header: 64px; /* 헤더 높이 */
+  --spacing-sidebar: 280px; /* 사이드바 너비 */
 
   /* ============================================
      Border Radius
      ============================================ */
 
-  --radius-sm: 0.25rem;                     /* 4px - Badge, Tag */
-  --radius-md: 0.5rem;                      /* 8px - Button, Input, Card */
-  --radius-lg: 1rem;                        /* 16px - Modal, Dialog */
-  --radius-full: 9999px;                    /* Avatar, Pill Button */
+  --radius-sm: 0.25rem; /* 4px - Badge, Tag */
+  --radius-md: 0.5rem; /* 8px - Button, Input, Card */
+  --radius-lg: 1rem; /* 16px - Modal, Dialog */
+  --radius-full: 9999px; /* Avatar, Pill Button */
 
   /* ============================================
      폰트 (Fonts)
      ============================================ */
 
-  --font-sans: "Pretendard", "Apple SD Gothic Neo", sans-serif;
+  --font-sans: 'Pretendard', 'Apple SD Gothic Neo', sans-serif;
 
   /* ============================================
      브레이크포인트 (Breakpoints)


### PR DESCRIPTION
## Summary
- React Query Provider 설정 및 브라우저 싱글턴 패턴 구현
- 라우트 그룹별 레이아웃 구성 ((auth), (main))
- 11개 라우트 페이지 플레이스홀더 생성
- Next.js 16 Async Params 패턴 적용

Closes #108

## Changes
- **React Query 설정**
  - `src/lib/react-query/query-client.ts`: QueryClient 팩토리 + 브라우저 싱글턴
  - `src/providers.tsx`: QueryClientProvider + Toaster 래핑
  - `src/app/layout.tsx`: Providers 적용

- **레이아웃 컴포넌트**
  - `src/components/layout/header.tsx`: Header 스텁 (64px, data-slot 패턴)
  - `src/components/layout/footer.tsx`: Footer 스텁
  - `src/components/layout/index.ts`: Barrel exports

- **라우트 그룹 레이아웃**
  - `src/app/(auth)/layout.tsx`: 인증 레이아웃 (로고 중앙)
  - `src/app/(main)/layout.tsx`: 메인 레이아웃 (Header + Footer)

- **페이지 플레이스홀더** (11개)
  - Auth: login, signup
  - Main: events, events/[id], queue/[scheduleId], reservation/[scheduleId], payment/[reservationId], payment/complete, mypage, mypage/reservations, mypage/profile
  - Next.js 16 패턴: Server Component는 `await params`, Client Component는 `use(params)`

- **의존성 추가**
  - @tanstack/react-query v5.90.20
  - zustand v5.0.11
  - prettier v3.8.1

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] ESLint 린트 통과
- [x] Prettier 포맷 체크 통과
- [x] 프로덕션 빌드 성공 (11개 라우트 생성)
- [x] Jest 테스트 통과 (9 suites, 64 tests)
- [x] 수동 확인: 주요 라우트 접근 확인
  - `/` → 홈 페이지 (Providers 래핑)
  - `/login` → Auth 레이아웃
  - `/events` → Main 레이아웃
  - `/events/123` → 공연 상세, ID 표시