### PR TITLE
design: Auth 레이아웃 Card 기반 개편 및 디자인 토큰 적용 #113

### DIFF
--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -1,10 +1,20 @@
+import Link from 'next/link'
+
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900">Ticket Queue</h1>
+    <div className="min-h-screen flex items-center justify-center bg-muted px-4 py-8">
+      <div className="w-full max-w-2xl min-w-[320px] space-y-8">
+        <div className="text-center">
+          <Link href="/">
+            <h1 className="text-3xl font-bold text-foreground cursor-pointer hover:opacity-80 transition-opacity">
+              Ticket Queue
+            </h1>
+          </Link>
+        </div>
+        <div className="w-full">
+          {children}
+        </div>
       </div>
-      <div className="w-full max-w-md">{children}</div>
     </div>
   )
 }

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,12 +1,34 @@
 'use client'
 
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card'
+
 export default function LoginPage() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-background">
-      <div className="text-center">
-        <h1 className="text-h1 text-foreground mb-md">로그인</h1>
-        <p className="text-body text-muted-foreground">로그인 페이지입니다</p>
-      </div>
-    </main>
+    <Card>
+      <CardHeader>
+        <CardTitle>로그인</CardTitle>
+        <CardDescription>이메일과 비밀번호를 입력해주세요.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="email">이메일</Label>
+          <Input id="email" type="email" placeholder="example@email.com" />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">비밀번호</Label>
+          <Input id="password" type="password" placeholder="비밀번호를 입력하세요" />
+        </div>
+        <Button className="w-full">로그인</Button>
+      </CardContent>
+      <CardFooter className="justify-center">
+        <Link href="/signup" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          회원가입
+        </Link>
+      </CardFooter>
+    </Card>
   )
 }


### PR DESCRIPTION
## Summary
Auth 레이아웃 Card 기반 개편 및 디자인 토큰 적용
- 원본 PR #135에서 디자인 부분만 분리
- #113 회원가입 위저드 기능은 별도 PR로 진행

## Changes
- **Auth 레이아웃**: `bg-muted` 디자인 토큰, `max-w-2xl` 확대, 반응형 패딩, 홈 링크 추가
- **로그인 페이지**: Card/CardHeader/CardContent/CardFooter 구조 적용

## Test plan
- [x] 디자인 PR: pnpm build 성공 확인
- [x] 디자인 PR: 로그인 페이지 Card UI 렌더링 확인
- [x] 디자인 PR merge 후: 기존 PR #135를 develop에 rebase하여 충돌 없음 확인