### PR TITLE
feat: 공통 Feign Client 설정 #91

### DIFF
--- a/backend/common/build.gradle.kts
+++ b/backend/common/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     runtimeOnly(libs.postgresql)
 
     // Test
+    testImplementation(libs.spring.cloud.starter.openfeign)
     testImplementation(libs.bundles.test.base)
     testImplementation(libs.spring.kafka)
     testImplementation("org.springframework.kafka:spring-kafka-test")

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/config/FeignConfig.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/config/FeignConfig.kt
@@ -1,7 +1,11 @@
 package com.ticketqueue.common.config
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.security.InternalApiKeyValidator
+import feign.Logger
 import feign.RequestInterceptor
+import feign.Retryer
+import feign.codec.ErrorDecoder
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.context.annotation.Bean
@@ -9,8 +13,8 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 @ConditionalOnClass(RequestInterceptor::class)
-class InternalApiFeignConfig(
-    @Value("\${internal_api_key}")
+class FeignConfig(
+    @Value("\${internal.api.key}")
     private val internalApiKey: String
 ) {
 
@@ -19,5 +23,21 @@ class InternalApiFeignConfig(
         return RequestInterceptor { template ->
             template.header(InternalApiKeyValidator.HEADER_NAME, internalApiKey)
         }
+    }
+
+    @Bean
+    fun feignErrorDecoder(objectMapper: ObjectMapper): ErrorDecoder {
+        return FeignErrorDecoder(objectMapper)
+    }
+
+    // 재시도 정책: 지수 백오프, period=500ms, maxPeriod=2000ms, maxAttempts=3
+    @Bean
+    fun feignRetryer(): Retryer {
+        return Retryer.Default(500, 2000, 3)
+    }
+
+    @Bean
+    fun feignLoggerLevel(): Logger.Level {
+        return Logger.Level.FULL
     }
 }

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/config/FeignErrorDecoder.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/config/FeignErrorDecoder.kt
@@ -1,0 +1,78 @@
+package com.ticketqueue.common.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.dto.ErrorResponse
+import com.ticketqueue.common.exception.BusinessException
+import com.ticketqueue.common.exception.ErrorCode
+import feign.Response
+import feign.RetryableException
+import feign.codec.ErrorDecoder
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.IOException
+
+class FeignErrorDecoder(
+    private val objectMapper: ObjectMapper
+) : ErrorDecoder {
+
+    private val logger = KotlinLogging.logger {}
+    private val defaultDecoder = ErrorDecoder.Default()
+
+    override fun decode(methodKey: String, response: Response): Exception {
+        val status = response.status()
+
+        logger.warn { "[FEIGN_ERROR] methodKey=$methodKey, status=$status, url=${response.request().url()}" }
+
+        val errorResponse = tryParseErrorResponse(response)
+
+        return when {
+            status in 400..499 -> handle4xxError(status, errorResponse, methodKey)
+            status in 500..599 -> handle5xxError(status, errorResponse, methodKey, response)
+            else -> defaultDecoder.decode(methodKey, response)
+        }
+    }
+
+    private fun handle4xxError(status: Int, errorResponse: ErrorResponse?, methodKey: String): BusinessException {
+        logger.error { "[FEIGN_4XX] methodKey=$methodKey, status=$status, code=${errorResponse?.code}" }
+        return when (status) {
+            401 -> BusinessException(
+                ErrorCode.INTERNAL_API_UNAUTHORIZED,
+                errorResponse?.message ?: ErrorCode.INTERNAL_API_UNAUTHORIZED.message
+            )
+            404 -> BusinessException(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                errorResponse?.message ?: ErrorCode.RESOURCE_NOT_FOUND.message
+            )
+            else -> BusinessException(
+                ErrorCode.INVALID_INPUT,
+                errorResponse?.message ?: ErrorCode.INVALID_INPUT.message
+            )
+        }
+    }
+
+    private fun handle5xxError(
+        status: Int,
+        errorResponse: ErrorResponse?,
+        methodKey: String,
+        response: Response
+    ): RetryableException {
+        logger.error { "[FEIGN_5XX] methodKey=$methodKey, status=$status, code=${errorResponse?.code}" }
+        return RetryableException(
+            status,
+            errorResponse?.message ?: "Internal server error from upstream service",
+            response.request().httpMethod(),
+            null as Long?,
+            response.request()
+        )
+    }
+
+    private fun tryParseErrorResponse(response: Response): ErrorResponse? {
+        return try {
+            response.body()?.asInputStream()?.use { stream ->
+                objectMapper.readValue(stream, ErrorResponse::class.java)
+            }
+        } catch (e: IOException) {
+            logger.debug { "[FEIGN_ERROR_PARSE] Failed to parse error response body: ${e.message}" }
+            null
+        }
+    }
+}

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/kafka/KafkaErrorHandlerConfig.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/kafka/KafkaErrorHandlerConfig.kt
@@ -1,6 +1,7 @@
 package com.ticketqueue.common.kafka
 
 import com.ticketqueue.common.kafka.KafkaTopicConfig
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization.StringSerializer
 import org.springframework.beans.factory.annotation.Value
@@ -44,7 +45,7 @@ class KafkaErrorHandlerConfig {
         return DeadLetterPublishingRecoverer(dlqKafkaTemplate) { record, _ ->
             val originalTopic = record.topic()
             val dlqTopic = KafkaTopicConfig.resolveDlqTopic(originalTopic)
-            log.warn("Sending failed record to DLQ: {} -> {}", originalTopic, dlqTopic)
+            logger.warn { "Sending failed record to DLQ: $originalTopic -> $dlqTopic" }
             org.apache.kafka.common.TopicPartition(dlqTopic, -1)
         }
     }

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/security/InternalApiKeyValidator.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/security/InternalApiKeyValidator.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class InternalApiKeyValidator(
-    @Value("\${internal_api_key:}")
+    @Value("\${internal.api.key:}")
     private val internalApiKey: String
 ) {
     private val logger = KotlinLogging.logger {}

--- a/backend/common/src/test/kotlin/com/ticketqueue/common/config/FeignConfigTest.kt
+++ b/backend/common/src/test/kotlin/com/ticketqueue/common/config/FeignConfigTest.kt
@@ -1,0 +1,37 @@
+package com.ticketqueue.common.config
+
+import com.ticketqueue.common.security.InternalApiKeyValidator
+import feign.RequestTemplate
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldNotBe
+
+class FeignConfigTest : DescribeSpec({
+
+    val apiKey = "test-internal-api-key-for-unit-test"
+    val feignConfig = FeignConfig(apiKey)
+
+    describe("FeignConfig - RequestInterceptor") {
+        context("Feign 요청 전송 시") {
+            it("모든 요청에 X-Service-Api-Key 헤더가 자동으로 추가된다") {
+                val interceptor = feignConfig.internalApiKeyRequestInterceptor()
+                val template = RequestTemplate()
+
+                interceptor.apply(template)
+
+                val headers = template.headers()
+                headers[InternalApiKeyValidator.HEADER_NAME] shouldNotBe null
+                headers[InternalApiKeyValidator.HEADER_NAME]!! shouldContain apiKey
+            }
+
+            it("헤더 이름은 X-Service-Api-Key 상수와 일치한다") {
+                val interceptor = feignConfig.internalApiKeyRequestInterceptor()
+                val template = RequestTemplate()
+
+                interceptor.apply(template)
+
+                template.headers().keys shouldContain InternalApiKeyValidator.HEADER_NAME
+            }
+        }
+    }
+})

--- a/backend/common/src/test/kotlin/com/ticketqueue/common/config/FeignErrorDecoderTest.kt
+++ b/backend/common/src/test/kotlin/com/ticketqueue/common/config/FeignErrorDecoderTest.kt
@@ -1,0 +1,120 @@
+package com.ticketqueue.common.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.ticketqueue.common.exception.BusinessException
+import com.ticketqueue.common.exception.ErrorCode
+import feign.Request
+import feign.Response
+import feign.RetryableException
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.nio.charset.StandardCharsets
+
+class FeignErrorDecoderTest : DescribeSpec({
+
+    val objectMapper = ObjectMapper().registerKotlinModule()
+    val decoder = FeignErrorDecoder(objectMapper)
+    val methodKey = "EventClient#getSoldSeats(String)"
+
+    fun buildRequest(): Request = Request.create(
+        Request.HttpMethod.GET,
+        "http://event-service/internal/seats/status/123",
+        emptyMap(),
+        null,
+        StandardCharsets.UTF_8,
+        null
+    )
+
+    fun buildResponse(status: Int, body: String? = null): Response =
+        Response.builder()
+            .status(status)
+            .request(buildRequest())
+            .headers(emptyMap())
+            .body(body, StandardCharsets.UTF_8)
+            .build()
+
+    describe("FeignErrorDecoder - 4xx 응답") {
+        context("401 응답") {
+            it("INTERNAL_API_UNAUTHORIZED BusinessException을 throw한다") {
+                val ex = decoder.decode(methodKey, buildResponse(401))
+                ex.shouldBeInstanceOf<BusinessException>()
+                (ex as BusinessException).errorCode shouldBe ErrorCode.INTERNAL_API_UNAUTHORIZED
+            }
+        }
+
+        context("404 응답") {
+            it("RESOURCE_NOT_FOUND BusinessException을 throw한다") {
+                val ex = decoder.decode(methodKey, buildResponse(404))
+                ex.shouldBeInstanceOf<BusinessException>()
+                (ex as BusinessException).errorCode shouldBe ErrorCode.RESOURCE_NOT_FOUND
+            }
+        }
+
+        context("400 응답") {
+            it("INVALID_INPUT BusinessException을 throw한다") {
+                val ex = decoder.decode(methodKey, buildResponse(400))
+                ex.shouldBeInstanceOf<BusinessException>()
+                (ex as BusinessException).errorCode shouldBe ErrorCode.INVALID_INPUT
+            }
+        }
+
+        context("403 응답") {
+            it("INVALID_INPUT BusinessException을 throw한다") {
+                val ex = decoder.decode(methodKey, buildResponse(403))
+                ex.shouldBeInstanceOf<BusinessException>()
+                (ex as BusinessException).errorCode shouldBe ErrorCode.INVALID_INPUT
+            }
+        }
+    }
+
+    describe("FeignErrorDecoder - 5xx 응답") {
+        context("500 응답") {
+            it("RetryableException을 throw한다 (재시도 가능)") {
+                val ex = decoder.decode(methodKey, buildResponse(500))
+                ex.shouldBeInstanceOf<RetryableException>()
+                (ex as RetryableException).status() shouldBe 500
+            }
+        }
+
+        context("503 응답") {
+            it("RetryableException을 throw한다 (재시도 가능)") {
+                val ex = decoder.decode(methodKey, buildResponse(503))
+                ex.shouldBeInstanceOf<RetryableException>()
+            }
+        }
+    }
+
+    describe("FeignErrorDecoder - 응답 body 파싱") {
+        context("유효한 ErrorResponse JSON body") {
+            it("응답 body의 message를 사용한다") {
+                val body = """{"code":"INTERNAL_API_UNAUTHORIZED","message":"내부 API 인증 실패","timestamp":"2026-01-01T00:00:00","traceId":"abc"}"""
+                val ex = decoder.decode(methodKey, buildResponse(401, body)) as BusinessException
+                ex.message shouldBe "내부 API 인증 실패"
+            }
+        }
+
+        context("body 파싱 실패 (invalid JSON)") {
+            it("ErrorCode 기본 message를 사용한다") {
+                val ex = decoder.decode(methodKey, buildResponse(401, "invalid-json")) as BusinessException
+                ex.message shouldBe ErrorCode.INTERNAL_API_UNAUTHORIZED.message
+            }
+        }
+
+        context("body 없음") {
+            it("ErrorCode 기본 message를 사용한다") {
+                val ex = decoder.decode(methodKey, buildResponse(404)) as BusinessException
+                ex.message shouldBe ErrorCode.RESOURCE_NOT_FOUND.message
+            }
+        }
+
+        context("5xx body 파싱") {
+            it("응답 body의 message를 RetryableException message로 사용한다") {
+                val body = """{"code":"INTERNAL_SERVER_ERROR","message":"서비스 내부 오류","timestamp":"2026-01-01T00:00:00","traceId":"abc"}"""
+                val ex = decoder.decode(methodKey, buildResponse(500, body)) as RetryableException
+                ex.message shouldBe "서비스 내부 오류"
+            }
+        }
+    }
+})

--- a/backend/payment-service/src/main/resources/application.yml
+++ b/backend/payment-service/src/main/resources/application.yml
@@ -64,7 +64,7 @@ feign:
     config:
       default:
         connect-timeout: 5000
-        read-timeout: 5000
+        read-timeout: 10000
       reservation-service:
         url: http://localhost:8084
 

--- a/backend/payment-service/src/main/resources/logback-spring.xml
+++ b/backend/payment-service/src/main/resources/logback-spring.xml
@@ -15,6 +15,7 @@
         <logger name="com.ticketqueue.payment" level="DEBUG"/>
         <logger name="org.hibernate.SQL" level="DEBUG"/>
         <logger name="io.github.resilience4j" level="DEBUG"/>
+        <logger name="feign" level="DEBUG"/>
     </springProfile>
 
     <!-- Profile: prod -->

--- a/backend/reservation-service/src/main/resources/application.yml
+++ b/backend/reservation-service/src/main/resources/application.yml
@@ -76,7 +76,7 @@ feign:
     config:
       default:
         connect-timeout: 5000
-        read-timeout: 5000
+        read-timeout: 10000
       event-service:
         url: http://localhost:8082
 

--- a/backend/reservation-service/src/main/resources/logback-spring.xml
+++ b/backend/reservation-service/src/main/resources/logback-spring.xml
@@ -14,6 +14,7 @@
         <!-- Service-specific logger levels -->
         <logger name="com.ticketqueue.reservation" level="DEBUG"/>
         <logger name="org.hibernate.SQL" level="DEBUG"/>
+        <logger name="feign" level="DEBUG"/>
     </springProfile>
 
     <!-- Profile: prod -->

--- a/backend/user-service/src/main/resources/logback-spring.xml
+++ b/backend/user-service/src/main/resources/logback-spring.xml
@@ -14,6 +14,7 @@
         <!-- Service-specific logger levels -->
         <logger name="org.hibernate.SQL" level="DEBUG"/>
         <logger name="com.ticketqueue.user" level="DEBUG"/>
+        <logger name="feign" level="DEBUG"/>
     </springProfile>
 
     <!-- Profile: prod -->


### PR DESCRIPTION
## Summary
- `InternalApiFeignConfig`를 `FeignConfig`로 대체하여 공통 Feign Client 설정 통합
- `FeignErrorDecoder` 추가: 4xx → `BusinessException`(즉시 실패), 5xx → `RetryableException`(재시도)
- 서비스 간 내부 API 호출 시 에러 처리 일관성 확보

## Changes
- **[COMMON] FeignConfig.kt 생성** (`InternalApiFeignConfig.kt` 대체)
  - `RequestInterceptor`: 모든 Feign 요청에 `X-Service-Api-Key` 헤더 자동 추가
  - `FeignErrorDecoder` Bean 등록
  - `Retryer.Default`: 지수 백오프 500ms→2s, 최대 3회 재시도 (5xx에만 적용)
  - `Logger.Level.FULL`: Feign 요청/응답 전체 로깅
- **[COMMON] FeignErrorDecoder.kt 생성**
  - `401` → `INTERNAL_API_UNAUTHORIZED`, `404` → `RESOURCE_NOT_FOUND`, 기타 4xx → `INVALID_INPUT` (즉시 실패)
  - `5xx` → `RetryableException` (Retryer 트리거)
  - 응답 body에서 `ErrorResponse` JSON 파싱 시도, 실패 시 기본 메시지 사용
- **[COMMON] InternalApiKeyValidator.kt** — property key `internal_api_key` → `internal.api.key` (YAML 네이밍 통일)
- **[reservation/payment-service] application.yml** — feign `read-timeout` 5,000ms → 10,000ms (Retryer 추가 여유 확보 + 시스템 내부 API 표준 timeout 10초 통일)
- **[reservation/payment/user-service] logback-spring.xml** — local 프로필에 `feign` DEBUG 로거 추가
- **[COMMON] FeignConfigTest.kt, FeignErrorDecoderTest.kt 추가** — 단위 테스트 12개

## Test plan
- [x] `./gradlew :common:compileKotlin` 빌드 성공 확인
- [x] Reservation → Event 내부 API 호출 시 `X-Service-Api-Key` 헤더 포함 확인 — `FeignConfigTest` 단위 테스트로 검증
- [x] 잘못된 API Key로 호출 시 401 → `BusinessException` 즉시 throw (재시도 없음) 확인 — `FeignErrorDecoderTest` 단위 테스트로 검증
- [x] Event Service 중단 상태에서 호출 시 5xx → `RetryableException` throw 확인 — `FeignErrorDecoderTest` 단위 테스트로 검증

Closes #91 