### PR TITLE
feat: 회원가입 4단계 위저드 UI 구현 #113 (Draft – blocked by backend)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "prepare": "cd .. && husky frontend/.husky"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.90.20",
     "axios": "^1.7.9",
     "class-variance-authority": "^0.7.1",
@@ -31,9 +32,12 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-error-boundary": "^6.1.0",
+    "react-google-recaptcha": "^3.1.0",
+    "react-hook-form": "^7.71.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "tw-animate-css": "^1.4.0",
+    "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },
   "devDependencies": {
@@ -45,6 +49,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/react-google-recaptcha": "^2.1.9",
     "axios-mock-adapter": "^2.1.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.71.1(react@19.2.3))
       '@tanstack/react-query':
         specifier: ^5.90.20
         version: 5.90.20(react@19.2.3)
@@ -41,6 +44,12 @@ importers:
       react-error-boundary:
         specifier: ^6.1.0
         version: 6.1.0(react@19.2.3)
+      react-google-recaptcha:
+        specifier: ^3.1.0
+        version: 3.1.0(react@19.2.3)
+      react-hook-form:
+        specifier: ^7.71.1
+        version: 7.71.1(react@19.2.3)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -50,6 +59,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.13)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
@@ -78,6 +90,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.13)
+      '@types/react-google-recaptcha':
+        specifier: ^2.1.9
+        version: 2.1.9
       axios-mock-adapter:
         specifier: ^2.1.0
         version: 2.1.0(axios@1.13.5)
@@ -383,6 +398,11 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1478,6 +1498,9 @@ packages:
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
 
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1671,6 +1694,9 @@ packages:
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
+
+  '@types/react-google-recaptcha@2.1.9':
+    resolution: {integrity: sha512-nT31LrBDuoSZJN4QuwtQSF3O89FVHC4jLhM+NtKEmVF5R1e8OY0Jo4//x2Yapn2aNHguwgX5doAq8Zo+Ehd0ug==}
 
   '@types/react@19.2.13':
     resolution: {integrity: sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==}
@@ -2652,6 +2678,9 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
@@ -3504,6 +3533,11 @@ packages:
       '@types/react-dom':
         optional: true
 
+  react-async-script@1.2.0:
+    resolution: {integrity: sha512-bCpkbm9JiAuMGhkqoAiC0lLkb40DJ0HOEJIku+9JDjxX3Rcs+ztEOG13wbrOskt3n2DTrjshhaQ/iay+SnGg5Q==}
+    peerDependencies:
+      react: '>=16.4.1'
+
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
@@ -3513,6 +3547,17 @@ packages:
     resolution: {integrity: sha512-02k9WQ/mUhdbXir0tC1NiMesGzRPaCsJEWU/4bcFrbY1YMZOtHShtZP6zw0SJrBWA/31H0KT9/FgdL8+sPKgHA==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
+
+  react-google-recaptcha@3.1.0:
+    resolution: {integrity: sha512-cYW2/DWas8nEKZGD7SCu9BSuVz8iOcOLHChHyi7upUuVhkpkhYG/6N3KDiTQ3XAiZ2UAZkfvYKMfAHOzBOcGEg==}
+    peerDependencies:
+      react: '>=16.4.1'
+
+  react-hook-form@7.71.1:
+    resolution: {integrity: sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -4415,6 +4460,11 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@hookform/resolvers@5.2.2(react-hook-form@7.71.1(react@19.2.3))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.71.1(react@19.2.3)
 
   '@humanfs/core@0.19.1': {}
 
@@ -5591,6 +5641,8 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@standard-schema/utils@0.3.0': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -5773,6 +5825,10 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.13)':
+    dependencies:
+      '@types/react': 19.2.13
+
+  '@types/react-google-recaptcha@2.1.9':
     dependencies:
       '@types/react': 19.2.13
 
@@ -6909,6 +6965,10 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hoist-non-react-statics@3.3.2:
+    dependencies:
+      react-is: 16.13.1
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
@@ -7992,12 +8052,28 @@ snapshots:
       '@types/react': 19.2.13
       '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
+  react-async-script@1.2.0(react@19.2.3):
+    dependencies:
+      hoist-non-react-statics: 3.3.2
+      prop-types: 15.8.1
+      react: 19.2.3
+
   react-dom@19.2.3(react@19.2.3):
     dependencies:
       react: 19.2.3
       scheduler: 0.27.0
 
   react-error-boundary@6.1.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
+  react-google-recaptcha@3.1.0(react@19.2.3):
+    dependencies:
+      prop-types: 15.8.1
+      react: 19.2.3
+      react-async-script: 1.2.0(react@19.2.3)
+
+  react-hook-form@7.71.1(react@19.2.3):
     dependencies:
       react: 19.2.3
 

--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -1,10 +1,20 @@
+import Link from 'next/link'
+
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900">Ticket Queue</h1>
+    <div className="min-h-screen flex items-center justify-center bg-muted px-4 py-8">
+      <div className="w-full max-w-2xl min-w-[320px] space-y-8">
+        <div className="text-center">
+          <Link href="/">
+            <h1 className="text-3xl font-bold text-foreground cursor-pointer hover:opacity-80 transition-opacity">
+              Ticket Queue
+            </h1>
+          </Link>
+        </div>
+        <div className="w-full">
+          {children}
+        </div>
       </div>
-      <div className="w-full max-w-md">{children}</div>
     </div>
   )
 }

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,12 +1,34 @@
 'use client'
 
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card'
+
 export default function LoginPage() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-background">
-      <div className="text-center">
-        <h1 className="text-h1 text-foreground mb-md">로그인</h1>
-        <p className="text-body text-muted-foreground">로그인 페이지입니다</p>
-      </div>
-    </main>
+    <Card>
+      <CardHeader>
+        <CardTitle>로그인</CardTitle>
+        <CardDescription>이메일과 비밀번호를 입력해주세요.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="email">이메일</Label>
+          <Input id="email" type="email" placeholder="example@email.com" />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">비밀번호</Label>
+          <Input id="password" type="password" placeholder="비밀번호를 입력하세요" />
+        </div>
+        <Button className="w-full">로그인</Button>
+      </CardContent>
+      <CardFooter className="justify-center">
+        <Link href="/signup" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          회원가입
+        </Link>
+      </CardFooter>
+    </Card>
   )
 }

--- a/frontend/src/app/(auth)/signup/page.tsx
+++ b/frontend/src/app/(auth)/signup/page.tsx
@@ -1,12 +1,115 @@
-'use client'
+'use client';
 
+import { useState } from 'react';
+import { toast } from 'sonner';
+import type { SignupStep, SignupWizardData } from '@/types/signup';
+import type { SignupRequest } from '@/types/auth';
+import {
+  ProgressBar,
+  TermsStep,
+  CaptchaStep,
+  VerifyStep,
+  InfoStep,
+} from '@/components/domain/auth/signup';
+
+/**
+ * 회원가입 페이지 (4단계 위저드)
+ *
+ * Step 1: 약관동의 (TermsStep)
+ * Step 2: CAPTCHA (CaptchaStep)
+ * Step 3: 본인인증 (VerifyStep - stub)
+ * Step 4: 정보입력 (InfoStep)
+ *
+ * @see docs/frontend/04_auth_security.md 2.2.1절
+ */
 export default function SignupPage() {
+  const [currentStep, setCurrentStep] = useState<SignupStep>(1);
+  const [wizardData, setWizardData] = useState<SignupWizardData>({
+    serviceTermsAgreed: false,
+    privacyTermsAgreed: false,
+    recaptchaToken: null,
+    ci: null,
+    di: null,
+  });
+
+  // Step 1 → 2: 약관 동의
+  const handleTermsNext = (serviceTerms: boolean, privacyTerms: boolean) => {
+    setWizardData((prev) => ({
+      ...prev,
+      serviceTermsAgreed: serviceTerms,
+      privacyTermsAgreed: privacyTerms,
+    }));
+    setCurrentStep(2);
+  };
+
+  // Step 2 → 3: CAPTCHA 인증
+  const handleCaptchaNext = (token: string) => {
+    setWizardData((prev) => ({
+      ...prev,
+      recaptchaToken: token,
+    }));
+    setCurrentStep(3);
+  };
+
+  // Step 3 → 4: 본인인증
+  const handleVerifyNext = (ci: string, di: string) => {
+    setWizardData((prev) => ({
+      ...prev,
+      ci,
+      di,
+    }));
+    setCurrentStep(4);
+  };
+
+  // Step 4: 회원가입 제출
+  const handleSignupSubmit = async (signupRequest: SignupRequest) => {
+    // TODO: 백엔드 연동 - POST /auth/signup API 호출
+    console.log('회원가입 요청 데이터:', signupRequest);
+    toast.success('회원가입 요청이 전송되었습니다. (백엔드 연동 전 개발용 메시지)');
+
+    // TODO: 성공 시 로그인 페이지로 리디렉션
+    // router.push('/login');
+  };
+
+  // 이전 단계로 이동 (데이터 보존)
+  const handleBack = () => {
+    setCurrentStep((prev) => Math.max(1, prev - 1) as SignupStep);
+  };
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-background">
-      <div className="text-center">
-        <h1 className="text-h1 text-foreground mb-md">회원가입</h1>
-        <p className="text-body text-muted-foreground">회원가입 페이지입니다</p>
-      </div>
-    </main>
-  )
+    <div className="space-y-6">
+      {/* Progress Bar */}
+      <ProgressBar currentStep={currentStep} />
+
+      {/* Step 1: 약관동의 */}
+      {currentStep === 1 && (
+        <TermsStep
+          onNext={handleTermsNext}
+          initialServiceTerms={wizardData.serviceTermsAgreed}
+          initialPrivacyTerms={wizardData.privacyTermsAgreed}
+        />
+      )}
+
+      {/* Step 2: CAPTCHA */}
+      {currentStep === 2 && (
+        <CaptchaStep onNext={handleCaptchaNext} onBack={handleBack} />
+      )}
+
+      {/* Step 3: 본인인증 */}
+      {currentStep === 3 && (
+        <VerifyStep onNext={handleVerifyNext} onBack={handleBack} />
+      )}
+
+      {/* Step 4: 정보입력 */}
+      {currentStep === 4 && wizardData.recaptchaToken && wizardData.ci && wizardData.di && (
+        <InfoStep
+          recaptchaToken={wizardData.recaptchaToken}
+          ci={wizardData.ci}
+          di={wizardData.di}
+          onSubmit={handleSignupSubmit}
+          onBack={handleBack}
+        />
+      )}
+    </div>
+  );
 }

--- a/frontend/src/components/domain/auth/signup/captcha-step.tsx
+++ b/frontend/src/components/domain/auth/signup/captcha-step.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import ReCAPTCHA from 'react-google-recaptcha';
+import { Button } from '@/components/ui/button';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
+import { toast } from 'sonner';
+
+interface CaptchaStepProps {
+  onNext: (token: string) => void;
+  onBack: () => void;
+}
+
+/**
+ * 회원가입 2단계: CAPTCHA 인증
+ * Google reCAPTCHA를 통해 봇이 아님을 검증합니다.
+ *
+ * @see docs/frontend/04_auth_security.md 2.2.1절 2단계, 3.1절
+ *
+ * @example
+ * ```tsx
+ * <CaptchaStep
+ *   onNext={(token) => console.log('CAPTCHA 토큰:', token)}
+ *   onBack={() => console.log('이전 단계로')}
+ * />
+ * ```
+ */
+export function CaptchaStep({ onNext, onBack }: CaptchaStepProps) {
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+  const recaptchaRef = useRef<ReCAPTCHA>(null);
+
+  // 환경변수에서 reCAPTCHA Site Key 가져오기
+  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+
+  if (!siteKey) {
+    console.error('NEXT_PUBLIC_RECAPTCHA_SITE_KEY 환경변수가 설정되지 않았습니다.');
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>보안 인증</CardTitle>
+          <CardDescription>봇이 아님을 확인하기 위한 인증 절차입니다.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center text-destructive">
+            <p className="text-sm">reCAPTCHA 설정 오류</p>
+            <p className="text-xs mt-2">환경변수를 확인해주세요.</p>
+          </div>
+        </CardContent>
+        <CardFooter>
+          <Button onClick={onBack} variant="outline" className="w-full">
+            이전
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  const handleCaptchaChange = (token: string | null) => {
+    setCaptchaToken(token);
+  };
+
+  const handleCaptchaExpired = () => {
+    setCaptchaToken(null);
+    toast.warning('CAPTCHA가 만료되었습니다. 다시 시도해주세요.');
+  };
+
+  const handleCaptchaError = () => {
+    setCaptchaToken(null);
+    toast.error('CAPTCHA 로드 중 오류가 발생했습니다.');
+  };
+
+  const handleNext = () => {
+    if (!captchaToken) {
+      toast.error('CAPTCHA 인증을 완료해주세요.');
+      return;
+    }
+    onNext(captchaToken);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>보안 인증</CardTitle>
+        <CardDescription>봇이 아님을 확인하기 위한 인증 절차입니다.</CardDescription>
+      </CardHeader>
+      <CardContent className="flex justify-center">
+        <ReCAPTCHA
+          ref={recaptchaRef}
+          sitekey={siteKey}
+          onChange={handleCaptchaChange}
+          onExpired={handleCaptchaExpired}
+          onErrored={handleCaptchaError}
+        />
+      </CardContent>
+      <CardFooter className="gap-3">
+        <Button onClick={onBack} variant="outline" className="flex-1" size="lg">
+          이전
+        </Button>
+        <Button
+          onClick={handleNext}
+          disabled={!captchaToken}
+          className="flex-1"
+          size="lg"
+        >
+          다음
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/frontend/src/components/domain/auth/signup/index.ts
+++ b/frontend/src/components/domain/auth/signup/index.ts
@@ -1,0 +1,9 @@
+/**
+ * 회원가입 위저드 컴포넌트 Barrel Export
+ */
+
+export { ProgressBar } from './progress-bar';
+export { TermsStep } from './terms-step';
+export { CaptchaStep } from './captcha-step';
+export { VerifyStep } from './verify-step';
+export { InfoStep } from './info-step';

--- a/frontend/src/components/domain/auth/signup/info-step.tsx
+++ b/frontend/src/components/domain/auth/signup/info-step.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
+import type { SignupRequest } from '@/types/auth';
+import type { SignupFormData } from '@/types/signup';
+
+interface InfoStepProps {
+  recaptchaToken: string;
+  ci: string;
+  di: string;
+  onSubmit: (data: SignupRequest) => void;
+  onBack: () => void;
+  isSubmitting?: boolean;
+}
+
+/**
+ * 회원가입 정보 입력 Zod 스키마
+ */
+const signupInfoSchema = z
+  .object({
+    email: z
+      .string()
+      .min(1, '이메일을 입력해주세요.')
+      .email('올바른 이메일 형식이 아닙니다.'),
+    password: z
+      .string()
+      .min(8, '비밀번호는 최소 8자 이상이어야 합니다.')
+      .regex(
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])/,
+        '비밀번호는 영문 대소문자, 숫자, 특수문자를 포함해야 합니다.'
+      ),
+    passwordConfirm: z.string().min(1, '비밀번호 확인을 입력해주세요.'),
+    name: z.string().min(2, '이름은 최소 2자 이상이어야 합니다.'),
+    phone: z
+      .string()
+      .regex(/^010-\d{4}-\d{4}$/, '휴대폰 번호 형식이 올바르지 않습니다. (예: 010-1234-5678)'),
+  })
+  .refine((data) => data.password === data.passwordConfirm, {
+    message: '비밀번호가 일치하지 않습니다.',
+    path: ['passwordConfirm'],
+  });
+
+type SignupInfoFormData = z.infer<typeof signupInfoSchema>;
+
+/**
+ * 회원가입 4단계: 정보입력
+ * react-hook-form + Zod를 사용하여 유효성 검증을 수행합니다.
+ *
+ * FormInput 컴포넌트의 onChange 시그니처 이슈로 인해
+ * 기본 Input + Label을 직접 사용합니다.
+ *
+ * @see docs/frontend/04_auth_security.md 2.2.1절 4단계
+ *
+ * @example
+ * ```tsx
+ * <InfoStep
+ *   recaptchaToken="captcha_token"
+ *   ci="ci_value"
+ *   di="di_value"
+ *   onSubmit={(data) => console.log('회원가입:', data)}
+ *   onBack={() => console.log('이전 단계로')}
+ * />
+ * ```
+ */
+export function InfoStep({
+  recaptchaToken,
+  ci,
+  di,
+  onSubmit,
+  onBack,
+  isSubmitting = false,
+}: InfoStepProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<SignupInfoFormData>({
+    resolver: zodResolver(signupInfoSchema),
+    mode: 'onBlur',
+  });
+
+  const onFormSubmit = (formData: SignupInfoFormData) => {
+    const { passwordConfirm, ...rest } = formData;
+    const signupRequest: SignupRequest = {
+      ...rest,
+      recaptchaToken,
+      ci,
+      di,
+    };
+    onSubmit(signupRequest);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onFormSubmit)}>
+      <Card>
+        <CardHeader>
+          <CardTitle>정보 입력</CardTitle>
+          <CardDescription>회원가입에 필요한 정보를 입력해주세요.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* 이메일 */}
+          <div className="space-y-2">
+            <Label htmlFor="email">
+              이메일 <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="example@email.com"
+              {...register('email')}
+              aria-invalid={!!errors.email}
+              aria-describedby={errors.email ? 'email-error' : undefined}
+            />
+            {errors.email && (
+              <p id="email-error" className="text-xs text-destructive">
+                {errors.email.message}
+              </p>
+            )}
+          </div>
+
+          {/* 비밀번호 */}
+          <div className="space-y-2">
+            <Label htmlFor="password">
+              비밀번호 <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="password"
+              type="password"
+              placeholder="영문 대소문자, 숫자, 특수문자 포함 8자 이상"
+              {...register('password')}
+              aria-invalid={!!errors.password}
+              aria-describedby={errors.password ? 'password-error' : undefined}
+            />
+            {errors.password && (
+              <p id="password-error" className="text-xs text-destructive">
+                {errors.password.message}
+              </p>
+            )}
+          </div>
+
+          {/* 비밀번호 확인 */}
+          <div className="space-y-2">
+            <Label htmlFor="passwordConfirm">
+              비밀번호 확인 <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="passwordConfirm"
+              type="password"
+              placeholder="비밀번호를 다시 입력해주세요"
+              {...register('passwordConfirm')}
+              aria-invalid={!!errors.passwordConfirm}
+              aria-describedby={errors.passwordConfirm ? 'passwordConfirm-error' : undefined}
+            />
+            {errors.passwordConfirm && (
+              <p id="passwordConfirm-error" className="text-xs text-destructive">
+                {errors.passwordConfirm.message}
+              </p>
+            )}
+          </div>
+
+          {/* 이름 */}
+          <div className="space-y-2">
+            <Label htmlFor="name">
+              이름 <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="name"
+              type="text"
+              placeholder="홍길동"
+              {...register('name')}
+              aria-invalid={!!errors.name}
+              aria-describedby={errors.name ? 'name-error' : undefined}
+            />
+            {errors.name && (
+              <p id="name-error" className="text-xs text-destructive">
+                {errors.name.message}
+              </p>
+            )}
+          </div>
+
+          {/* 휴대폰 번호 */}
+          <div className="space-y-2">
+            <Label htmlFor="phone">
+              휴대폰 번호 <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="phone"
+              type="tel"
+              placeholder="010-1234-5678"
+              {...register('phone')}
+              aria-invalid={!!errors.phone}
+              aria-describedby={errors.phone ? 'phone-error' : undefined}
+            />
+            {errors.phone && (
+              <p id="phone-error" className="text-xs text-destructive">
+                {errors.phone.message}
+              </p>
+            )}
+          </div>
+        </CardContent>
+        <CardFooter className="gap-3">
+          <Button
+            type="button"
+            onClick={onBack}
+            variant="outline"
+            className="flex-1"
+            size="lg"
+            disabled={isSubmitting}
+          >
+            이전
+          </Button>
+          <Button
+            type="submit"
+            className="flex-1"
+            size="lg"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? '처리 중...' : '회원가입'}
+          </Button>
+        </CardFooter>
+      </Card>
+    </form>
+  );
+}

--- a/frontend/src/components/domain/auth/signup/progress-bar.tsx
+++ b/frontend/src/components/domain/auth/signup/progress-bar.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import type { SignupStep } from '@/types/signup';
+import { cn } from '@/lib/utils';
+
+interface ProgressBarProps {
+  currentStep: SignupStep;
+}
+
+const STEPS = [
+  { step: 1 as const, label: '약관동의' },
+  { step: 2 as const, label: 'CAPTCHA' },
+  { step: 3 as const, label: '본인인증' },
+  { step: 4 as const, label: '정보입력' },
+];
+
+/**
+ * 회원가입 위저드 진행 상태를 시각적으로 표시하는 컴포넌트
+ *
+ * @example
+ * ```tsx
+ * <ProgressBar currentStep={2} />
+ * ```
+ */
+export function ProgressBar({ currentStep }: ProgressBarProps) {
+  return (
+    <nav
+      className="w-full"
+      role="navigation"
+      aria-label="회원가입 진행 단계"
+    >
+      <ol className="flex items-center justify-between">
+        {STEPS.map((step, index) => {
+          const isCompleted = currentStep > step.step;
+          const isCurrent = currentStep === step.step;
+          const isFuture = currentStep < step.step;
+          const isLastStep = index === STEPS.length - 1;
+
+          return (
+            <li key={step.step} className="flex items-center flex-1 last:flex-none">
+              {/* Step Circle */}
+              <div className="flex flex-col items-center">
+                <div
+                  className={cn(
+                    'w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold transition-colors',
+                    {
+                      'bg-primary text-primary-foreground': isCompleted || isCurrent,
+                      'border-2 border-muted-foreground text-muted-foreground': isFuture,
+                    }
+                  )}
+                  aria-current={isCurrent ? 'step' : undefined}
+                  aria-label={`${step.label} (${isCompleted ? '완료' : isCurrent ? '현재' : '대기'})`}
+                >
+                  {step.step}
+                </div>
+                {/* Step Label (hidden on mobile) */}
+                <span
+                  className={cn(
+                    'hidden md:block mt-2 text-xs font-medium transition-colors',
+                    {
+                      'text-primary': isCompleted || isCurrent,
+                      'text-muted-foreground': isFuture,
+                    }
+                  )}
+                >
+                  {step.label}
+                </span>
+              </div>
+
+              {/* Connection Line */}
+              {!isLastStep && (
+                <div
+                  className={cn(
+                    'flex-1 h-0.5 mx-2 transition-colors',
+                    {
+                      'bg-primary': isCompleted,
+                      'bg-muted': !isCompleted,
+                    }
+                  )}
+                  aria-hidden="true"
+                />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/frontend/src/components/domain/auth/signup/terms-step.tsx
+++ b/frontend/src/components/domain/auth/signup/terms-step.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
+
+interface TermsStepProps {
+  onNext: (serviceTerms: boolean, privacyTerms: boolean) => void;
+  initialServiceTerms?: boolean;
+  initialPrivacyTerms?: boolean;
+}
+
+/**
+ * 회원가입 1단계: 약관동의
+ * 서비스 이용약관과 개인정보 수집 및 이용 동의를 받습니다.
+ *
+ * @see docs/frontend/04_auth_security.md 2.2.1절 1단계
+ *
+ * @example
+ * ```tsx
+ * <TermsStep
+ *   onNext={(service, privacy) => {
+ *     console.log('약관 동의:', service, privacy);
+ *   }}
+ * />
+ * ```
+ */
+export function TermsStep({
+  onNext,
+  initialServiceTerms = false,
+  initialPrivacyTerms = false,
+}: TermsStepProps) {
+  const [serviceTerms, setServiceTerms] = useState(initialServiceTerms);
+  const [privacyTerms, setPrivacyTerms] = useState(initialPrivacyTerms);
+
+  const canProceed = serviceTerms && privacyTerms;
+
+  const handleNext = () => {
+    if (canProceed) {
+      onNext(serviceTerms, privacyTerms);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>약관 동의</CardTitle>
+        <CardDescription>서비스 이용을 위해 아래 약관에 동의해주세요.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* 서비스 이용약관 */}
+        <div className="flex items-start space-x-3 border rounded-lg p-4">
+          <Checkbox
+            id="service-terms"
+            checked={serviceTerms}
+            onCheckedChange={(checked) => setServiceTerms(checked === true)}
+            aria-required="true"
+          />
+          <div className="flex-1">
+            <Label
+              htmlFor="service-terms"
+              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+            >
+              서비스 이용약관 동의 <span className="text-destructive">(필수)</span>
+            </Label>
+            <p className="text-xs text-muted-foreground mt-1">
+              서비스 제공에 필요한 약관입니다.
+            </p>
+          </div>
+        </div>
+
+        {/* 개인정보 수집 및 이용 동의 */}
+        <div className="flex items-start space-x-3 border rounded-lg p-4">
+          <Checkbox
+            id="privacy-terms"
+            checked={privacyTerms}
+            onCheckedChange={(checked) => setPrivacyTerms(checked === true)}
+            aria-required="true"
+          />
+          <div className="flex-1">
+            <Label
+              htmlFor="privacy-terms"
+              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+            >
+              개인정보 수집 및 이용 동의 <span className="text-destructive">(필수)</span>
+            </Label>
+            <p className="text-xs text-muted-foreground mt-1">
+              회원가입 및 서비스 이용을 위한 개인정보 수집에 동의합니다.
+            </p>
+          </div>
+        </div>
+      </CardContent>
+      <CardFooter className="flex-col space-y-3">
+        <Button
+          onClick={handleNext}
+          disabled={!canProceed}
+          className="w-full"
+          size="lg"
+        >
+          다음
+        </Button>
+
+        <div className="text-center">
+          <Link
+            href="/login"
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            로그인으로 돌아가기
+          </Link>
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/frontend/src/components/domain/auth/signup/verify-step.tsx
+++ b/frontend/src/components/domain/auth/signup/verify-step.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
+import { ShieldCheck } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface VerifyStepProps {
+  onNext: (ci: string, di: string) => void;
+  onBack: () => void;
+}
+
+/**
+ * 회원가입 3단계: 본인인증 (Stub)
+ * PortOne 본인인증 연동은 백엔드 API 구현 후 진행됩니다.
+ *
+ * 현재는 개발용 "건너뛰기" 버튼을 제공하여 mock CI/DI 값으로 다음 단계로 이동합니다.
+ *
+ * @see docs/frontend/04_auth_security.md 2.2.1절 3단계, 4.2절
+ *
+ * TODO: usePortOne Hook 연동
+ * - loadPortOneSDK() 호출
+ * - window.IMP.init(impCode)
+ * - window.IMP.certification() 호출
+ * - 백엔드 API로 imp_uid 전송하여 CI/DI 추출
+ *
+ * @example
+ * ```tsx
+ * <VerifyStep
+ *   onNext={(ci, di) => console.log('CI/DI:', ci, di)}
+ *   onBack={() => console.log('이전 단계로')}
+ * />
+ * ```
+ */
+export function VerifyStep({ onNext, onBack }: VerifyStepProps) {
+  const handleVerify = () => {
+    toast.info('본인인증 기능은 백엔드 연동 후 사용 가능합니다.');
+    // TODO: 실제 본인인증 로직
+    // 1. loadPortOneSDK() 호출
+    // 2. window.IMP.init(process.env.NEXT_PUBLIC_PORTONE_IMP_CODE)
+    // 3. window.IMP.certification() 호출
+    // 4. 응답으로 받은 imp_uid를 백엔드로 전송
+    // 5. 백엔드에서 PortOne API로 CI/DI 추출
+    // 6. onNext(ci, di) 호출
+  };
+
+  const handleSkip = () => {
+    // 개발용 mock CI/DI 값
+    const mockCi = 'mock_ci_' + Date.now();
+    const mockDi = 'mock_di_' + Date.now();
+    toast.success('개발용 mock CI/DI로 다음 단계로 이동합니다.');
+    onNext(mockCi, mockDi);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>본인인증</CardTitle>
+        <CardDescription>1인 1계정 정책을 위해 본인인증이 필요합니다.</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center py-4 space-y-4">
+        <ShieldCheck className="w-16 h-16 text-primary" />
+        <p className="text-center text-sm text-muted-foreground">
+          휴대폰 번호로 본인인증을 진행합니다.
+          <br />
+          본인명의 휴대폰이 필요합니다.
+        </p>
+      </CardContent>
+      <CardFooter className="flex-col space-y-3">
+        <Button onClick={handleVerify} className="w-full" size="lg">
+          본인인증하기
+        </Button>
+
+        <div className="flex gap-3 w-full">
+          <Button onClick={onBack} variant="outline" className="flex-1" size="lg">
+            이전
+          </Button>
+          <Button
+            onClick={handleSkip}
+            variant="ghost"
+            className="flex-1"
+            size="lg"
+          >
+            건너뛰기 (개발용)
+          </Button>
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/frontend/src/lib/portone/init.ts
+++ b/frontend/src/lib/portone/init.ts
@@ -1,0 +1,97 @@
+/**
+ * PortOne (구 아임포트) SDK 초기화 유틸
+ * CDN 스크립트를 동적으로 로드하고 중복 로딩을 방지합니다.
+ * @see docs/frontend/04_auth_security.md 4.1절
+ */
+
+const PORTONE_SDK_URL = 'https://cdn.iamport.kr/v1/iamport.js';
+const SCRIPT_ID = 'portone-sdk';
+
+let loadPromise: Promise<void> | null = null;
+
+/**
+ * PortOne SDK를 동적으로 로드합니다.
+ * 이미 로드 중이거나 로드 완료된 경우 기존 Promise를 반환하여 중복 로딩을 방지합니다.
+ *
+ * @returns SDK 로드 완료 Promise
+ * @throws SDK 로드 실패 시 에러
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await loadPortOneSDK();
+ *   if (window.IMP) {
+ *     window.IMP.init('your_imp_code');
+ *   }
+ * } catch (error) {
+ *   console.error('PortOne SDK 로드 실패:', error);
+ * }
+ * ```
+ */
+export async function loadPortOneSDK(): Promise<void> {
+  // 이미 로드된 경우
+  if (typeof window !== 'undefined' && window.IMP) {
+    return Promise.resolve();
+  }
+
+  // 이미 로딩 중인 경우
+  if (loadPromise) {
+    return loadPromise;
+  }
+
+  // 새로운 로딩 시작
+  loadPromise = new Promise<void>((resolve, reject) => {
+    // 서버 사이드 렌더링 환경 체크
+    if (typeof window === 'undefined') {
+      reject(new Error('PortOne SDK는 브라우저 환경에서만 사용 가능합니다.'));
+      return;
+    }
+
+    // 이미 스크립트 태그가 존재하는지 확인
+    const existingScript = document.getElementById(SCRIPT_ID);
+    if (existingScript) {
+      // 스크립트는 있지만 IMP가 없는 경우 (로딩 중)
+      existingScript.addEventListener('load', () => {
+        if (window.IMP) {
+          resolve();
+        } else {
+          reject(new Error('PortOne SDK 로드 완료되었으나 IMP 객체가 없습니다.'));
+        }
+      });
+      existingScript.addEventListener('error', () => {
+        reject(new Error('PortOne SDK 스크립트 로드에 실패했습니다.'));
+      });
+      return;
+    }
+
+    // 새로운 스크립트 태그 생성
+    const script = document.createElement('script');
+    script.id = SCRIPT_ID;
+    script.src = PORTONE_SDK_URL;
+    script.async = true;
+
+    script.onload = () => {
+      if (window.IMP) {
+        resolve();
+      } else {
+        reject(new Error('PortOne SDK 로드 완료되었으나 IMP 객체가 없습니다.'));
+      }
+    };
+
+    script.onerror = () => {
+      reject(new Error('PortOne SDK 스크립트 로드에 실패했습니다.'));
+    };
+
+    document.head.appendChild(script);
+  });
+
+  return loadPromise;
+}
+
+/**
+ * PortOne SDK 로드 상태 확인
+ * @returns SDK 로드 완료 여부
+ */
+export function isPortOneLoaded(): boolean {
+  return typeof window !== 'undefined' && !!window.IMP;
+}

--- a/frontend/src/types/portone.d.ts
+++ b/frontend/src/types/portone.d.ts
@@ -1,0 +1,56 @@
+/**
+ * PortOne (구 아임포트) 본인인증 SDK 타입 정의
+ * @see https://portone.gitbook.io/docs/auth/guide
+ */
+
+/**
+ * 본인인증 요청 파라미터
+ */
+export interface IMPCertificationParams {
+  /** 가맹점 식별코드 */
+  merchant_uid: string;
+  /** 본인인증 방식 (phone: 휴대폰, card: 카드, cert: 공동인증서) */
+  m_redirect_url?: string;
+  /** 본인인증 팝업 여부 */
+  popup?: boolean;
+}
+
+/**
+ * 본인인증 응답 데이터
+ */
+export interface IMPCertificationResponse {
+  /** 본인인증 성공 여부 */
+  success: boolean;
+  /** 본인인증 고유번호 (백엔드로 전달하여 CI/DI 추출) */
+  imp_uid?: string;
+  /** 가맹점 주문번호 */
+  merchant_uid?: string;
+  /** 에러 코드 */
+  error_code?: string;
+  /** 에러 메시지 */
+  error_msg?: string;
+}
+
+/**
+ * PortOne SDK 인터페이스
+ */
+export interface IMP {
+  /** PortOne SDK 초기화 */
+  init: (impCode: string) => void;
+  /** 본인인증 요청 */
+  certification: (
+    params: IMPCertificationParams,
+    callback?: (response: IMPCertificationResponse) => void,
+  ) => void;
+}
+
+/**
+ * Window 객체에 IMP 추가
+ */
+declare global {
+  interface Window {
+    IMP?: IMP;
+  }
+}
+
+export {};

--- a/frontend/src/types/signup.ts
+++ b/frontend/src/types/signup.ts
@@ -1,0 +1,36 @@
+/**
+ * 회원가입 위저드 단계
+ * 1: 약관동의
+ * 2: CAPTCHA
+ * 3: 본인인증
+ * 4: 정보입력
+ */
+export type SignupStep = 1 | 2 | 3 | 4;
+
+/**
+ * 회원가입 위저드 데이터
+ * 각 단계에서 수집한 데이터를 저장
+ */
+export interface SignupWizardData {
+  /** 서비스 이용약관 동의 여부 */
+  serviceTermsAgreed: boolean;
+  /** 개인정보 수집 및 이용 동의 여부 */
+  privacyTermsAgreed: boolean;
+  /** Google reCAPTCHA 토큰 */
+  recaptchaToken: string | null;
+  /** 본인인증 CI (Connecting Information) */
+  ci: string | null;
+  /** 본인인증 DI (Duplication Information) */
+  di: string | null;
+}
+
+/**
+ * 회원가입 폼 데이터 (Step 4)
+ */
+export interface SignupFormData {
+  email: string;
+  password: string;
+  passwordConfirm: string;
+  name: string;
+  phone: string;
+}


### PR DESCRIPTION
## Summary
- 회원가입 4단계 위저드 UI 구현 (Step 1-4)
- PortOne 본인인증 stub (백엔드 API 연동 대기)

## Changes
- **Step 1: 약관동의** - 서비스 이용약관, 개인정보 수집 동의 체크박스
- **Step 2: reCAPTCHA 인증** - react-google-recaptcha 연동
- **Step 3: 본인인증 stub** - PortOne SDK 초기화 유틸, 백엔드 연동 전 건너뛰기 기능
- **Step 4: 정보입력** - react-hook-form + Zod 유효성 검증
- **ProgressBar** - 위저드 진행 상태 시각화 (1/2/3/4)
- **Auth 레이아웃** - Card 컴포넌트 기반 개편, 반응형 디자인, 디자인 토큰 적용
- **로그인 페이지** - Card 기반 구조 (회원가입과 일관된 UI)

## Test plan
- [ ] Step 1-4 위저드 플로우 정상 동작 확인
- [ ] 약관 체크 시 다음 버튼 활성화
- [ ] reCAPTCHA 인증 (NEXT_PUBLIC_RECAPTCHA_SITE_KEY 환경변수 설정 시)
- [ ] 본인인증 건너뛰기 동작
- [ ] 정보입력 폼 유효성 검증 (이메일, 비밀번호, 이름, 휴대폰)
- [ ] 반응형 레이아웃 (320px ~ 데스크톱)
- [ ] 백엔드 연동 후 실제 회원가입 API 호출 테스트 (대기 중)

**Note**: 레이아웃 및 디자인 개선 부분은 별도 PR (design/auth-layout-#113)로 분리되어 먼저 merge 예정

Closes #113