### PR TITLE
feat: common.processed_events 테이블 정리 배치 작업 구현 #90

### DIFF
--- a/backend/common/src/main/kotlin/com/ticketqueue/common/outbox/ProcessedEventsCleanupBatchService.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/outbox/ProcessedEventsCleanupBatchService.kt
@@ -1,0 +1,36 @@
+package com.ticketqueue.common.outbox
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+// processed-event.cleanup.enabled=true 설정이 있을 때만 Bean 등록
+// Consumer 서비스(Reservation, Event)에서만 활성화
+@Service
+@ConditionalOnProperty(prefix = "processed-event.cleanup", name = ["enabled"], havingValue = "true")
+class ProcessedEventsCleanupBatchService(
+    private val processedEventRepository: ProcessedEventRepository,
+    // 보관 주기 (기본 30일)
+    @Value("\${processed-event.cleanup.retention-days:30}") private val retentionDays: Long
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    // 매일 02:00 KST에 실행 (초 분 시 일 월 요일)
+    @Scheduled(cron = "0 0 2 * * ?", zone = "Asia/Seoul")
+    @Transactional
+    fun cleanupOldProcessedEvents() {
+        val cutoff = LocalDateTime.now(ZoneOffset.UTC).minusDays(retentionDays)
+        val deletedCount = processedEventRepository.deleteByProcessedAtBefore(cutoff)
+        log.info(
+            "Cleaned up {} processed events older than {} days",
+            deletedCount,
+            retentionDays
+        )
+    }
+}

--- a/backend/common/src/test/kotlin/com/ticketqueue/common/outbox/ProcessedEventsCleanupBatchServiceConditionalTest.kt
+++ b/backend/common/src/test/kotlin/com/ticketqueue/common/outbox/ProcessedEventsCleanupBatchServiceConditionalTest.kt
@@ -1,0 +1,70 @@
+package com.ticketqueue.common.outbox
+
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * @ConditionalOnProperty 동작 검증 테스트
+ *
+ * 서비스 기동 없이 ApplicationContextRunner로 bean 생성 여부를 검증합니다.
+ * - processed-event.cleanup.enabled=true  → ProcessedEventsCleanupBatchService 생성 O (Reservation/Event Service)
+ * - 프로퍼티 미설정                          → ProcessedEventsCleanupBatchService 생성 X (Payment Service)
+ */
+class ProcessedEventsCleanupBatchServiceConditionalTest {
+
+    // ProcessedEventRepository mock을 제공하는 테스트 설정
+    @Configuration
+    class MockRepoConfig {
+        @Bean
+        fun processedEventRepository(): ProcessedEventRepository = mockk(relaxed = true)
+    }
+
+    private val contextRunner = ApplicationContextRunner()
+        .withUserConfiguration(
+            MockRepoConfig::class.java,
+            ProcessedEventsCleanupBatchService::class.java
+        )
+
+    @Test
+    fun `processed-event cleanup enabled=true 이면 bean이 생성된다 (Reservation, Event Service)`() {
+        contextRunner
+            .withPropertyValues(
+                "processed-event.cleanup.enabled=true",
+                "processed-event.cleanup.retention-days=30"
+            )
+            .run { context ->
+                assertThat(context).hasSingleBean(ProcessedEventsCleanupBatchService::class.java)
+            }
+    }
+
+    @Test
+    fun `processed-event cleanup 프로퍼티 미설정 시 bean이 생성되지 않는다 (Payment Service)`() {
+        contextRunner
+            .run { context ->
+                assertThat(context).doesNotHaveBean(ProcessedEventsCleanupBatchService::class.java)
+            }
+    }
+
+    @Test
+    fun `processed-event cleanup enabled=false 이면 bean이 생성되지 않는다`() {
+        contextRunner
+            .withPropertyValues("processed-event.cleanup.enabled=false")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(ProcessedEventsCleanupBatchService::class.java)
+            }
+    }
+
+    @Test
+    fun `retention-days 기본값 30일이 적용된다`() {
+        contextRunner
+            .withPropertyValues("processed-event.cleanup.enabled=true")
+            .run { context ->
+                assertThat(context).hasSingleBean(ProcessedEventsCleanupBatchService::class.java)
+                // bean이 정상 생성되면 기본값 30일 적용 확인 (예외 없이 기동)
+            }
+    }
+}

--- a/backend/common/src/test/kotlin/com/ticketqueue/common/outbox/ProcessedEventsCleanupBatchServiceTest.kt
+++ b/backend/common/src/test/kotlin/com/ticketqueue/common/outbox/ProcessedEventsCleanupBatchServiceTest.kt
@@ -1,0 +1,114 @@
+package com.ticketqueue.common.outbox
+
+import io.kotest.matchers.shouldBe
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@ExtendWith(MockKExtension::class)
+class ProcessedEventsCleanupBatchServiceTest {
+
+    @MockK
+    private lateinit var processedEventRepository: ProcessedEventRepository
+
+    private lateinit var service: ProcessedEventsCleanupBatchService
+
+    @BeforeEach
+    fun setUp() {
+        service = ProcessedEventsCleanupBatchService(processedEventRepository, retentionDays = 30L)
+    }
+
+    @Test
+    fun `처리 완료된 이벤트 정리 성공`() {
+        // given
+        val expectedDeletedCount = 10
+        every { processedEventRepository.deleteByProcessedAtBefore(any()) } returns expectedDeletedCount
+
+        // when
+        service.cleanupOldProcessedEvents()
+
+        // then
+        verify(exactly = 1) {
+            processedEventRepository.deleteByProcessedAtBefore(
+                match { it.isBefore(LocalDateTime.now(ZoneOffset.UTC)) && it.isAfter(LocalDateTime.now(ZoneOffset.UTC).minusDays(31)) }
+            )
+        }
+    }
+
+    @Test
+    fun `삭제 대상이 없는 경우`() {
+        // given
+        every { processedEventRepository.deleteByProcessedAtBefore(any()) } returns 0
+
+        // when & then (예외 없이 정상 동작)
+        service.cleanupOldProcessedEvents()
+
+        verify(exactly = 1) {
+            processedEventRepository.deleteByProcessedAtBefore(any())
+        }
+    }
+
+    @Test
+    fun `cutoff 날짜가 retentionDays 기반으로 계산되는지 확인`() {
+        // given
+        val fixedNow = LocalDateTime.of(2026, 2, 8, 14, 30, 0)
+        val expectedCutoff = fixedNow.minusDays(30)
+
+        mockkStatic(LocalDateTime::class)
+        every { LocalDateTime.now(ZoneOffset.UTC) } returns fixedNow
+
+        val capturedCutoff = slot<LocalDateTime>()
+        every { processedEventRepository.deleteByProcessedAtBefore(capture(capturedCutoff)) } returns 3
+
+        // when
+        service.cleanupOldProcessedEvents()
+
+        // then
+        capturedCutoff.captured shouldBe expectedCutoff
+
+        // cleanup
+        unmockkStatic(LocalDateTime::class)
+    }
+
+    @Test
+    fun `다수의 이벤트가 삭제된 경우`() {
+        // given
+        val largeDeletedCount = 100
+        every { processedEventRepository.deleteByProcessedAtBefore(any()) } returns largeDeletedCount
+
+        // when & then (예외 없이 정상 동작)
+        service.cleanupOldProcessedEvents()
+
+        verify(exactly = 1) {
+            processedEventRepository.deleteByProcessedAtBefore(any())
+        }
+    }
+
+    @Test
+    fun `retentionDays 커스텀 값 적용 확인`() {
+        // given
+        val customRetentionService = ProcessedEventsCleanupBatchService(processedEventRepository, retentionDays = 60L)
+        val fixedNow = LocalDateTime.of(2026, 2, 8, 14, 30, 0)
+        val expectedCutoff = fixedNow.minusDays(60)
+
+        mockkStatic(LocalDateTime::class)
+        every { LocalDateTime.now(ZoneOffset.UTC) } returns fixedNow
+
+        val capturedCutoff = slot<LocalDateTime>()
+        every { processedEventRepository.deleteByProcessedAtBefore(capture(capturedCutoff)) } returns 15
+
+        // when
+        customRetentionService.cleanupOldProcessedEvents()
+
+        // then
+        capturedCutoff.captured shouldBe expectedCutoff
+
+        // cleanup
+        unmockkStatic(LocalDateTime::class)
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/EventServiceApplication.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/EventServiceApplication.kt
@@ -4,10 +4,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication(scanBasePackages = ["com.ticketqueue.event", "com.ticketqueue.common"])
 @EnableJpaRepositories(basePackages = ["com.ticketqueue.event.repository"])
 @EntityScan(basePackages = ["com.ticketqueue.event.entity"])
+@EnableScheduling
 class EventServiceApplication
 
 fun main(args: Array<String>) {

--- a/backend/event-service/src/main/resources/application.yml
+++ b/backend/event-service/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 server:
   port: 8082
 
+processed-event:
+  cleanup:
+    enabled: true
+    retention-days: 30
+
 spring:
   application:
     name: event-service

--- a/backend/payment-service/src/main/resources/application.yml
+++ b/backend/payment-service/src/main/resources/application.yml
@@ -96,9 +96,3 @@ management:
   endpoint:
     health:
       show-details: always
-
-outbox:
-  cleanup:
-    enabled: true
-    aggregate-type: Payment
-    retention-days: 7

--- a/backend/reservation-service/src/main/resources/application.yml
+++ b/backend/reservation-service/src/main/resources/application.yml
@@ -12,6 +12,11 @@ outbox:
     aggregate-type: Reservation
     retention-days: 7
 
+processed-event:
+  cleanup:
+    enabled: true
+    retention-days: 30
+
 spring:
   application:
     name: reservation-service

--- a/backend/reservation-service/src/main/resources/application.yml
+++ b/backend/reservation-service/src/main/resources/application.yml
@@ -91,9 +91,3 @@ management:
   endpoint:
     health:
       show-details: always
-
-outbox:
-  cleanup:
-    enabled: true
-    aggregate-type: Reservation
-    retention-days: 7

--- a/docs/architecture/04_data.md
+++ b/docs/architecture/04_data.md
@@ -1047,7 +1047,7 @@ COMMENT ON TABLE common.processed_events IS 'Kafka Consumer 멱등성 보장. (e
 </details>
 
 **정리 배치 작업:**
-- **실행 주기**: 매일 02:00 UTC
+- **실행 주기**: 매일 02:00 KST (Asia/Seoul)
 - **SQL**:
   ```sql
   -- 30일 이상 된 처리 기록 삭제


### PR DESCRIPTION
## Summary
- `common.processed_events` 테이블의 30일 이상 된 레코드를 자동 삭제하는 정리 배치 작업 구현 (#90)
- `OutboxCleanupBatchService` 패턴을 그대로 따르며, `@ConditionalOnProperty`로 서비스별 활성화 제어

## Changes
- `ProcessedEventsCleanupBatchService` 추가: 매일 02:00 KST 실행, 기본 보관 기간 30일
- `ProcessedEventsCleanupBatchServiceTest` 추가: 5개 단위 테스트 (MockK + Kotest)
- `EventServiceApplication`에 `@EnableScheduling` 추가
- `reservation-service`, `event-service` `application.yml`에 `processed-event.cleanup` 설정 추가
- `docs/architecture/04_data.md` 실행 주기 표기 수정: `02:00 UTC` → `02:00 KST (Asia/Seoul)`
- `KafkaErrorHandlerConfig` 기존 컴파일 오류 수정 (`import io.github.oshai.kotlinlogging.KotlinLogging` 누락, `log` → `logger` 참조 오류)

## Test plan
- [x] `./gradlew :common:test --tests "*ProcessedEventsCleanupBatchServiceTest"` — 5개 테스트 통과
- [x] `./gradlew build -x test` — 전체 빌드 성공
- [x] Reservation/Event Service 기동 시 `ProcessedEventsCleanupBatchService` bean 생성 로그 확인
- [x] Payment Service 기동 시 해당 bean 미생성 확인

Closes #90 