### PR TITLE
feat: 레이아웃 컴포넌트 구현 (Header, Footer, Navigation) #107

### DIFF
--- a/frontend/src/components/layout/__tests__/footer.test.tsx
+++ b/frontend/src/components/layout/__tests__/footer.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { Footer } from '../footer'
+
+describe('Footer', () => {
+  it('renders brand section with logo and tagline', () => {
+    render(<Footer />)
+
+    expect(screen.getByRole('heading', { name: '티켓큐', level: 2 })).toBeInTheDocument()
+    expect(screen.getByText('공정한 티켓팅의 시작')).toBeInTheDocument()
+  })
+
+  it('renders quick links section', () => {
+    render(<Footer />)
+
+    expect(screen.getByRole('heading', { name: '바로가기', level: 3 })).toBeInTheDocument()
+
+    const homeLink = screen.getByRole('link', { name: '홈' })
+    expect(homeLink).toBeInTheDocument()
+    expect(homeLink).toHaveAttribute('href', '/')
+
+    const eventsLink = screen.getByRole('link', { name: '공연 목록' })
+    expect(eventsLink).toBeInTheDocument()
+    expect(eventsLink).toHaveAttribute('href', '/events')
+
+    const mypageLink = screen.getByRole('link', { name: '마이페이지' })
+    expect(mypageLink).toBeInTheDocument()
+    expect(mypageLink).toHaveAttribute('href', '/mypage')
+  })
+
+  it('renders support links section', () => {
+    render(<Footer />)
+
+    expect(screen.getByRole('heading', { name: '고객지원', level: 3 })).toBeInTheDocument()
+
+    expect(screen.getByRole('link', { name: '공지사항' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'FAQ' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '문의하기' })).toBeInTheDocument()
+  })
+
+  it('renders copyright text', () => {
+    render(<Footer />)
+
+    expect(screen.getByText('© 2026 Ticket Queue. All rights reserved.')).toBeInTheDocument()
+  })
+
+  it('renders social icons with aria-labels', () => {
+    render(<Footer />)
+
+    const githubLink = screen.getByRole('link', { name: 'GitHub' })
+    expect(githubLink).toBeInTheDocument()
+    expect(githubLink).toHaveAttribute('aria-label', 'GitHub')
+  })
+})

--- a/frontend/src/components/layout/__tests__/header.test.tsx
+++ b/frontend/src/components/layout/__tests__/header.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Header } from '../header'
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(() => '/'),
+}))
+
+jest.mock('@/hooks/use-auth', () => ({
+  useAuth: jest.fn(() => ({
+    user: null,
+    isAuthenticated: false,
+  })),
+}))
+
+jest.mock('../navigation', () => ({
+  Navigation: ({ orientation }: { orientation: string }) => (
+    <nav data-testid="navigation" data-orientation={orientation} />
+  ),
+}))
+
+jest.mock('../mobile-nav', () => ({
+  MobileNav: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => (
+    <div data-testid="mobile-nav" data-open={isOpen} onClick={onClose} />
+  ),
+}))
+
+describe('Header', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders logo with link to home', () => {
+    render(<Header />)
+    const logo = screen.getByText('티켓큐')
+    expect(logo).toBeInTheDocument()
+    expect(logo.closest('a')).toHaveAttribute('href', '/')
+  })
+
+  it('shows desktop navigation on large screens', () => {
+    render(<Header />)
+    const nav = screen.getByTestId('navigation')
+    expect(nav).toBeInTheDocument()
+    expect(nav).toHaveAttribute('data-orientation', 'horizontal')
+    expect(nav.parentElement).toHaveClass('hidden', 'md:flex')
+  })
+
+  it('shows hamburger menu button on mobile', () => {
+    render(<Header />)
+    const hamburger = screen.getByRole('button', { name: '메뉴 열기' })
+    expect(hamburger).toBeInTheDocument()
+    expect(hamburger).toHaveAttribute('aria-label', '메뉴 열기')
+  })
+
+  it('toggles mobile navigation on hamburger click', async () => {
+    const user = userEvent.setup()
+    render(<Header />)
+
+    const hamburger = screen.getByRole('button', { name: '메뉴 열기' })
+    expect(hamburger).toHaveAttribute('aria-expanded', 'false')
+
+    await user.click(hamburger)
+
+    expect(hamburger).toHaveAttribute('aria-expanded', 'true')
+    const mobileNav = screen.getByTestId('mobile-nav')
+    expect(mobileNav).toHaveAttribute('data-open', 'true')
+  })
+
+  it('shows login/signup buttons when not authenticated', () => {
+    const { useAuth } = require('@/hooks/use-auth')
+    useAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+    })
+
+    render(<Header />)
+
+    expect(screen.getByRole('link', { name: '로그인' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '회원가입' })).toBeInTheDocument()
+  })
+
+  it('shows user greeting when authenticated', () => {
+    const { useAuth } = require('@/hooks/use-auth')
+    useAuth.mockReturnValue({
+      user: { name: '테스트' },
+      isAuthenticated: true,
+    })
+
+    render(<Header />)
+
+    expect(screen.getByText('안녕하세요, 테스트님')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: '로그인' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: '회원가입' })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/layout/__tests__/mobile-nav.test.tsx
+++ b/frontend/src/components/layout/__tests__/mobile-nav.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MobileNav } from '../mobile-nav'
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(() => '/'),
+}))
+
+jest.mock('@/hooks/use-auth', () => ({
+  useAuth: jest.fn(() => ({
+    user: null,
+    isAuthenticated: false,
+  })),
+}))
+
+jest.mock('../navigation', () => ({
+  Navigation: ({ orientation, onLinkClick }: { orientation: string; onLinkClick: () => void }) => (
+    <nav data-testid="navigation" data-orientation={orientation} onClick={onLinkClick}>
+      Navigation
+    </nav>
+  ),
+}))
+
+describe('MobileNav', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders when isOpen is true', () => {
+    render(<MobileNav isOpen={true} onClose={jest.fn()} />)
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('티켓큐')).toBeInTheDocument()
+  })
+
+  it('does not render when isOpen is false', () => {
+    render(<MobileNav isOpen={false} onClose={jest.fn()} />)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('calls onClose when close button is clicked', async () => {
+    const user = userEvent.setup()
+    const onClose = jest.fn()
+
+    render(<MobileNav isOpen={true} onClose={onClose} />)
+
+    const closeButton = screen.getByRole('button', { name: '닫기' })
+    await user.click(closeButton)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders Navigation component in vertical mode', () => {
+    render(<MobileNav isOpen={true} onClose={jest.fn()} />)
+
+    const navigation = screen.getByTestId('navigation')
+    expect(navigation).toBeInTheDocument()
+    expect(navigation).toHaveAttribute('data-orientation', 'vertical')
+  })
+
+  it('shows login/signup buttons when not authenticated', () => {
+    const { useAuth } = require('@/hooks/use-auth')
+    useAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+    })
+
+    render(<MobileNav isOpen={true} onClose={jest.fn()} />)
+
+    expect(screen.getByRole('button', { name: '로그인' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '회원가입' })).toBeInTheDocument()
+  })
+
+  it('shows user info and logout when authenticated', () => {
+    const { useAuth } = require('@/hooks/use-auth')
+    useAuth.mockReturnValue({
+      user: {
+        name: '테스트',
+        email: 'test@test.com'
+      },
+      isAuthenticated: true,
+    })
+
+    render(<MobileNav isOpen={true} onClose={jest.fn()} />)
+
+    expect(screen.getByText('테스트')).toBeInTheDocument()
+    expect(screen.getByText('test@test.com')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '로그아웃' })).toBeInTheDocument()
+
+    expect(screen.queryByRole('button', { name: '로그인' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '회원가입' })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/layout/__tests__/navigation.test.tsx
+++ b/frontend/src/components/layout/__tests__/navigation.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Navigation } from '../navigation'
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(() => '/'),
+}))
+
+jest.mock('@/hooks/use-auth', () => ({
+  useAuth: jest.fn(() => ({
+    user: null,
+    isAuthenticated: false,
+  })),
+}))
+
+describe('Navigation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders all navigation items', () => {
+    const { useAuth } = require('@/hooks/use-auth')
+    useAuth.mockReturnValue({
+      user: { name: '테스트' },
+      isAuthenticated: true,
+    })
+
+    render(<Navigation />)
+
+    expect(screen.getByRole('link', { name: /홈/ })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /공연 목록/ })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /마이페이지/ })).toBeInTheDocument()
+  })
+
+  it('highlights active page with aria-current', () => {
+    const { usePathname } = require('next/navigation')
+    const { useAuth } = require('@/hooks/use-auth')
+
+    usePathname.mockReturnValue('/events')
+    useAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+    })
+
+    render(<Navigation />)
+
+    const eventsLink = screen.getByRole('link', { name: /공연 목록/ })
+    expect(eventsLink).toHaveAttribute('aria-current', 'page')
+
+    const homeLink = screen.getByRole('link', { name: /홈/ })
+    expect(homeLink).not.toHaveAttribute('aria-current')
+  })
+
+  it('calls onLinkClick when link is clicked', async () => {
+    const user = userEvent.setup()
+    const onLinkClick = jest.fn()
+
+    const { useAuth } = require('@/hooks/use-auth')
+    useAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+    })
+
+    render(<Navigation onLinkClick={onLinkClick} />)
+
+    const homeLink = screen.getByRole('link', { name: /홈/ })
+    await user.click(homeLink)
+
+    expect(onLinkClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('filters out items requiring auth when not authenticated', () => {
+    const { useAuth } = require('@/hooks/use-auth')
+    useAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+    })
+
+    render(<Navigation />)
+
+    expect(screen.getByRole('link', { name: /홈/ })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /공연 목록/ })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /마이페이지/ })).not.toBeInTheDocument()
+  })
+
+  it('applies correct orientation classes', () => {
+    const { useAuth } = require('@/hooks/use-auth')
+    useAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+    })
+
+    const { rerender } = render(<Navigation orientation="horizontal" />)
+    let nav = screen.getByRole('navigation')
+    expect(nav).toHaveClass('flex-row')
+    expect(nav).not.toHaveClass('flex-col')
+
+    rerender(<Navigation orientation="vertical" />)
+    nav = screen.getByRole('navigation')
+    expect(nav).toHaveClass('flex-col')
+    expect(nav).not.toHaveClass('flex-row')
+  })
+})

--- a/frontend/src/components/layout/footer.tsx
+++ b/frontend/src/components/layout/footer.tsx
@@ -1,7 +1,105 @@
+import Link from 'next/link'
+import { Github } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
 export function Footer() {
   return (
-    <footer data-slot="footer" className="border-t border-border bg-background py-4 px-6">
-      <p className="text-sm text-muted-foreground">© 2026 Ticket Queue</p>
+    <footer data-slot="footer" className="border-t border-border bg-background">
+      <div className="max-w-7xl mx-auto px-6 py-12">
+        {/* 3-Column Grid Layout */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 md:gap-12">
+          {/* Column 1 - Brand Section */}
+          <div>
+            <h2 className="text-xl font-bold mb-2">티켓큐</h2>
+            <p className="text-sm text-muted-foreground">
+              공정한 티켓팅의 시작
+            </p>
+          </div>
+
+          {/* Column 2 - Quick Links */}
+          <div>
+            <h3 className="font-semibold mb-4">바로가기</h3>
+            <ul className="space-y-3">
+              <li>
+                <Link
+                  href="/"
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  홈
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/events"
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  공연 목록
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/mypage"
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  마이페이지
+                </Link>
+              </li>
+            </ul>
+          </div>
+
+          {/* Column 3 - Support Links */}
+          <div>
+            <h3 className="font-semibold mb-4">고객지원</h3>
+            <ul className="space-y-3">
+              <li>
+                <Link
+                  href="#"
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  공지사항
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="#"
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  FAQ
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="#"
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  문의하기
+                </Link>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        {/* Bottom Section */}
+        <div className="border-t border-border mt-8 pt-8">
+          <div className="flex flex-col md:flex-row justify-between items-center gap-4">
+            {/* Copyright */}
+            <p className="text-sm text-muted-foreground">
+              © 2026 Ticket Queue. All rights reserved.
+            </p>
+
+            {/* Social Icons */}
+            <div className="flex items-center gap-4">
+              <Link
+                href="#"
+                aria-label="GitHub"
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <Github className="w-5 h-5" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
     </footer>
   )
 }

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -1,12 +1,62 @@
 'use client'
 
+import { useState } from 'react'
+import Link from 'next/link'
+import { Menu } from 'lucide-react'
+import { Navigation } from './navigation'
+import { MobileNav } from './mobile-nav'
+import { Button } from '@/components/ui/button'
+import { useAuth } from '@/hooks/use-auth'
+
 export function Header() {
+  const [isMobileNavOpen, setIsMobileNavOpen] = useState(false)
+  const { isAuthenticated, user } = useAuth()
+
   return (
-    <header
-      data-slot="header"
-      className="h-16 border-b border-border bg-background flex items-center px-6"
-    >
-      <div className="text-lg font-semibold text-foreground">Ticket Queue</div>
+    <header className="sticky top-0 z-40 h-16 border-b border-border bg-background">
+      <div className="max-w-7xl mx-auto px-6 h-full flex items-center justify-between">
+        {/* Logo */}
+        <Link href="/" className="text-lg font-semibold text-foreground hover:text-foreground/80 transition-colors">
+          티켓큐
+        </Link>
+
+        {/* Desktop Navigation */}
+        <div className="hidden md:flex">
+          <Navigation orientation="horizontal" />
+        </div>
+
+        {/* Desktop Auth Section */}
+        <div className="hidden md:flex items-center gap-4">
+          {isAuthenticated ? (
+            <span className="text-sm text-foreground">
+              안녕하세요, {user?.name || '사용자'}님
+            </span>
+          ) : (
+            <>
+              <Button variant="ghost" asChild>
+                <Link href="/login">로그인</Link>
+              </Button>
+              <Button asChild>
+                <Link href="/signup">회원가입</Link>
+              </Button>
+            </>
+          )}
+        </div>
+
+        {/* Mobile Hamburger */}
+        <Button
+          variant="ghost"
+          size="sm"
+          className="md:hidden"
+          onClick={() => setIsMobileNavOpen(true)}
+          aria-label="메뉴 열기"
+          aria-expanded={isMobileNavOpen}
+        >
+          <Menu className="h-6 w-6" />
+        </Button>
+      </div>
+
+      <MobileNav isOpen={isMobileNavOpen} onClose={() => setIsMobileNavOpen(false)} />
     </header>
   )
 }

--- a/frontend/src/components/layout/index.ts
+++ b/frontend/src/components/layout/index.ts
@@ -1,2 +1,4 @@
 export { Header } from './header'
 export { Footer } from './footer'
+export { Navigation } from './navigation'
+export { MobileNav } from './mobile-nav'

--- a/frontend/src/components/layout/mobile-nav.tsx
+++ b/frontend/src/components/layout/mobile-nav.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { X } from 'lucide-react'
+import * as Dialog from '@radix-ui/react-dialog'
+import { Button } from '@/components/ui/button'
+import { Navigation } from './navigation'
+import { useAuth } from '@/hooks/use-auth'
+
+interface MobileNavProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function MobileNav({ isOpen, onClose }: MobileNavProps) {
+  const { isAuthenticated, user } = useAuth()
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={onClose}>
+      <Dialog.Portal>
+        {/* Overlay */}
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+
+        {/* Sidebar Content */}
+        <Dialog.Content
+          className="fixed inset-y-0 left-0 z-50 w-[280px] bg-sidebar shadow-2xl focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left data-[state=closed]:duration-300 data-[state=open]:duration-300"
+          aria-describedby={undefined}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-border/40 px-6 py-4">
+            <Dialog.Title className="text-lg font-bold tracking-tight text-foreground">
+              티켓큐
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                aria-label="닫기"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          {/* Navigation */}
+          <div className="flex-1 overflow-y-auto px-4 py-6">
+            <Navigation orientation="vertical" onLinkClick={onClose} />
+          </div>
+
+          {/* Auth Section */}
+          <div className="border-t border-border/40 p-4">
+            {isAuthenticated && user ? (
+              <div className="space-y-3">
+                <div className="rounded-lg bg-accent/50 px-4 py-3">
+                  <p className="text-sm font-medium text-foreground">
+                    {user.name}
+                  </p>
+                  <p className="text-xs text-muted-foreground">{user.email}</p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  onClick={onClose}
+                >
+                  로그아웃
+                </Button>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  className="w-full"
+                  onClick={onClose}
+                >
+                  로그인
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  onClick={onClose}
+                >
+                  회원가입
+                </Button>
+              </div>
+            )}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/frontend/src/components/layout/navigation.tsx
+++ b/frontend/src/components/layout/navigation.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { cn } from '@/lib/utils'
+import { NAV_ITEMS } from '@/lib/constants/navigation'
+import { useAuth } from '@/hooks/use-auth'
+
+interface NavigationProps {
+  orientation?: 'horizontal' | 'vertical'
+  onLinkClick?: () => void
+  className?: string
+}
+
+export function Navigation({
+  orientation = 'horizontal',
+  onLinkClick,
+  className,
+}: NavigationProps) {
+  const pathname = usePathname()
+  const { isAuthenticated } = useAuth()
+
+  const visibleItems = NAV_ITEMS.filter(
+    (item) => !item.requiresAuth || isAuthenticated
+  )
+
+  return (
+    <nav
+      role="navigation"
+      aria-label="메인 네비게이션"
+      className={cn(
+        'flex',
+        orientation === 'horizontal' ? 'flex-row gap-6' : 'flex-col gap-2',
+        className
+      )}
+    >
+      {visibleItems.map((item) => {
+        const isActive = pathname === item.href
+        const Icon = item.icon
+
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            onClick={onLinkClick}
+            aria-current={isActive ? 'page' : undefined}
+            className={cn(
+              'flex items-center gap-2 transition-colors',
+              isActive
+                ? 'text-primary font-medium'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <Icon className="w-5 h-5" />
+            <span>{item.label}</span>
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -1,0 +1,33 @@
+'use client'
+
+// Toggle this to test authenticated/unauthenticated UI states
+const MOCK_AUTHENTICATED = false
+
+interface User {
+  id: string
+  email: string
+  name: string
+}
+
+interface UseAuthReturn {
+  user: User | null
+  isAuthenticated: boolean
+}
+
+export function useAuth(): UseAuthReturn {
+  if (MOCK_AUTHENTICATED) {
+    return {
+      user: {
+        id: '1',
+        email: 'user@example.com',
+        name: '테스트 사용자',
+      },
+      isAuthenticated: true,
+    }
+  }
+
+  return {
+    user: null,
+    isAuthenticated: false,
+  }
+}

--- a/frontend/src/lib/constants/navigation.ts
+++ b/frontend/src/lib/constants/navigation.ts
@@ -1,0 +1,27 @@
+import { Home, Ticket, User } from 'lucide-react'
+
+export interface NavItem {
+  label: string
+  href: string
+  icon: React.ComponentType<{ className?: string }>
+  requiresAuth?: boolean
+}
+
+export const NAV_ITEMS: NavItem[] = [
+  {
+    label: '홈',
+    href: '/',
+    icon: Home,
+  },
+  {
+    label: '공연 목록',
+    href: '/events',
+    icon: Ticket,
+  },
+  {
+    label: '마이페이지',
+    href: '/mypage',
+    icon: User,
+    requiresAuth: true,
+  },
+]


### PR DESCRIPTION
## Summary
- Header, Footer, Navigation, MobileNav 컴포넌트 구현
- 반응형 레이아웃 시스템 완성 (Desktop/Mobile 대응)
- Radix Dialog 기반 접근성 준수

## Changes
- **Constants & Hooks** (2개)
  - `lib/constants/navigation.ts`: 네비게이션 아이템 정의 (홈, 공연 목록, 마이페이지)
  - `hooks/use-auth.ts`: Mock 인증 훅 (실제 auth store 연동 준비)

- **Components** (5개)
  - `navigation.tsx`: 수평/수직 모드 지원, 활성 페이지 하이라이트, 인증 기반 필터링
  - `mobile-nav.tsx`: Radix Dialog 기반 280px 사이드바, slide-in 애니메이션
  - `header.tsx`: Sticky 반응형 헤더 (Desktop: 네비+인증, Mobile: 햄버거 메뉴)
  - `footer.tsx`: 3-column 반응형 그리드 (브랜드, 바로가기, 고객지원)
  - `index.ts`: Barrel export 업데이트

- **Tests** (4개)
  - `header.test.tsx`: 6개 테스트 (로고, 네비, 햄버거, 인증 상태)
  - `footer.test.tsx`: 5개 테스트 (브랜드, 링크, 저작권, 소셜)
  - `navigation.test.tsx`: 5개 테스트 (아이템, aria-current, 클릭, 인증 필터)
  - `mobile-nav.test.tsx`: 6개 테스트 (열기/닫기, 네비, 인증 섹션)

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] 전체 테스트 통과 (13 suites, 86 tests)
- [x] Next.js 프로덕션 빌드 성공 (3.2초)
- [x] 반응형 디자인 확인 (Desktop/Mobile 뷰포트)
- [x] 접근성 검증 (aria-label, aria-current, role 속성)

Closes #107