### PR TITLE
feat: 공연장/홀 관리 API 구현 #32

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## 프로젝트 개요
 
-**Ticket Queue**는 대규모 트래픽을 처리하는 콘서트 티켓팅 시스템입니다. MSA(마이크로서비스 아키텍처)를 기반으로 하며, 현재 **설계 단계(Design Phase)**에 있습니다.
+**Ticket Queue**는 대규모 트래픽을 처리하는 콘서트 티켓팅 시스템입니다. MSA(마이크로서비스 아키텍처)를 기반으로 하며, 현재 **구현 진행 단계(Implementation Phase)**에 있습니다.
 
 ### 핵심 목표
 - K-pop 콘서트와 같은 높은 동시성 환경에서의 공정한 티켓 판매
@@ -79,14 +79,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## 기술 스택
 
 ### Backend
-- **Language**: Kotlin (Java 21 기반)
-- **Framework**: Spring Boot 3.5.10, Spring Cloud Gateway
-- **Build Tool**: Gradle (Kotlin DSL)
+- **Language**: Kotlin 2.1.0 (Java 21 기반)
+- **Framework**: Spring Boot 3.5.10, Spring Cloud Gateway (Spring Cloud 2025.0.1)
+- **Build Tool**: Gradle (Kotlin DSL), KSP (Kotlin Symbol Processing)
 - **Database**: PostgreSQL 18 (단일 인스턴스, 스키마 분리)
+- **ORM**: Spring Data JPA + QueryDSL 6.12 (openfeign fork, KSP 코드 생성)
 - **Cache**: Valkey 8.1.5 (Redis 대체, 캐시, 대기열, 분산 락)
-- **Messaging**: Apache Kafka 4.1.1 KRaft 모드 (이벤트 스트리밍, Zookeeper 불필요)
-- **Distributed Lock**: Redisson
-- **Resilience**: Resilience4j (Circuit Breaker, Rate Limiter)
+- **Messaging**: Apache Kafka (KRaft 모드, Zookeeper 불필요)
+- **Distributed Lock**: Redisson 3.40.2
+- **Resilience**: Resilience4j 2.2.0 (Circuit Breaker, Rate Limiter)
+- **JWT**: JJWT 0.12.6
+- **Cloud**: Spring Cloud AWS 3.4.2 (Secrets Manager 연동)
 
 ### Frontend (미구현)
 - Next.js 16+ (Vercel 배포, GitHub 연동 자동 CI/CD)
@@ -288,9 +291,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### 암호화
 - **비밀번호**: BCrypt 해싱 (REQ-AUTH-014)
-- **개인정보**: 평문 저장 (포트폴리오 범위 내 아키텍처 검증 집중)
-  - 실제 상용 환경에서는 TDE 또는 컬럼 암호화 필요
-- **1인 1계정 강제**: `ci` 컬럼 Unique Constraint
+- **개인정보**: AES 암호화 적용 (`EncryptionService.encrypt()`) — 이메일, 이름, 전화번호, CI
+- **검색용 해시**: SHA-256 해시(`EncryptionService.hash()`) — emailHash, phoneHash, ciHash (중복 체크용)
+- **1인 1계정 강제**: `ci_hash` 컬럼 Unique Constraint
 
 ## 개발 환경 설정 및 실행
 
@@ -378,10 +381,10 @@ ticket-queue/
 - **Commit Messages**: Conventional Commits 형식
   - `feat:`, `fix:`, `refactor:`, `chore:`, `docs:` 등
 
-#### 테스트 전략 (계획)
-- **Unit Tests**: JUnit 5, Mockito, Kotest
-- **Integration Tests**: TestContainers (PostgreSQL, Valkey, Kafka)
-- **Load Testing**: k6 (대기열 및 예매 시나리오 집중)
+#### 테스트 전략
+- **Unit Tests**: JUnit 5, MockK, Kotest (Mockito 대신 MockK 사용)
+- **Integration Tests**: TestContainers (PostgreSQL, Kafka) — common 모듈 Outbox 테스트 구현 완료
+- **Load Testing**: k6 (대기열 및 예매 시나리오 집중, 미구현)
 
 #### 브랜치 전략 (계획)
 - **main**: 프로덕션 릴리스
@@ -432,28 +435,25 @@ ticket-queue/
 
 ## 현재 상태 및 다음 단계
 
-**현재**: 설계 및 문서화 완료 (Draft 1.1.0)
-- 110개 요구사항 정의 완료 (필수 74개, 선택 36개)
-- 최근 업데이트:
-  - **API 명세서 작성 완료**: 6개 서비스별 상세 API 명세 (`docs/specification/`)
-  - 데이터 아키텍처: User/Event/Reservation/Payment 스키마 상세 설계 완료
-  - 메시징 아키텍처: DLQ 예외 분류 및 재시도 전략 구체화
-  - 공통 규약: 날짜/시간 형식, 에러 응답 형식 표준화
+**현재**: 구현 진행 중 (Implementation Phase, feat/32 브랜치)
 
-**다음 단계**:
-1. 각 서비스의 Spring Boot 프로젝트 생성 및 기본 구조 설정
-2. PostgreSQL 스키마 및 ERD 기반 JPA Entity 구현
-   - `common.outbox_events`, `common.processed_events` 우선 구현
-3. Redis 및 Kafka 연동 설정
-   - Redisson 분산 락 설정
-   - Kafka Producer/Consumer 설정 (멱등성, 수동 커밋)
-4. API Gateway 라우팅 및 JWT 검증 필터 구현
-5. Queue Service 대기열 로직 구현 (Redis Sorted Set, Lua 스크립트)
-6. Reservation Service 분산 락 및 좌석 선점 로직 구현
-   - `hold_seats:{scheduleId}` SET 관리 로직
-7. Payment Service PortOne 연동 및 SAGA 패턴 구현
-   - Outbox Pattern 적용
-8. 통합 테스트 및 부하 테스트 (k6)
+### ✅ 완료된 구현
+- **Common 모듈** — Outbox Pattern(OutboxPollerService, OutboxCleanupBatchService), Kafka 멱등성(IdempotentConsumerTemplate, ProcessedEventService, KafkaErrorHandlerConfig), 공통 이벤트 스키마(BaseEvent/PaymentEvents/ReservationEvents), 내부 API 보안(InternalApiKeyValidator/InternalApiAuthInterceptor), 공통 설정(JacksonConfig, QuerydslConfig, TimeZoneConfig, TraceIdFilter)
+- **Event Service** — Venue/Hall CRUD API (Controller, Service, Repository, QueryDSL), JPA Entity (Event, EventSchedule, Hall, Venue, Seat), Kafka Consumer 설정, Redis 설정, 내부 API 보안 필터
+- **User Service** — 회원가입 API (reCAPTCHA, AES 암호화, 해시 중복 체크), AuthController/AuthService, SecurityConfig
+- **API Gateway** — TraceId 전파 필터, 기본 프로젝트 구조
+- **Payment Service** — Kafka/Resilience4j/WebClient 기본 설정
+- **Queue Service** — Redis/Queue 기본 설정 (QueueConfig, QueueProperties)
+- **Reservation Service** — Kafka/Redisson 기본 설정
+
+### 🔄 진행 필요
+1. **User Service**: 로그인/로그아웃/토큰 갱신 API, JWT 발급, Refresh Token Rotation
+2. **API Gateway**: JWT 검증 필터, 라우팅 설정 (Issue #13~#19), Circuit Breaker
+3. **Event Service**: 공연(Event)/회차(EventSchedule)/좌석(Seat) CRUD API, Redis 캐싱
+4. **Queue Service**: 대기열 진입/상태/이탈 API (Redis Sorted Set, Lua 스크립트), Queue Token 발급
+5. **Reservation Service**: 좌석 선점 API (Redisson 분산 락), 예매 조회/관리, Kafka Consumer
+6. **Payment Service**: PortOne 연동, 결제 요청/승인 API, SAGA 패턴, Outbox Pattern 적용
+7. **통합 테스트 및 부하 테스트** (k6)
 
 ## 핵심 설계 결정 (ADR 요약)
 
@@ -464,7 +464,7 @@ ticket-queue/
 5. **단일 Queue Token + Reservation 기반 결제 권한**: qp_token 제거, 결제 권한은 Reservation(PENDING + hold_expires_at) 검증
 6. **DLQ 재시도 전략**: 지수 백오프 3회, 재시도 불가능 예외는 즉시 DLQ
 7. **보상 토픽 제외**: `payment.events`의 PaymentFailed가 보상 트리거 (YAGNI 원칙)
-8. **개인정보 평문 저장**: 암호화 복잡도 제거, 아키텍처/로직 검증 집중 (포트폴리오 최적화)
+8. **개인정보 AES 암호화 + 해시**: 이메일/이름/전화번호/CI는 AES 암호화 저장, 검색/중복 체크용 해시(emailHash 등) 별도 관리
 
 ---
 

--- a/backend/common/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
@@ -49,5 +49,13 @@ enum class ErrorCode(
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT_NOT_FOUND", "존재하지 않는 공연입니다."),
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE_NOT_FOUND", "존재하지 않는 공연 회차입니다."),
     TICKET_SALE_NOT_STARTED(HttpStatus.BAD_REQUEST, "TICKET_SALE_NOT_STARTED", "티켓 판매가 아직 시작되지 않았습니다."),
-    TICKET_SALE_ENDED(HttpStatus.BAD_REQUEST, "TICKET_SALE_ENDED", "티켓 판매가 종료되었습니다.")
+    TICKET_SALE_ENDED(HttpStatus.BAD_REQUEST, "TICKET_SALE_ENDED", "티켓 판매가 종료되었습니다."),
+    VENUE_NOT_FOUND(HttpStatus.NOT_FOUND, "VENUE_NOT_FOUND", "존재하지 않는 공연장입니다."),
+    VENUE_HAS_HALLS(HttpStatus.CONFLICT, "VENUE_HAS_HALLS", "홀이 존재하는 공연장은 삭제할 수 없습니다."),
+    VENUE_HAS_EVENTS(HttpStatus.CONFLICT, "VENUE_HAS_EVENTS", "공연이 존재하는 공연장은 삭제할 수 없습니다."),
+    HALL_NOT_FOUND(HttpStatus.NOT_FOUND, "HALL_NOT_FOUND", "존재하지 않는 홀입니다."),
+    HALL_NAME_DUPLICATE(HttpStatus.CONFLICT, "HALL_NAME_DUPLICATE", "동일 공연장 내 중복된 홀 이름입니다."),
+    HALL_HAS_EVENTS(HttpStatus.CONFLICT, "HALL_HAS_EVENTS", "공연이 존재하는 홀은 삭제할 수 없습니다."),
+    INVALID_SEAT_TEMPLATE(HttpStatus.INTERNAL_SERVER_ERROR, "SEAT_TEMPLATE_INVALID", "좌석 템플릿 데이터가 손상되었습니다."),
+    INVALID_SEAT_TEMPLATE_MAPPING(HttpStatus.BAD_REQUEST, "SEAT_TEMPLATE_MAPPING_INVALID", "좌석 템플릿의 행-등급 매핑이 올바르지 않습니다.")
 }

--- a/backend/event-service/build.gradle.kts
+++ b/backend/event-service/build.gradle.kts
@@ -20,4 +20,5 @@ dependencies {
     // Test
     testImplementation(libs.bundles.test.base)
     testImplementation(libs.bundles.testcontainers)
+    testImplementation(libs.spring.security.test)
 }

--- a/backend/event-service/build.gradle.kts
+++ b/backend/event-service/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.kotlin.jpa)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.spring.dependency.management)
 }
@@ -9,6 +10,9 @@ plugins {
 dependencies {
     // Common module
     implementation(project(":common"))
+
+    // QueryDSL - Q클래스 생성 (querydsl-jpa는 common api()로 전파됨)
+    ksp(libs.querydsl.ksp.codegen)
 
     // Spring Boot
     implementation(libs.spring.boot.starter.data.redis)

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/GatewayAuthFilter.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/GatewayAuthFilter.kt
@@ -1,0 +1,54 @@
+package com.ticketqueue.event.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * API Gateway 인증 헤더 기반 필터
+ *
+ * API Gateway에서 JWT 검증 후 전달하는 사용자 정보 헤더를 파싱하여
+ * Spring Security의 SecurityContext에 인증 객체를 설정한다.
+ *
+ * 동작 흐름:
+ * 1. 클라이언트 -> API Gateway: JWT 토큰 전송
+ * 2. API Gateway: JWT 검증 후 X-User-Id, X-User-Role 헤더 추가
+ * 3. API Gateway -> Event Service: 헤더 포함 요청 전달
+ * 4. 이 필터: 헤더를 읽어 SecurityContext에 인증 정보 설정
+ *
+ * 헤더가 없는 경우(비인증 요청) SecurityContext를 설정하지 않으며,
+ * SecurityConfig의 permitAll() 규칙에 의해 공개 API 접근이 허용된다.
+ */
+@Component
+class GatewayAuthFilter : OncePerRequestFilter() {
+
+    /**
+     * 요청마다 한 번 실행되는 필터 로직
+     *
+     * X-User-Id와 X-User-Role 헤더가 모두 존재할 때만 인증 객체를 생성한다.
+     * Role 값에 "ROLE_" 접두사를 붙여 Spring Security 권한 형식에 맞춘다.
+     * (예: "ADMIN" -> "ROLE_ADMIN")
+     */
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val userId = request.getHeader("X-User-Id")
+        val userRole = request.getHeader("X-User-Role")
+
+        if (userId != null && userRole != null) {
+            // Spring Security 권한 형식으로 변환 후 인증 객체 생성
+            val authorities = listOf(SimpleGrantedAuthority("ROLE_$userRole"))
+            val authentication = UsernamePasswordAuthenticationToken(userId, null, authorities)
+            SecurityContextHolder.getContext().authentication = authentication
+        }
+
+        filterChain.doFilter(request, response)
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/SecurityConfig.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/SecurityConfig.kt
@@ -1,0 +1,107 @@
+package com.ticketqueue.event.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.dto.ErrorResponse
+import com.ticketqueue.common.exception.ErrorCode
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+/**
+ * Spring Security 설정
+ *
+ * Event Service의 보안 정책을 정의한다.
+ * - CSRF 비활성화: API 서버이므로 상태 비저장(Stateless) 방식 사용
+ * - 세션 미사용: JWT 기반 인증을 사용하므로 서버 세션 불필요
+ * - GatewayAuthFilter를 UsernamePasswordAuthenticationFilter 앞에 등록하여
+ *   API Gateway가 전달한 헤더 기반 인증을 처리
+ * - 커스텀 에러 핸들러: 401/403 응답을 프로젝트 표준 ErrorResponse 형식으로 반환
+ *
+ * @see GatewayAuthFilter
+ */
+@Configuration
+@EnableWebSecurity
+class SecurityConfig(
+    private val gatewayAuthFilter: GatewayAuthFilter,
+    private val objectMapper: ObjectMapper
+) {
+
+    /**
+     * 보안 필터 체인 구성
+     *
+     * 엔드포인트별 권한 규칙:
+     * - GET /venues/.. : 공개 (인증 불필요) - 공연장/홀 조회
+     * - POST, PATCH, DELETE /venues/.. : ADMIN 권한 필요 - 공연장/홀 생성/수정/삭제
+     * - /actuator/.. : 공개 (헬스체크, 모니터링용)
+     * - 그 외 모든 요청: 인증 필요
+     */
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        return http
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { auth ->
+                auth
+                    // 공연장/홀 조회 API - 공개
+                    .requestMatchers(HttpMethod.GET, "/venues/**").permitAll()
+                    // 공연장/홀 변경 API - ADMIN 전용
+                    .requestMatchers(HttpMethod.POST, "/venues/**").hasRole("ADMIN")
+                    .requestMatchers(HttpMethod.PATCH, "/venues/**").hasRole("ADMIN")
+                    .requestMatchers(HttpMethod.DELETE, "/venues/**").hasRole("ADMIN")
+                    // 액추에이터 - 공개
+                    .requestMatchers("/actuator/**").permitAll()
+                    .anyRequest().authenticated()
+            }
+            .exceptionHandling { exceptions ->
+                exceptions
+                    .authenticationEntryPoint(customAuthenticationEntryPoint())
+                    .accessDeniedHandler(customAccessDeniedHandler())
+            }
+            .addFilterBefore(gatewayAuthFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .build()
+    }
+
+    /**
+     * 401 Unauthorized 에러 핸들러
+     *
+     * 인증 실패 시 프로젝트 표준 ErrorResponse JSON 형식으로 반환한다.
+     */
+    private fun customAuthenticationEntryPoint(): AuthenticationEntryPoint {
+        return AuthenticationEntryPoint { request: HttpServletRequest, response: HttpServletResponse, authException: AuthenticationException ->
+            response.status = HttpServletResponse.SC_UNAUTHORIZED
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            response.characterEncoding = "UTF-8"
+
+            val errorResponse = ErrorResponse.of(ErrorCode.UNAUTHORIZED)
+            response.writer.write(objectMapper.writeValueAsString(errorResponse))
+        }
+    }
+
+    /**
+     * 403 Forbidden 에러 핸들러
+     *
+     * 인가 실패 시 프로젝트 표준 ErrorResponse JSON 형식으로 반환한다.
+     */
+    private fun customAccessDeniedHandler(): AccessDeniedHandler {
+        return AccessDeniedHandler { request: HttpServletRequest, response: HttpServletResponse, accessDeniedException: AccessDeniedException ->
+            response.status = HttpServletResponse.SC_FORBIDDEN
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            response.characterEncoding = "UTF-8"
+
+            val errorResponse = ErrorResponse.of(ErrorCode.FORBIDDEN)
+            response.writer.write(objectMapper.writeValueAsString(errorResponse))
+        }
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/SecurityConfig.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/SecurityConfig.kt
@@ -54,6 +54,8 @@ class SecurityConfig(
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests { auth ->
                 auth
+                    // 내부 서비스 간 통신 API - Spring Security 공개 (API Key 인증은 InternalApiAuthInterceptor에서 처리)
+                    .requestMatchers("/internal/**").permitAll()
                     // 공연장/홀 조회 API - 공개
                     .requestMatchers(HttpMethod.GET, "/venues/**").permitAll()
                     // 공연장/홀 변경 API - ADMIN 전용

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/SecurityConfig.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/SecurityConfig.kt
@@ -62,8 +62,8 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.POST, "/venues/**").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.PATCH, "/venues/**").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.DELETE, "/venues/**").hasRole("ADMIN")
-                    // 액추에이터 - 공개
-                    .requestMatchers("/actuator/**").permitAll()
+                    // 액추에이터 - 헬스체크/정보만 공개
+                    .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                     .anyRequest().authenticated()
             }
             .exceptionHandling { exceptions ->

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/HallController.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/HallController.kt
@@ -1,0 +1,83 @@
+package com.ticketqueue.event.controller
+
+import com.ticketqueue.event.dto.HallDto
+import com.ticketqueue.event.service.HallService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+/**
+ * 홀(Hall) 관리 REST API 컨트롤러
+ *
+ * 공연장 하위 리소스로 중첩 URL 구조를 사용한다: /venues/{venueId}/halls
+ *
+ * 엔드포인트 목록:
+ * - POST   /venues/{venueId}/halls           : 홀 생성 (ADMIN 전용) - REQ-EVT-012
+ * - GET    /venues/{venueId}/halls           : 홀 목록 조회 (공개) - REQ-EVT-013
+ * - GET    /venues/{venueId}/halls/{hallId}  : 홀 상세 조회 (공개) - REQ-EVT-014
+ * - PATCH  /venues/{venueId}/halls/{hallId}  : 홀 수정 (ADMIN 전용) - REQ-EVT-015
+ * - DELETE /venues/{venueId}/halls/{hallId}  : 홀 삭제 (ADMIN 전용) - REQ-EVT-016
+ *
+ * GET 요청은 인증 없이 접근 가능하며, 변경 작업은 ADMIN 권한이 필요하다.
+ *
+ * @see SecurityConfig
+ */
+@RestController
+@RequestMapping("/venues/{venueId}/halls")
+class HallController(
+    private val hallService: HallService
+) {
+
+    /** 홀 생성 (REQ-EVT-012) - ADMIN 권한 필요, 좌석 템플릿 검증 후 JSON 저장 */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createHall(
+        @PathVariable venueId: UUID,
+        @Valid @RequestBody request: HallDto.CreateRequest
+    ): HallDto.Response {
+        return hallService.createHall(venueId, request)
+    }
+
+    /** 홀 목록 조회 (REQ-EVT-013) - 공개 API */
+    @GetMapping
+    fun getHalls(@PathVariable venueId: UUID): List<HallDto.Response> {
+        return hallService.getHalls(venueId)
+    }
+
+    /** 홀 상세 조회 (REQ-EVT-014) - 공개 API, 좌석 템플릿 포함 */
+    @GetMapping("/{hallId}")
+    fun getHall(
+        @PathVariable venueId: UUID,
+        @PathVariable hallId: UUID
+    ): HallDto.DetailResponse {
+        return hallService.getHall(venueId, hallId)
+    }
+
+    /** 홀 부분 수정 (REQ-EVT-015) - ADMIN 권한 필요, 이름 변경 시 중복 검증 */
+    @PatchMapping("/{hallId}")
+    fun updateHall(
+        @PathVariable venueId: UUID,
+        @PathVariable hallId: UUID,
+        @Valid @RequestBody request: HallDto.UpdateRequest
+    ): HallDto.UpdateResponse {
+        return hallService.updateHall(venueId, hallId, request)
+    }
+
+    /** 홀 삭제 (REQ-EVT-016) - ADMIN 권한 필요, 연관 이벤트 존재 시 삭제 불가 */
+    @DeleteMapping("/{hallId}")
+    fun deleteHall(
+        @PathVariable venueId: UUID,
+        @PathVariable hallId: UUID
+    ): HallDto.DeleteResponse {
+        return hallService.deleteHall(venueId, hallId)
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/VenueController.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/VenueController.kt
@@ -1,0 +1,84 @@
+package com.ticketqueue.event.controller
+
+import com.ticketqueue.common.dto.PageResponse
+import com.ticketqueue.event.dto.VenueDto
+import com.ticketqueue.event.service.VenueService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+/**
+ * 공연장(Venue) 관리 REST API 컨트롤러
+ *
+ * 엔드포인트 목록:
+ * - POST   /venues           : 공연장 생성 (ADMIN 전용) - REQ-EVT-007
+ * - GET    /venues           : 공연장 목록 조회 (공개) - REQ-EVT-008
+ * - GET    /venues/{venueId} : 공연장 상세 조회 (공개) - REQ-EVT-009
+ * - PATCH  /venues/{venueId} : 공연장 수정 (ADMIN 전용) - REQ-EVT-010
+ * - DELETE /venues/{venueId} : 공연장 삭제 (ADMIN 전용) - REQ-EVT-011
+ *
+ * GET 요청은 인증 없이 접근 가능하며, 변경 작업(POST/PATCH/DELETE)은 ADMIN 권한이 필요하다.
+ * 권한 규칙은 SecurityConfig에서 정의된다.
+ *
+ * @see SecurityConfig
+ */
+@RestController
+@RequestMapping("/venues")
+class VenueController(
+    private val venueService: VenueService
+) {
+
+    /** 공연장 생성 (REQ-EVT-007) - ADMIN 권한 필요 */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createVenue(@Valid @RequestBody request: VenueDto.CreateRequest): VenueDto.Response {
+        return venueService.createVenue(request)
+    }
+
+    /** 공연장 목록 조회 (REQ-EVT-008) - 공개 API, 도시 필터링 및 페이징 지원 */
+    @GetMapping
+    fun getVenues(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int,
+        @RequestParam(required = false) city: String?
+    ): PageResponse<VenueDto.Response> {
+        val result = venueService.getVenues(page, size, city)
+        return PageResponse(
+            list = result.content,
+            page = result.number,
+            size = result.size,
+            totalElements = result.totalElements
+        )
+    }
+
+    /** 공연장 상세 조회 (REQ-EVT-009) - 공개 API, 소속 홀 목록 포함 */
+    @GetMapping("/{venueId}")
+    fun getVenue(@PathVariable venueId: UUID): VenueDto.DetailResponse {
+        return venueService.getVenue(venueId)
+    }
+
+    /** 공연장 부분 수정 (REQ-EVT-010) - ADMIN 권한 필요, PATCH로 null 필드는 무시 */
+    @PatchMapping("/{venueId}")
+    fun updateVenue(
+        @PathVariable venueId: UUID,
+        @Valid @RequestBody request: VenueDto.UpdateRequest
+    ): VenueDto.UpdateResponse {
+        return venueService.updateVenue(venueId, request)
+    }
+
+    /** 공연장 삭제 (REQ-EVT-011) - ADMIN 권한 필요, 연관 이벤트/홀 존재 시 삭제 불가 */
+    @DeleteMapping("/{venueId}")
+    fun deleteVenue(@PathVariable venueId: UUID): VenueDto.DeleteResponse {
+        return venueService.deleteVenue(venueId)
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/HallDto.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/HallDto.kt
@@ -1,0 +1,118 @@
+package com.ticketqueue.event.dto
+
+import com.ticketqueue.event.entity.Hall
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * 홀(Hall) API 요청/응답 DTO 모음
+ *
+ * - [CreateRequest] : POST 요청 - 홀 생성, seatTemplate을 DTO로 수신하여 Bean Validation 후 JSON 변환
+ * - [UpdateRequest] : PATCH 요청 - 모든 필드 nullable (부분 수정 지원)
+ * - [Response] : 목록 조회 응답 - seatTemplate 제외 (목록에서는 불필요)
+ * - [DetailResponse] : 상세 조회 응답 - seatTemplate 포함 (JSONB -> DTO 역직렬화)
+ * - [UpdateResponse] : 수정 응답 - updatedAt 포함
+ * - [DeleteResponse] : 삭제 응답 - 결과 메시지
+ */
+class HallDto {
+
+    /**
+     * 홀 생성 요청
+     *
+     * seatTemplate은 SeatTemplateDto 타입으로 수신하여 @Valid를 통해
+     * 중첩 검증(rows, seatsPerRow, gradeMapping)을 수행한 뒤,
+     * HallService에서 ObjectMapper로 JSON 문자열 변환하여 DB에 저장한다.
+     */
+    data class CreateRequest(
+        @field:NotBlank(message = "홀 이름은 필수입니다.")
+        val name: String,
+
+        @field:Min(value = 1, message = "수용 인원은 1 이상이어야 합니다.")
+        val capacity: Int,
+
+        @field:Valid
+        @field:NotNull(message = "좌석 템플릿은 필수입니다.")
+        val seatTemplate: SeatTemplateDto
+    )
+
+    /** 홀 수정 요청 - 모든 필드 nullable (PATCH 부분 수정, null 필드는 기존 값 유지) */
+    data class UpdateRequest(
+        @field:Size(min = 1, message = "홀 이름은 비어있을 수 없습니다.")
+        val name: String? = null,
+
+        @field:Min(value = 1, message = "수용 인원은 1 이상이어야 합니다.")
+        val capacity: Int? = null,
+
+        @field:Valid
+        val seatTemplate: SeatTemplateDto? = null
+    )
+
+    /** 홀 목록 조회 응답 - seatTemplate 제외 (목록에서는 경량 응답) */
+    data class Response(
+        val id: UUID,
+        val venueId: UUID,
+        val name: String,
+        val capacity: Int,
+        val createdAt: LocalDateTime
+    ) {
+        companion object {
+            fun from(hall: Hall): Response = Response(
+                id = hall.id!!,
+                venueId = hall.venue.id!!,
+                name = hall.name,
+                capacity = hall.capacity,
+                createdAt = hall.createdAt!!
+            )
+        }
+    }
+
+    /** 홀 상세 조회 응답 - seatTemplate(JSONB -> DTO 역직렬화), updatedAt 포함 */
+    data class DetailResponse(
+        val id: UUID,
+        val venueId: UUID,
+        val name: String,
+        val capacity: Int,
+        val seatTemplate: SeatTemplateDto,
+        val createdAt: LocalDateTime,
+        val updatedAt: LocalDateTime
+    ) {
+        companion object {
+            fun from(hall: Hall, seatTemplate: SeatTemplateDto): DetailResponse = DetailResponse(
+                id = hall.id!!,
+                venueId = hall.venue.id!!,
+                name = hall.name,
+                capacity = hall.capacity,
+                seatTemplate = seatTemplate,
+                createdAt = hall.createdAt!!,
+                updatedAt = hall.updatedAt!!
+            )
+        }
+    }
+
+    /** 홀 수정 응답 - 수정된 정보와 updatedAt 포함 */
+    data class UpdateResponse(
+        val id: UUID,
+        val name: String,
+        val capacity: Int,
+        val updatedAt: LocalDateTime
+    ) {
+        companion object {
+            fun from(hall: Hall): UpdateResponse = UpdateResponse(
+                id = hall.id!!,
+                name = hall.name,
+                capacity = hall.capacity,
+                updatedAt = hall.updatedAt!!
+            )
+        }
+    }
+
+    /** 홀 삭제 응답 */
+    data class DeleteResponse(
+        val message: String
+    )
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/SeatTemplateDto.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/SeatTemplateDto.kt
@@ -1,0 +1,27 @@
+package com.ticketqueue.event.dto
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotEmpty
+
+/**
+ * 좌석 템플릿 DTO
+ *
+ * 홀(Hall)의 좌석 배치 구조를 정의하는 검증용 DTO이다.
+ * 클라이언트에서 수신한 좌석 정보를 Bean Validation으로 검증한 뒤,
+ * HallService에서 ObjectMapper를 통해 JSON 문자열로 직렬화하여 DB JSONB 컬럼에 저장한다.
+ * 조회 시에는 JSONB 문자열을 다시 이 DTO로 역직렬화하여 응답한다.
+ *
+ * @property rows 좌석 행 식별자 목록 (예: ["A", "B", "C"])
+ * @property seatsPerRow 각 행당 좌석 수
+ * @property gradeMapping 행 -> 등급 매핑 (예: {"A": "VIP", "B": "R", "C": "S"})
+ */
+data class SeatTemplateDto(
+    @field:NotEmpty(message = "좌석 행 목록은 비어있을 수 없습니다.")
+    val rows: List<String>,
+
+    @field:Min(value = 1, message = "행당 좌석 수는 1 이상이어야 합니다.")
+    val seatsPerRow: Int,
+
+    @field:NotEmpty(message = "등급 매핑은 비어있을 수 없습니다.")
+    val gradeMapping: Map<String, String>
+)

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/VenueDto.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/VenueDto.kt
@@ -1,0 +1,127 @@
+package com.ticketqueue.event.dto
+
+import com.ticketqueue.event.entity.Hall
+import com.ticketqueue.event.entity.Venue
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * 공연장(Venue) API 요청/응답 DTO 모음
+ *
+ * - [CreateRequest] : POST 요청 - 공연장 생성 시 필수 필드 검증
+ * - [UpdateRequest] : PATCH 요청 - 모든 필드가 nullable (부분 수정 지원)
+ * - [Response] : 목록 조회 응답 - 기본 공연장 정보
+ * - [DetailResponse] : 상세 조회 응답 - 소속 홀 목록 포함
+ * - [UpdateResponse] : 수정 응답 - updatedAt 포함
+ * - [HallSummary] : 상세 조회 시 홀 요약 정보 (id, name, capacity만)
+ * - [DeleteResponse] : 삭제 응답 - 결과 메시지
+ */
+class VenueDto {
+
+    /** 공연장 생성 요청 - 모든 필드 필수 (@NotBlank 검증) */
+    data class CreateRequest(
+        @field:NotBlank(message = "공연장 이름은 필수입니다.")
+        val name: String,
+
+        @field:NotBlank(message = "주소는 필수입니다.")
+        val address: String,
+
+        @field:NotBlank(message = "도시는 필수입니다.")
+        val city: String
+    )
+
+    /** 공연장 수정 요청 - 모든 필드 nullable (PATCH 부분 수정, null 필드는 기존 값 유지) */
+    data class UpdateRequest(
+        @field:Size(min = 1, message = "공연장 이름은 비어있을 수 없습니다.")
+        val name: String? = null,
+
+        @field:Size(min = 1, message = "주소는 비어있을 수 없습니다.")
+        val address: String? = null,
+
+        @field:Size(min = 1, message = "도시는 비어있을 수 없습니다.")
+        val city: String? = null
+    )
+
+    /** 공연장 목록 조회 응답 - 기본 정보만 포함 */
+    data class Response(
+        val id: UUID,
+        val name: String,
+        val address: String,
+        val city: String,
+        val createdAt: LocalDateTime
+    ) {
+        companion object {
+            fun from(venue: Venue): Response = Response(
+                id = venue.id!!,
+                name = venue.name,
+                address = venue.address,
+                city = venue.city,
+                createdAt = venue.createdAt!!
+            )
+        }
+    }
+
+    /** 홀 요약 정보 - 공연장 상세 조회 시 소속 홀의 요약 정보 */
+    data class HallSummary(
+        val id: UUID,
+        val name: String,
+        val capacity: Int
+    ) {
+        companion object {
+            fun from(hall: Hall): HallSummary = HallSummary(
+                id = hall.id!!,
+                name = hall.name,
+                capacity = hall.capacity
+            )
+        }
+    }
+
+    /** 공연장 상세 조회 응답 - 소속 홀 목록(HallSummary), updatedAt 포함 */
+    data class DetailResponse(
+        val id: UUID,
+        val name: String,
+        val address: String,
+        val city: String,
+        val halls: List<HallSummary>,
+        val createdAt: LocalDateTime,
+        val updatedAt: LocalDateTime
+    ) {
+        companion object {
+            fun from(venue: Venue, halls: List<Hall>): DetailResponse = DetailResponse(
+                id = venue.id!!,
+                name = venue.name,
+                address = venue.address,
+                city = venue.city,
+                halls = halls.map { HallSummary.from(it) },
+                createdAt = venue.createdAt!!,
+                updatedAt = venue.updatedAt!!
+            )
+        }
+    }
+
+    /** 공연장 수정 응답 - 수정된 정보와 updatedAt 포함 */
+    data class UpdateResponse(
+        val id: UUID,
+        val name: String,
+        val address: String,
+        val city: String,
+        val updatedAt: LocalDateTime
+    ) {
+        companion object {
+            fun from(venue: Venue): UpdateResponse = UpdateResponse(
+                id = venue.id!!,
+                name = venue.name,
+                address = venue.address,
+                city = venue.city,
+                updatedAt = venue.updatedAt!!
+            )
+        }
+    }
+
+    /** 공연장 삭제 응답 */
+    data class DeleteResponse(
+        val message: String
+    )
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Hall.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Hall.kt
@@ -10,10 +10,22 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.type.SqlTypes
 import java.time.LocalDateTime
 import java.util.UUID
 
+/**
+ * 홀(Hall) 엔티티
+ *
+ * 공연장(Venue) 내부의 개별 공연 공간을 나타낸다.
+ * 각 홀은 고유한 좌석 배치 정보(seatTemplate)를 JSONB 형태로 저장하며,
+ * 이 템플릿은 공연(Event) 생성 시 실제 좌석 데이터의 원본이 된다.
+ *
+ * @see Venue
+ * @see SeatTemplateDto
+ */
 @Entity
 @Table(name = "halls", schema = "event_service")
 class Hall(
@@ -26,13 +38,14 @@ class Hall(
     val venue: Venue,
 
     @Column(nullable = false)
-    val name: String,
+    var name: String,
 
     @Column(nullable = false)
-    val capacity: Int,
+    var capacity: Int,
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "seat_template", columnDefinition = "jsonb", nullable = false)
-    val seatTemplate: String,
+    var seatTemplate: String,
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -42,6 +55,22 @@ class Hall(
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime? = null
 ) {
+    /**
+     * PATCH 요청을 위한 부분 업데이트
+     *
+     * null이 아닌 필드만 선택적으로 변경한다.
+     * seatTemplate은 이미 JSON 문자열로 직렬화된 상태로 전달받는다.
+     *
+     * @param name 변경할 홀 이름 (null이면 기존 값 유지)
+     * @param capacity 변경할 수용 인원 (null이면 기존 값 유지)
+     * @param seatTemplate 변경할 좌석 템플릿 JSON 문자열 (null이면 기존 값 유지)
+     */
+    fun update(name: String?, capacity: Int?, seatTemplate: String?) {
+        name?.let { this.name = it }
+        capacity?.let { this.capacity = it }
+        seatTemplate?.let { this.seatTemplate = it }
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Hall) return false

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Venue.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Venue.kt
@@ -14,6 +14,15 @@ import org.hibernate.annotations.UpdateTimestamp
 import java.time.LocalDateTime
 import java.util.UUID
 
+/**
+ * 공연장(Venue) 엔티티
+ *
+ * 콘서트, 뮤지컬 등의 공연이 열리는 물리적 장소를 나타낸다.
+ * 하나의 공연장은 여러 홀(Hall)을 포함할 수 있으며,
+ * 홀과는 1:N 관계로 CascadeType.PERSIST/MERGE를 통해 영속성을 전이한다.
+ *
+ * @see Hall
+ */
 @Entity
 @Table(name = "venues", schema = "event_service")
 class Venue(
@@ -22,13 +31,13 @@ class Venue(
     val id: UUID? = null,
 
     @Column(nullable = false)
-    val name: String,
+    var name: String,
 
     @Column(nullable = false)
-    val address: String,
+    var address: String,
 
     @Column(nullable = false)
-    val city: String,
+    var city: String,
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -41,6 +50,22 @@ class Venue(
     @OneToMany(mappedBy = "venue", cascade = [CascadeType.PERSIST, CascadeType.MERGE], fetch = FetchType.LAZY)
     val halls: MutableList<Hall> = mutableListOf()
 ) {
+    /**
+     * PATCH 요청을 위한 부분 업데이트
+     *
+     * null이 아닌 필드만 선택적으로 변경한다.
+     * Kotlin의 let 스코프 함수를 활용하여 null 파라미터는 기존 값을 유지한다.
+     *
+     * @param name 변경할 공연장 이름 (null이면 기존 값 유지)
+     * @param address 변경할 주소 (null이면 기존 값 유지)
+     * @param city 변경할 도시 (null이면 기존 값 유지)
+     */
+    fun update(name: String?, address: String?, city: String?) {
+        name?.let { this.name = it }
+        address?.let { this.address = it }
+        city?.let { this.city = it }
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Venue) return false

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepository.kt
@@ -6,4 +6,7 @@ import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface EventRepository : JpaRepository<Event, UUID>
+interface EventRepository : JpaRepository<Event, UUID> {
+    fun existsByVenueId(venueId: UUID): Boolean
+    fun existsByHallId(hallId: UUID): Boolean
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/HallRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/HallRepository.kt
@@ -6,10 +6,9 @@ import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface HallRepository : JpaRepository<Hall, UUID> {
+interface HallRepository : JpaRepository<Hall, UUID>, HallRepositoryCustom {
     fun findByVenueId(venueId: UUID): List<Hall>
     fun findByVenueIdAndId(venueId: UUID, id: UUID): Hall?
     fun existsByVenueId(venueId: UUID): Boolean
     fun existsByVenueIdAndName(venueId: UUID, name: String): Boolean
-    fun existsByVenueIdAndNameAndIdNot(venueId: UUID, name: String, id: UUID): Boolean
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/HallRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/HallRepository.kt
@@ -6,4 +6,10 @@ import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface HallRepository : JpaRepository<Hall, UUID>
+interface HallRepository : JpaRepository<Hall, UUID> {
+    fun findByVenueId(venueId: UUID): List<Hall>
+    fun findByVenueIdAndId(venueId: UUID, id: UUID): Hall?
+    fun existsByVenueId(venueId: UUID): Boolean
+    fun existsByVenueIdAndName(venueId: UUID, name: String): Boolean
+    fun existsByVenueIdAndNameAndIdNot(venueId: UUID, name: String, id: UUID): Boolean
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/HallRepositoryCustom.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/HallRepositoryCustom.kt
@@ -1,0 +1,7 @@
+package com.ticketqueue.event.repository
+
+import java.util.UUID
+
+interface HallRepositoryCustom {
+    fun existsByVenueIdAndNameExcluding(venueId: UUID, name: String, excludeHallId: UUID): Boolean
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/HallRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/HallRepositoryCustomImpl.kt
@@ -1,0 +1,29 @@
+package com.ticketqueue.event.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.ticketqueue.event.entity.QHall
+import java.util.UUID
+
+/**
+ * Hall Custom Repository 구현체
+ *
+ * 과도하게 긴 Spring Data JPA 메서드명(`existsByVenueIdAndNameAndIdNot`) 대신
+ * QueryDSL로 가독성 높은 쿼리를 제공한다.
+ */
+class HallRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory
+) : HallRepositoryCustom {
+
+    override fun existsByVenueIdAndNameExcluding(venueId: UUID, name: String, excludeHallId: UUID): Boolean {
+        val hall = QHall.hall
+
+        return queryFactory.selectOne()
+            .from(hall)
+            .where(
+                hall.venue.id.eq(venueId),
+                hall.name.eq(name),
+                hall.id.ne(excludeHallId)
+            )
+            .fetchFirst() != null
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/VenueRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/VenueRepository.kt
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface VenueRepository : JpaRepository<Venue, UUID> {
+interface VenueRepository : JpaRepository<Venue, UUID>, VenueRepositoryCustom {
     fun findByCity(city: String, pageable: Pageable): Page<Venue>
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/VenueRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/VenueRepository.kt
@@ -1,9 +1,13 @@
 package com.ticketqueue.event.repository
 
 import com.ticketqueue.event.entity.Venue
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface VenueRepository : JpaRepository<Venue, UUID>
+interface VenueRepository : JpaRepository<Venue, UUID> {
+    fun findByCity(city: String, pageable: Pageable): Page<Venue>
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/VenueRepositoryCustom.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/VenueRepositoryCustom.kt
@@ -1,0 +1,8 @@
+package com.ticketqueue.event.repository
+
+import com.ticketqueue.event.entity.Venue
+import java.util.UUID
+
+interface VenueRepositoryCustom {
+    fun findVenueWithHalls(venueId: UUID): Venue?
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/VenueRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/VenueRepositoryCustomImpl.kt
@@ -1,0 +1,28 @@
+package com.ticketqueue.event.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.ticketqueue.event.entity.QHall
+import com.ticketqueue.event.entity.QVenue
+import com.ticketqueue.event.entity.Venue
+import java.util.UUID
+
+/**
+ * Venue Custom Repository 구현체
+ *
+ * N+1 문제 해결을 위해 QueryDSL의 fetchJoin을 사용하여
+ * Venue와 Hall을 단일 쿼리로 조회한다.
+ */
+class VenueRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory
+) : VenueRepositoryCustom {
+
+    override fun findVenueWithHalls(venueId: UUID): Venue? {
+        val venue = QVenue.venue
+        val hall = QHall.hall
+
+        return queryFactory.selectFrom(venue)
+            .leftJoin(venue.halls, hall).fetchJoin()
+            .where(venue.id.eq(venueId))
+            .fetchOne()
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/HallService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/HallService.kt
@@ -1,0 +1,204 @@
+package com.ticketqueue.event.service
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.dto.HallDto
+import com.ticketqueue.event.dto.SeatTemplateDto
+import com.ticketqueue.event.entity.Hall
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.repository.EventRepository
+import com.ticketqueue.event.repository.HallRepository
+import com.ticketqueue.event.repository.VenueRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+/**
+ * 홀(Hall) 관리 서비스
+ *
+ * 공연장 내 홀의 CRUD 기능을 제공한다.
+ * 좌석 템플릿(SeatTemplateDto)은 DTO 형태로 수신하여 검증 후 JSON 문자열로 직렬화하여 저장하고,
+ * 조회 시에는 JSON 문자열을 다시 DTO로 역직렬화하여 반환한다.
+ * ObjectMapper를 통해 SeatTemplateDto <-> JSONB 변환을 처리한다.
+ */
+@Service
+@Transactional(readOnly = true)
+class HallService(
+    private val hallRepository: HallRepository,
+    private val venueRepository: VenueRepository,
+    private val eventRepository: EventRepository,
+    private val objectMapper: ObjectMapper
+) {
+
+    /**
+     * 홀 생성
+     *
+     * 1. 공연장 존재 여부 확인
+     * 2. 동일 공연장 내 홀 이름 중복 검증
+     * 3. 좌석 템플릿 비즈니스 검증 (행-등급 매핑 일관성)
+     * 4. SeatTemplateDto를 JSON 문자열로 직렬화하여 JSONB 컬럼에 저장
+     *
+     * @param venueId 홀이 속할 공연장 ID
+     * @param request 홀 생성 요청 (이름, 수용 인원, 좌석 템플릿)
+     * @return 생성된 홀 정보
+     * @throws EventException 공연장이 존재하지 않거나 (VENUE_NOT_FOUND),
+     *         동일 이름의 홀이 이미 존재하거나 (HALL_NAME_DUPLICATE),
+     *         좌석 템플릿 매핑이 올바르지 않을 경우 (INVALID_SEAT_TEMPLATE_MAPPING)
+     */
+    @Transactional
+    fun createHall(venueId: UUID, request: HallDto.CreateRequest): HallDto.Response {
+        val venue = venueRepository.findById(venueId)
+            .orElseThrow { EventException(ErrorCode.VENUE_NOT_FOUND) }
+
+        // 동일 공연장 내 홀 이름 중복 검증
+        if (hallRepository.existsByVenueIdAndName(venueId, request.name)) {
+            throw EventException(ErrorCode.HALL_NAME_DUPLICATE)
+        }
+
+        // 좌석 템플릿 비즈니스 검증
+        validateSeatTemplate(request.seatTemplate)
+
+        // SeatTemplateDto -> JSON 문자열로 직렬화하여 JSONB 컬럼에 저장
+        val seatTemplateJson = objectMapper.writeValueAsString(request.seatTemplate)
+        val hall = Hall(
+            venue = venue,
+            name = request.name,
+            capacity = request.capacity,
+            seatTemplate = seatTemplateJson
+        )
+        val saved = hallRepository.save(hall)
+        return HallDto.Response.from(saved)
+    }
+
+    /**
+     * 특정 공연장의 홀 목록 조회
+     *
+     * @param venueId 공연장 ID
+     * @return 해당 공연장에 속한 홀 목록
+     * @throws EventException 공연장이 존재하지 않을 경우 (VENUE_NOT_FOUND)
+     */
+    fun getHalls(venueId: UUID): List<HallDto.Response> {
+        if (!venueRepository.existsById(venueId)) {
+            throw EventException(ErrorCode.VENUE_NOT_FOUND)
+        }
+        return hallRepository.findByVenueId(venueId)
+            .map { HallDto.Response.from(it) }
+    }
+
+    /**
+     * 홀 상세 조회
+     *
+     * DB에 JSONB로 저장된 좌석 템플릿을 SeatTemplateDto로 역직렬화하여 응답에 포함한다.
+     *
+     * @param venueId 공연장 ID
+     * @param hallId 홀 ID
+     * @return 홀 상세 정보 (좌석 템플릿 포함)
+     * @throws EventException 홀이 존재하지 않거나 (HALL_NOT_FOUND),
+     *         좌석 템플릿 데이터가 손상된 경우 (INVALID_SEAT_TEMPLATE)
+     */
+    fun getHall(venueId: UUID, hallId: UUID): HallDto.DetailResponse {
+        val hall = findHallByVenueIdAndId(venueId, hallId)
+        // JSONB 문자열 -> SeatTemplateDto 역직렬화 (에러 핸들링)
+        val seatTemplate = try {
+            objectMapper.readValue(hall.seatTemplate, SeatTemplateDto::class.java)
+        } catch (e: JsonProcessingException) {
+            throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE)
+        }
+        return HallDto.DetailResponse.from(hall, seatTemplate)
+    }
+
+    /**
+     * 홀 부분 수정 (PATCH)
+     *
+     * 1. 이름 변경 요청 시에만 중복 검증 수행 (기존 이름과 다를 때만)
+     *    - 자기 자신을 제외한 동일 공연장 내 이름 중복 체크 (idNot 조건)
+     * 2. seatTemplate이 요청에 포함된 경우 비즈니스 검증 후 JSON 직렬화 수행
+     * 3. null 필드는 엔티티의 update()에서 무시됨 (기존 값 유지)
+     *
+     * @param venueId 공연장 ID
+     * @param hallId 수정할 홀 ID
+     * @param request 수정할 필드 (null인 필드는 변경하지 않음)
+     * @return 수정된 홀 정보
+     * @throws EventException 홀이 존재하지 않거나 (HALL_NOT_FOUND),
+     *         동일 이름의 홀이 이미 존재하거나 (HALL_NAME_DUPLICATE),
+     *         좌석 템플릿 매핑이 올바르지 않을 경우 (INVALID_SEAT_TEMPLATE_MAPPING)
+     */
+    @Transactional
+    fun updateHall(venueId: UUID, hallId: UUID, request: HallDto.UpdateRequest): HallDto.UpdateResponse {
+        val hall = findHallByVenueIdAndId(venueId, hallId)
+
+        // 이름이 실제로 변경될 때만 중복 검증 (자기 자신 제외)
+        if (request.name != null && request.name != hall.name) {
+            if (hallRepository.existsByVenueIdAndNameAndIdNot(venueId, request.name, hallId)) {
+                throw EventException(ErrorCode.HALL_NAME_DUPLICATE)
+            }
+        }
+
+        // seatTemplate이 요청에 포함된 경우 비즈니스 검증 및 JSON 직렬화
+        val seatTemplateJson = request.seatTemplate?.let {
+            validateSeatTemplate(it)
+            objectMapper.writeValueAsString(it)
+        }
+        hall.update(
+            name = request.name,
+            capacity = request.capacity,
+            seatTemplate = seatTemplateJson
+        )
+        return HallDto.UpdateResponse.from(hall)
+    }
+
+    /**
+     * 홀 삭제
+     *
+     * 삭제 전 해당 홀에 등록된 이벤트가 있는지 확인하여 데이터 무결성을 보장한다.
+     *
+     * @param venueId 공연장 ID
+     * @param hallId 삭제할 홀 ID
+     * @return 삭제 완료 메시지
+     * @throws EventException 홀이 존재하지 않거나 (HALL_NOT_FOUND),
+     *         연관된 이벤트가 있을 경우 (HALL_HAS_EVENTS)
+     */
+    @Transactional
+    fun deleteHall(venueId: UUID, hallId: UUID): HallDto.DeleteResponse {
+        val hall = findHallByVenueIdAndId(venueId, hallId)
+
+        // 이벤트가 등록된 홀은 삭제 불가
+        if (eventRepository.existsByHallId(hallId)) {
+            throw EventException(ErrorCode.HALL_HAS_EVENTS)
+        }
+
+        hallRepository.delete(hall)
+        return HallDto.DeleteResponse(message = "홀이 삭제되었습니다.")
+    }
+
+    private fun findHallByVenueIdAndId(venueId: UUID, hallId: UUID): Hall {
+        return hallRepository.findByVenueIdAndId(venueId, hallId)
+            ?: throw EventException(ErrorCode.HALL_NOT_FOUND)
+    }
+
+    /**
+     * 좌석 템플릿 비즈니스 검증
+     *
+     * 1. 모든 행(rows)이 gradeMapping에 매핑되어 있는지 확인
+     * 2. 중복 행 이름 검증
+     *
+     * @param seatTemplate 검증할 좌석 템플릿
+     * @throws EventException 좌석 템플릿 매핑이 올바르지 않을 경우 (INVALID_SEAT_TEMPLATE_MAPPING)
+     */
+    private fun validateSeatTemplate(seatTemplate: SeatTemplateDto) {
+        // 중복 행 이름 검증
+        val uniqueRows = seatTemplate.rows.toSet()
+        if (uniqueRows.size != seatTemplate.rows.size) {
+            throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING)
+        }
+
+        // 모든 행이 gradeMapping에 존재하는지 확인
+        val unmappedRows = seatTemplate.rows.filter { row ->
+            !seatTemplate.gradeMapping.containsKey(row)
+        }
+        if (unmappedRows.isNotEmpty()) {
+            throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING)
+        }
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/HallService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/HallService.kt
@@ -103,7 +103,7 @@ class HallService(
         val seatTemplate = try {
             objectMapper.readValue(hall.seatTemplate, SeatTemplateDto::class.java)
         } catch (e: JsonProcessingException) {
-            throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE)
+            throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE, cause = e)
         }
         return HallDto.DetailResponse.from(hall, seatTemplate)
     }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/HallService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/HallService.kt
@@ -130,7 +130,7 @@ class HallService(
 
         // 이름이 실제로 변경될 때만 중복 검증 (자기 자신 제외)
         if (request.name != null && request.name != hall.name) {
-            if (hallRepository.existsByVenueIdAndNameAndIdNot(venueId, request.name, hallId)) {
+            if (hallRepository.existsByVenueIdAndNameExcluding(venueId, request.name, hallId)) {
                 throw EventException(ErrorCode.HALL_NAME_DUPLICATE)
             }
         }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/HallService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/HallService.kt
@@ -193,11 +193,9 @@ class HallService(
             throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING)
         }
 
-        // 모든 행이 gradeMapping에 존재하는지 확인
-        val unmappedRows = seatTemplate.rows.filter { row ->
-            !seatTemplate.gradeMapping.containsKey(row)
-        }
-        if (unmappedRows.isNotEmpty()) {
+        // rows와 gradeMapping 키가 완전히 일치하는지 양방향 검증
+        // 정방향: 매핑 누락 행 검출 / 역방향: 잉여 매핑 키 검출
+        if (uniqueRows != seatTemplate.gradeMapping.keys) {
             throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING)
         }
     }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/VenueService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/VenueService.kt
@@ -57,7 +57,9 @@ class VenueService(
      * @return 페이징된 공연장 목록
      */
     fun getVenues(page: Int, size: Int, city: String?): Page<VenueDto.Response> {
-        val pageable = PageRequest.of(page, size)
+        val safePage = page.coerceAtLeast(0)
+        val safeSize = size.coerceIn(1, 100)
+        val pageable = PageRequest.of(safePage, safeSize)
         val venues = if (city != null) {
             venueRepository.findByCity(city, pageable)
         } else {

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/VenueService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/VenueService.kt
@@ -69,16 +69,16 @@ class VenueService(
     /**
      * 공연장 상세 조회
      *
-     * 공연장 기본 정보와 함께 소속 홀 목록을 포함하여 반환한다.
+     * QueryDSL LEFT JOIN FETCH로 Venue와 Hall을 단일 쿼리로 조회하여 N+1 문제를 해결한다.
      *
      * @param venueId 조회할 공연장 ID
      * @return 공연장 상세 정보 (홀 목록 포함)
      * @throws EventException 공연장이 존재하지 않을 경우 (VENUE_NOT_FOUND)
      */
     fun getVenue(venueId: UUID): VenueDto.DetailResponse {
-        val venue = findVenueById(venueId)
-        val halls = hallRepository.findByVenueId(venueId)
-        return VenueDto.DetailResponse.from(venue, halls)
+        val venue = venueRepository.findVenueWithHalls(venueId)
+            ?: throw EventException(ErrorCode.VENUE_NOT_FOUND)
+        return VenueDto.DetailResponse.from(venue, venue.halls)
     }
 
     /**

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/VenueService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/VenueService.kt
@@ -1,0 +1,143 @@
+package com.ticketqueue.event.service
+
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.dto.VenueDto
+import com.ticketqueue.event.entity.Venue
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.repository.EventRepository
+import com.ticketqueue.event.repository.HallRepository
+import com.ticketqueue.event.repository.VenueRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+/**
+ * 공연장(Venue) 관리 서비스
+ *
+ * 공연장의 CRUD 기능을 제공한다.
+ * 삭제 시에는 데이터 무결성을 위해 연관된 이벤트 및 홀의 존재 여부를 검증한다.
+ * 기본적으로 읽기 전용 트랜잭션으로 동작하며, 쓰기 작업은 개별 메서드에서 트랜잭션을 오버라이드한다.
+ */
+@Service
+@Transactional(readOnly = true)
+class VenueService(
+    private val venueRepository: VenueRepository,
+    private val hallRepository: HallRepository,
+    private val eventRepository: EventRepository
+) {
+
+    /**
+     * 공연장 생성
+     *
+     * @param request 공연장 생성 요청 (이름, 주소, 도시)
+     * @return 생성된 공연장 정보
+     */
+    @Transactional
+    fun createVenue(request: VenueDto.CreateRequest): VenueDto.Response {
+        val venue = Venue(
+            name = request.name,
+            address = request.address,
+            city = request.city
+        )
+        val saved = venueRepository.save(venue)
+        return VenueDto.Response.from(saved)
+    }
+
+    /**
+     * 공연장 목록 조회 (페이징)
+     *
+     * 도시(city) 파라미터가 있으면 해당 도시로 필터링하고,
+     * 없으면 전체 공연장을 조회한다.
+     *
+     * @param page 페이지 번호 (0부터 시작)
+     * @param size 페이지 크기
+     * @param city 도시 필터 (null이면 전체 조회)
+     * @return 페이징된 공연장 목록
+     */
+    fun getVenues(page: Int, size: Int, city: String?): Page<VenueDto.Response> {
+        val pageable = PageRequest.of(page, size)
+        val venues = if (city != null) {
+            venueRepository.findByCity(city, pageable)
+        } else {
+            venueRepository.findAll(pageable)
+        }
+        return venues.map { VenueDto.Response.from(it) }
+    }
+
+    /**
+     * 공연장 상세 조회
+     *
+     * 공연장 기본 정보와 함께 소속 홀 목록을 포함하여 반환한다.
+     *
+     * @param venueId 조회할 공연장 ID
+     * @return 공연장 상세 정보 (홀 목록 포함)
+     * @throws EventException 공연장이 존재하지 않을 경우 (VENUE_NOT_FOUND)
+     */
+    fun getVenue(venueId: UUID): VenueDto.DetailResponse {
+        val venue = findVenueById(venueId)
+        val halls = hallRepository.findByVenueId(venueId)
+        return VenueDto.DetailResponse.from(venue, halls)
+    }
+
+    /**
+     * 공연장 부분 수정 (PATCH)
+     *
+     * 요청에 포함된 필드만 업데이트하며, null 필드는 기존 값을 유지한다.
+     * JPA 더티 체킹을 통해 트랜잭션 종료 시 자동으로 UPDATE 쿼리가 실행된다.
+     *
+     * @param venueId 수정할 공연장 ID
+     * @param request 수정할 필드 (null인 필드는 변경하지 않음)
+     * @return 수정된 공연장 정보
+     * @throws EventException 공연장이 존재하지 않을 경우 (VENUE_NOT_FOUND)
+     */
+    @Transactional
+    fun updateVenue(venueId: UUID, request: VenueDto.UpdateRequest): VenueDto.UpdateResponse {
+        val venue = findVenueById(venueId)
+        venue.update(
+            name = request.name,
+            address = request.address,
+            city = request.city
+        )
+        return VenueDto.UpdateResponse.from(venue)
+    }
+
+    /**
+     * 공연장 삭제
+     *
+     * 삭제 전 데이터 무결성을 보장하기 위해 두 단계의 검증을 수행한다:
+     * 1. 이벤트 존재 여부 확인 - 공연이 등록된 공연장은 삭제 불가
+     * 2. 홀 존재 여부 확인 - 홀이 남아있는 공연장은 삭제 불가
+     *
+     * 이벤트 검증을 먼저 수행하여, 사용자에게 더 구체적인 오류 메시지를 제공한다.
+     *
+     * @param venueId 삭제할 공연장 ID
+     * @return 삭제 완료 메시지
+     * @throws EventException 공연장이 존재하지 않거나 (VENUE_NOT_FOUND),
+     *         연관된 이벤트가 있거나 (VENUE_HAS_EVENTS),
+     *         연관된 홀이 있을 경우 (VENUE_HAS_HALLS)
+     */
+    @Transactional
+    fun deleteVenue(venueId: UUID): VenueDto.DeleteResponse {
+        val venue = findVenueById(venueId)
+
+        // 1. 이벤트 존재 여부 확인 (공연이 있으면 삭제 불가)
+        if (eventRepository.existsByVenueId(venueId)) {
+            throw EventException(ErrorCode.VENUE_HAS_EVENTS)
+        }
+
+        // 2. 홀 존재 여부 확인 (홀이 남아있으면 삭제 불가)
+        if (hallRepository.existsByVenueId(venueId)) {
+            throw EventException(ErrorCode.VENUE_HAS_HALLS)
+        }
+
+        venueRepository.delete(venue)
+        return VenueDto.DeleteResponse(message = "공연장이 삭제되었습니다.")
+    }
+
+    private fun findVenueById(venueId: UUID): Venue {
+        return venueRepository.findById(venueId)
+            .orElseThrow { EventException(ErrorCode.VENUE_NOT_FOUND) }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/HallControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/HallControllerTest.kt
@@ -154,6 +154,15 @@ class HallControllerTest {
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$[0].name").value("KSPO DOME"))
         }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 공연장")
+        fun venueNotFound() {
+            every { hallService.getHalls(venueId) } throws EventException(ErrorCode.VENUE_NOT_FOUND)
+
+            mockMvc.perform(get("/venues/{venueId}/halls", venueId))
+                .andExpect(status().isNotFound)
+        }
     }
 
     @Nested

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/HallControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/HallControllerTest.kt
@@ -1,0 +1,240 @@
+package com.ticketqueue.event.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.exception.GlobalExceptionHandler
+import com.ticketqueue.event.dto.HallDto
+import com.ticketqueue.event.dto.SeatTemplateDto
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.service.HallService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDateTime
+import java.util.UUID
+
+class HallControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var hallService: HallService
+    private val objectMapper: ObjectMapper = jacksonObjectMapper().apply {
+        registerModule(JavaTimeModule())
+    }
+
+    private val venueId = UUID.randomUUID()
+    private val hallId = UUID.randomUUID()
+    private val now = LocalDateTime.now()
+
+    private val seatTemplateDto = SeatTemplateDto(
+        rows = listOf("A", "B", "C"),
+        seatsPerRow = 10,
+        gradeMapping = mapOf("A" to "VIP", "B" to "S", "C" to "A")
+    )
+
+    private fun hallResponse() = HallDto.Response(
+        id = hallId,
+        venueId = venueId,
+        name = "KSPO DOME",
+        capacity = 15000,
+        createdAt = now
+    )
+
+    @BeforeEach
+    fun setUp() {
+        hallService = mockk()
+        val controller = HallController(hallService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(GlobalExceptionHandler())
+            .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
+            .build()
+    }
+
+    @Nested
+    @DisplayName("POST /venues/{venueId}/halls")
+    inner class CreateHall {
+
+        @Test
+        @DisplayName("201 Created - 관리자가 홀을 생성한다")
+        fun created() {
+            every { hallService.createHall(venueId, any()) } returns hallResponse()
+
+            val request = HallDto.CreateRequest(
+                name = "KSPO DOME",
+                capacity = 15000,
+                seatTemplate = seatTemplateDto
+            )
+            mockMvc.perform(
+                post("/venues/{venueId}/halls", venueId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.name").value("KSPO DOME"))
+                .andExpect(jsonPath("$.capacity").value(15000))
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - seatTemplate 누락")
+        fun badRequestSeatTemplate() {
+            val request = mapOf(
+                "name" to "KSPO DOME",
+                "capacity" to 15000
+            )
+
+            mockMvc.perform(
+                post("/venues/{venueId}/halls", venueId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - capacity가 0")
+        fun badRequestCapacity() {
+            val request = mapOf(
+                "name" to "KSPO DOME",
+                "capacity" to 0,
+                "seatTemplate" to seatTemplateDto
+            )
+
+            mockMvc.perform(
+                post("/venues/{venueId}/halls", venueId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isBadRequest)
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /venues/{venueId}/halls")
+    inner class GetHalls {
+
+        @Test
+        @DisplayName("200 OK - 홀 목록을 조회한다")
+        fun list() {
+            every { hallService.getHalls(venueId) } returns listOf(hallResponse())
+
+            mockMvc.perform(get("/venues/{venueId}/halls", venueId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$[0].name").value("KSPO DOME"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /venues/{venueId}/halls/{hallId}")
+    inner class GetHall {
+
+        @Test
+        @DisplayName("200 OK - 홀 상세를 조회한다")
+        fun detail() {
+            val detail = HallDto.DetailResponse(
+                id = hallId,
+                venueId = venueId,
+                name = "KSPO DOME",
+                capacity = 15000,
+                seatTemplate = seatTemplateDto,
+                createdAt = now,
+                updatedAt = now
+            )
+            every { hallService.getHall(venueId, hallId) } returns detail
+
+            mockMvc.perform(get("/venues/{venueId}/halls/{hallId}", venueId, hallId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.name").value("KSPO DOME"))
+                .andExpect(jsonPath("$.seatTemplate.rows[0]").value("A"))
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 홀")
+        fun notFound() {
+            every { hallService.getHall(venueId, hallId) } throws EventException(ErrorCode.HALL_NOT_FOUND)
+
+            mockMvc.perform(get("/venues/{venueId}/halls/{hallId}", venueId, hallId))
+                .andExpect(status().isNotFound)
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /venues/{venueId}/halls/{hallId}")
+    inner class UpdateHall {
+
+        @Test
+        @DisplayName("200 OK - 홀을 수정한다")
+        fun success() {
+            val response = HallDto.UpdateResponse(
+                id = hallId,
+                name = "올림픽홀",
+                capacity = 15000,
+                updatedAt = now
+            )
+            every { hallService.updateHall(venueId, hallId, any()) } returns response
+
+            val request = HallDto.UpdateRequest(name = "올림픽홀")
+            mockMvc.perform(
+                patch("/venues/{venueId}/halls/{hallId}", venueId, hallId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.name").value("올림픽홀"))
+        }
+
+        @Test
+        @DisplayName("409 Conflict - 이름 중복")
+        fun conflict() {
+            every { hallService.updateHall(venueId, hallId, any()) } throws
+                EventException(ErrorCode.HALL_NAME_DUPLICATE)
+
+            val request = HallDto.UpdateRequest(name = "올림픽홀")
+            mockMvc.perform(
+                patch("/venues/{venueId}/halls/{hallId}", venueId, hallId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isConflict)
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /venues/{venueId}/halls/{hallId}")
+    inner class DeleteHall {
+
+        @Test
+        @DisplayName("200 OK - 홀을 삭제한다")
+        fun success() {
+            every { hallService.deleteHall(venueId, hallId) } returns
+                HallDto.DeleteResponse("홀이 삭제되었습니다.")
+
+            mockMvc.perform(delete("/venues/{venueId}/halls/{hallId}", venueId, hallId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.message").value("홀이 삭제되었습니다."))
+        }
+
+        @Test
+        @DisplayName("409 Conflict - 공연이 존재하는 홀 삭제 시")
+        fun conflict() {
+            every { hallService.deleteHall(venueId, hallId) } throws
+                EventException(ErrorCode.HALL_HAS_EVENTS)
+
+            mockMvc.perform(delete("/venues/{venueId}/halls/{hallId}", venueId, hallId))
+                .andExpect(status().isConflict)
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/HallControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/HallControllerTest.kt
@@ -120,6 +120,25 @@ class HallControllerTest {
             )
                 .andExpect(status().isBadRequest)
         }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 공연장")
+        fun venueNotFound() {
+            every { hallService.createHall(venueId, any()) } throws
+                EventException(ErrorCode.VENUE_NOT_FOUND)
+
+            val request = HallDto.CreateRequest(
+                name = "KSPO DOME",
+                capacity = 15000,
+                seatTemplate = seatTemplateDto
+            )
+            mockMvc.perform(
+                post("/venues/{venueId}/halls", venueId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isNotFound)
+        }
     }
 
     @Nested

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/VenueControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/VenueControllerTest.kt
@@ -1,0 +1,235 @@
+package com.ticketqueue.event.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.exception.GlobalExceptionHandler
+import com.ticketqueue.event.dto.VenueDto
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.service.VenueService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.http.MediaType
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDateTime
+import java.util.UUID
+
+class VenueControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var venueService: VenueService
+    private val objectMapper: ObjectMapper = jacksonObjectMapper().apply {
+        registerModule(JavaTimeModule())
+    }
+
+    private val venueId = UUID.randomUUID()
+    private val now = LocalDateTime.now()
+
+    private fun venueResponse() = VenueDto.Response(
+        id = venueId,
+        name = "올림픽공원",
+        address = "서울시 송파구",
+        city = "서울",
+        createdAt = now
+    )
+
+    @BeforeEach
+    fun setUp() {
+        venueService = mockk()
+        val controller = VenueController(venueService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(GlobalExceptionHandler())
+            .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
+            .build()
+    }
+
+    @Nested
+    @DisplayName("POST /venues")
+    inner class CreateVenue {
+
+        @Test
+        @DisplayName("201 Created - 관리자가 공연장을 생성한다")
+        fun created() {
+            val request = VenueDto.CreateRequest(
+                name = "올림픽공원",
+                address = "서울시 송파구",
+                city = "서울"
+            )
+            every { venueService.createVenue(any()) } returns venueResponse()
+
+            mockMvc.perform(
+                post("/venues")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.name").value("올림픽공원"))
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - 유효성 검사 실패")
+        fun badRequest() {
+            val request = mapOf("name" to "", "address" to "", "city" to "")
+
+            mockMvc.perform(
+                post("/venues")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isBadRequest)
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /venues")
+    inner class GetVenues {
+
+        @Test
+        @DisplayName("200 OK - 공연장 목록을 조회한다")
+        fun list() {
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(listOf(venueResponse()), pageable, 1)
+            every { venueService.getVenues(0, 20, null) } returns page
+
+            mockMvc.perform(get("/venues"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.list[0].name").value("올림픽공원"))
+                .andExpect(jsonPath("$.totalElements").value(1))
+        }
+
+        @Test
+        @DisplayName("200 OK - 도시 필터로 공연장 목록을 조회한다")
+        fun listWithCityFilter() {
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(listOf(venueResponse()), pageable, 1)
+            every { venueService.getVenues(0, 20, "서울") } returns page
+
+            mockMvc.perform(get("/venues").param("city", "서울"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.list[0].city").value("서울"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /venues/{venueId}")
+    inner class GetVenue {
+
+        @Test
+        @DisplayName("200 OK - 공연장 상세를 조회한다")
+        fun detail() {
+            val detail = VenueDto.DetailResponse(
+                id = venueId,
+                name = "올림픽공원",
+                address = "서울시 송파구",
+                city = "서울",
+                halls = emptyList(),
+                createdAt = now,
+                updatedAt = now
+            )
+            every { venueService.getVenue(venueId) } returns detail
+
+            mockMvc.perform(get("/venues/{venueId}", venueId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.name").value("올림픽공원"))
+                .andExpect(jsonPath("$.halls").isArray)
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 공연장")
+        fun notFound() {
+            every { venueService.getVenue(venueId) } throws EventException(ErrorCode.VENUE_NOT_FOUND)
+
+            mockMvc.perform(get("/venues/{venueId}", venueId))
+                .andExpect(status().isNotFound)
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /venues/{venueId}")
+    inner class UpdateVenue {
+
+        @Test
+        @DisplayName("200 OK - 공연장을 수정한다")
+        fun success() {
+            val response = VenueDto.UpdateResponse(
+                id = venueId,
+                name = "고척스카이돔",
+                address = "서울시 송파구",
+                city = "서울",
+                updatedAt = now
+            )
+            every { venueService.updateVenue(venueId, any()) } returns response
+
+            val request = VenueDto.UpdateRequest(name = "고척스카이돔")
+            mockMvc.perform(
+                patch("/venues/{venueId}", venueId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.name").value("고척스카이돔"))
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 공연장 수정")
+        fun notFound() {
+            every { venueService.updateVenue(venueId, any()) } throws EventException(ErrorCode.VENUE_NOT_FOUND)
+
+            val request = VenueDto.UpdateRequest(name = "고척스카이돔")
+            mockMvc.perform(
+                patch("/venues/{venueId}", venueId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isNotFound)
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /venues/{venueId}")
+    inner class DeleteVenue {
+
+        @Test
+        @DisplayName("200 OK - 공연장을 삭제한다")
+        fun success() {
+            every { venueService.deleteVenue(venueId) } returns VenueDto.DeleteResponse("공연장이 삭제되었습니다.")
+
+            mockMvc.perform(delete("/venues/{venueId}", venueId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.message").value("공연장이 삭제되었습니다."))
+        }
+
+        @Test
+        @DisplayName("409 Conflict - 공연이 존재하는 공연장 삭제 시")
+        fun conflict() {
+            every { venueService.deleteVenue(venueId) } throws EventException(ErrorCode.VENUE_HAS_EVENTS)
+
+            mockMvc.perform(delete("/venues/{venueId}", venueId))
+                .andExpect(status().isConflict)
+        }
+
+        @Test
+        @DisplayName("409 Conflict - 홀이 존재하는 공연장 삭제 시")
+        fun conflictHalls() {
+            every { venueService.deleteVenue(venueId) } throws EventException(ErrorCode.VENUE_HAS_HALLS)
+
+            mockMvc.perform(delete("/venues/{venueId}", venueId))
+                .andExpect(status().isConflict)
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/HallServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/HallServiceTest.kt
@@ -135,6 +135,72 @@ class HallServiceTest {
             }
             assertEquals(ErrorCode.HALL_NAME_DUPLICATE, exception.errorCode)
         }
+
+        @Test
+        @DisplayName("중복 행 이름이 있으면 예외가 발생한다")
+        fun duplicateRowNames() {
+            val venue = createVenue()
+            val request = HallDto.CreateRequest(
+                name = "KSPO DOME",
+                capacity = 15000,
+                seatTemplate = SeatTemplateDto(
+                    rows = listOf("A", "A", "B"),
+                    seatsPerRow = 10,
+                    gradeMapping = mapOf("A" to "VIP", "B" to "S")
+                )
+            )
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.existsByVenueIdAndName(venueId, "KSPO DOME") } returns false
+
+            val exception = assertThrows<EventException> {
+                hallService.createHall(venueId, request)
+            }
+            assertEquals(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("gradeMapping에 매핑되지 않은 행이 있으면 예외가 발생한다")
+        fun unmappedRow() {
+            val venue = createVenue()
+            val request = HallDto.CreateRequest(
+                name = "KSPO DOME",
+                capacity = 15000,
+                seatTemplate = SeatTemplateDto(
+                    rows = listOf("A", "B", "C"),
+                    seatsPerRow = 10,
+                    gradeMapping = mapOf("A" to "VIP", "B" to "S")
+                )
+            )
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.existsByVenueIdAndName(venueId, "KSPO DOME") } returns false
+
+            val exception = assertThrows<EventException> {
+                hallService.createHall(venueId, request)
+            }
+            assertEquals(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("gradeMapping에 잉여 키가 있으면 예외가 발생한다")
+        fun orphanGradeMappingKeys() {
+            val venue = createVenue()
+            val request = HallDto.CreateRequest(
+                name = "KSPO DOME",
+                capacity = 15000,
+                seatTemplate = SeatTemplateDto(
+                    rows = listOf("A", "B"),
+                    seatsPerRow = 10,
+                    gradeMapping = mapOf("A" to "VIP", "B" to "S", "C" to "A")
+                )
+            )
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.existsByVenueIdAndName(venueId, "KSPO DOME") } returns false
+
+            val exception = assertThrows<EventException> {
+                hallService.createHall(venueId, request)
+            }
+            assertEquals(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING, exception.errorCode)
+        }
     }
 
     @Nested
@@ -193,6 +259,18 @@ class HallServiceTest {
                 hallService.getHall(venueId, hallId)
             }
             assertEquals(ErrorCode.HALL_NOT_FOUND, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("손상된 JSON seatTemplate 조회 시 예외가 발생한다")
+        fun invalidSeatTemplateJson() {
+            val hall = createHall(seatTemplate = "invalid-json")
+            every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns hall
+
+            val exception = assertThrows<EventException> {
+                hallService.getHall(venueId, hallId)
+            }
+            assertEquals(ErrorCode.INVALID_SEAT_TEMPLATE, exception.errorCode)
         }
     }
 

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/HallServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/HallServiceTest.kt
@@ -1,0 +1,308 @@
+package com.ticketqueue.event.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.dto.HallDto
+import com.ticketqueue.event.dto.SeatTemplateDto
+import com.ticketqueue.event.entity.Hall
+import com.ticketqueue.event.entity.Venue
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.repository.EventRepository
+import com.ticketqueue.event.repository.HallRepository
+import com.ticketqueue.event.repository.VenueRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+import java.util.Optional
+import java.util.UUID
+
+class HallServiceTest {
+
+    private lateinit var hallRepository: HallRepository
+    private lateinit var venueRepository: VenueRepository
+    private lateinit var eventRepository: EventRepository
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var hallService: HallService
+
+    private val venueId = UUID.randomUUID()
+    private val hallId = UUID.randomUUID()
+    private val now = LocalDateTime.now()
+
+    private val seatTemplateDto = SeatTemplateDto(
+        rows = listOf("A", "B", "C"),
+        seatsPerRow = 10,
+        gradeMapping = mapOf("A" to "VIP", "B" to "S", "C" to "A")
+    )
+
+    private fun createVenue(): Venue = Venue(
+        id = venueId,
+        name = "올림픽공원",
+        address = "서울시 송파구",
+        city = "서울",
+        createdAt = now,
+        updatedAt = now
+    )
+
+    private fun createHall(
+        id: UUID = hallId,
+        venue: Venue = createVenue(),
+        name: String = "KSPO DOME",
+        capacity: Int = 15000,
+        seatTemplate: String? = null
+    ): Hall = Hall(
+        id = id,
+        venue = venue,
+        name = name,
+        capacity = capacity,
+        seatTemplate = seatTemplate ?: objectMapper.writeValueAsString(seatTemplateDto),
+        createdAt = now,
+        updatedAt = now
+    )
+
+    @BeforeEach
+    fun setUp() {
+        hallRepository = mockk()
+        venueRepository = mockk()
+        eventRepository = mockk()
+        objectMapper = jacksonObjectMapper()
+        hallService = HallService(hallRepository, venueRepository, eventRepository, objectMapper)
+    }
+
+    @Nested
+    @DisplayName("createHall")
+    inner class CreateHall {
+
+        @Test
+        @DisplayName("성공적으로 홀을 생성한다")
+        fun success() {
+            val venue = createVenue()
+            val request = HallDto.CreateRequest(
+                name = "KSPO DOME",
+                capacity = 15000,
+                seatTemplate = seatTemplateDto
+            )
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.existsByVenueIdAndName(venueId, "KSPO DOME") } returns false
+            every { hallRepository.save(any()) } returns createHall(venue = venue)
+
+            val result = hallService.createHall(venueId, request)
+
+            assertEquals(hallId, result.id)
+            assertEquals("KSPO DOME", result.name)
+            assertEquals(15000, result.capacity)
+            verify { hallRepository.save(any()) }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 공연장의 홀 생성 시 예외가 발생한다")
+        fun venueNotFound() {
+            val request = HallDto.CreateRequest(
+                name = "KSPO DOME",
+                capacity = 15000,
+                seatTemplate = seatTemplateDto
+            )
+            every { venueRepository.findById(venueId) } returns Optional.empty()
+
+            val exception = assertThrows<EventException> {
+                hallService.createHall(venueId, request)
+            }
+            assertEquals(ErrorCode.VENUE_NOT_FOUND, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("동일 공연장 내 중복 이름 시 예외가 발생한다")
+        fun duplicateName() {
+            val venue = createVenue()
+            val request = HallDto.CreateRequest(
+                name = "KSPO DOME",
+                capacity = 15000,
+                seatTemplate = seatTemplateDto
+            )
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.existsByVenueIdAndName(venueId, "KSPO DOME") } returns true
+
+            val exception = assertThrows<EventException> {
+                hallService.createHall(venueId, request)
+            }
+            assertEquals(ErrorCode.HALL_NAME_DUPLICATE, exception.errorCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("getHalls")
+    inner class GetHalls {
+
+        @Test
+        @DisplayName("공연장의 홀 목록을 조회한다")
+        fun success() {
+            val hall = createHall()
+            every { venueRepository.existsById(venueId) } returns true
+            every { hallRepository.findByVenueId(venueId) } returns listOf(hall)
+
+            val result = hallService.getHalls(venueId)
+
+            assertEquals(1, result.size)
+            assertEquals("KSPO DOME", result[0].name)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 공연장의 홀 목록 조회 시 예외가 발생한다")
+        fun venueNotFound() {
+            every { venueRepository.existsById(venueId) } returns false
+
+            val exception = assertThrows<EventException> {
+                hallService.getHalls(venueId)
+            }
+            assertEquals(ErrorCode.VENUE_NOT_FOUND, exception.errorCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("getHall")
+    inner class GetHall {
+
+        @Test
+        @DisplayName("홀 상세를 조회한다")
+        fun success() {
+            val hall = createHall()
+            every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns hall
+
+            val result = hallService.getHall(venueId, hallId)
+
+            assertEquals(hallId, result.id)
+            assertEquals("KSPO DOME", result.name)
+            assertEquals(seatTemplateDto.rows, result.seatTemplate.rows)
+            assertEquals(seatTemplateDto.seatsPerRow, result.seatTemplate.seatsPerRow)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 홀 조회 시 예외가 발생한다")
+        fun notFound() {
+            every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns null
+
+            val exception = assertThrows<EventException> {
+                hallService.getHall(venueId, hallId)
+            }
+            assertEquals(ErrorCode.HALL_NOT_FOUND, exception.errorCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("updateHall")
+    inner class UpdateHall {
+
+        @Test
+        @DisplayName("전체 필드를 업데이트한다")
+        fun fullUpdate() {
+            val hall = createHall()
+            val newTemplate = SeatTemplateDto(
+                rows = listOf("A", "B"),
+                seatsPerRow = 20,
+                gradeMapping = mapOf("A" to "VIP", "B" to "S")
+            )
+            val request = HallDto.UpdateRequest(
+                name = "올림픽홀",
+                capacity = 3000,
+                seatTemplate = newTemplate
+            )
+            every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns hall
+            every { hallRepository.existsByVenueIdAndNameAndIdNot(venueId, "올림픽홀", hallId) } returns false
+
+            val result = hallService.updateHall(venueId, hallId, request)
+
+            assertEquals("올림픽홀", result.name)
+            assertEquals(3000, result.capacity)
+        }
+
+        @Test
+        @DisplayName("부분 필드만 업데이트한다")
+        fun partialUpdate() {
+            val hall = createHall()
+            val request = HallDto.UpdateRequest(capacity = 20000)
+            every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns hall
+
+            val result = hallService.updateHall(venueId, hallId, request)
+
+            assertEquals("KSPO DOME", result.name)
+            assertEquals(20000, result.capacity)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 홀 업데이트 시 예외가 발생한다")
+        fun notFound() {
+            val request = HallDto.UpdateRequest(name = "올림픽홀")
+            every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns null
+
+            val exception = assertThrows<EventException> {
+                hallService.updateHall(venueId, hallId, request)
+            }
+            assertEquals(ErrorCode.HALL_NOT_FOUND, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("이름 변경 시 중복되면 예외가 발생한다")
+        fun duplicateName() {
+            val hall = createHall()
+            val request = HallDto.UpdateRequest(name = "올림픽홀")
+            every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns hall
+            every { hallRepository.existsByVenueIdAndNameAndIdNot(venueId, "올림픽홀", hallId) } returns true
+
+            val exception = assertThrows<EventException> {
+                hallService.updateHall(venueId, hallId, request)
+            }
+            assertEquals(ErrorCode.HALL_NAME_DUPLICATE, exception.errorCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteHall")
+    inner class DeleteHall {
+
+        @Test
+        @DisplayName("성공적으로 홀을 삭제한다")
+        fun success() {
+            val hall = createHall()
+            every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns hall
+            every { eventRepository.existsByHallId(hallId) } returns false
+            every { hallRepository.delete(hall) } returns Unit
+
+            val result = hallService.deleteHall(venueId, hallId)
+
+            assertNotNull(result.message)
+            verify { hallRepository.delete(hall) }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 홀 삭제 시 예외가 발생한다")
+        fun notFound() {
+            every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns null
+
+            val exception = assertThrows<EventException> {
+                hallService.deleteHall(venueId, hallId)
+            }
+            assertEquals(ErrorCode.HALL_NOT_FOUND, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("공연이 존재하는 홀 삭제 시 예외가 발생한다")
+        fun hasEvents() {
+            val hall = createHall()
+            every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns hall
+            every { eventRepository.existsByHallId(hallId) } returns true
+
+            val exception = assertThrows<EventException> {
+                hallService.deleteHall(venueId, hallId)
+            }
+            assertEquals(ErrorCode.HALL_HAS_EVENTS, exception.errorCode)
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/HallServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/HallServiceTest.kt
@@ -215,7 +215,7 @@ class HallServiceTest {
                 seatTemplate = newTemplate
             )
             every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns hall
-            every { hallRepository.existsByVenueIdAndNameAndIdNot(venueId, "올림픽홀", hallId) } returns false
+            every { hallRepository.existsByVenueIdAndNameExcluding(venueId, "올림픽홀", hallId) } returns false
 
             val result = hallService.updateHall(venueId, hallId, request)
 
@@ -254,7 +254,7 @@ class HallServiceTest {
             val hall = createHall()
             val request = HallDto.UpdateRequest(name = "올림픽홀")
             every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns hall
-            every { hallRepository.existsByVenueIdAndNameAndIdNot(venueId, "올림픽홀", hallId) } returns true
+            every { hallRepository.existsByVenueIdAndNameExcluding(venueId, "올림픽홀", hallId) } returns true
 
             val exception = assertThrows<EventException> {
                 hallService.updateHall(venueId, hallId, request)

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/VenueServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/VenueServiceTest.kt
@@ -117,22 +117,20 @@ class VenueServiceTest {
     inner class GetVenue {
 
         @Test
-        @DisplayName("공연장 상세를 조회한다")
+        @DisplayName("공연장 상세를 조회한다 (fetch join으로 단일 쿼리)")
         fun success() {
             val venue = createVenue()
-            val halls = listOf(
-                Hall(
-                    id = UUID.randomUUID(),
-                    venue = venue,
-                    name = "KSPO DOME",
-                    capacity = 15000,
-                    seatTemplate = "{}",
-                    createdAt = now,
-                    updatedAt = now
-                )
+            val hall = Hall(
+                id = UUID.randomUUID(),
+                venue = venue,
+                name = "KSPO DOME",
+                capacity = 15000,
+                seatTemplate = "{}",
+                createdAt = now,
+                updatedAt = now
             )
-            every { venueRepository.findById(venueId) } returns Optional.of(venue)
-            every { hallRepository.findByVenueId(venueId) } returns halls
+            venue.halls.add(hall)
+            every { venueRepository.findVenueWithHalls(venueId) } returns venue
 
             val result = venueService.getVenue(venueId)
 
@@ -144,7 +142,7 @@ class VenueServiceTest {
         @Test
         @DisplayName("존재하지 않는 공연장 조회 시 예외가 발생한다")
         fun notFound() {
-            every { venueRepository.findById(venueId) } returns Optional.empty()
+            every { venueRepository.findVenueWithHalls(venueId) } returns null
 
             val exception = assertThrows<EventException> {
                 venueService.getVenue(venueId)

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/VenueServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/VenueServiceTest.kt
@@ -1,0 +1,261 @@
+package com.ticketqueue.event.service
+
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.dto.VenueDto
+import com.ticketqueue.event.entity.Hall
+import com.ticketqueue.event.entity.Venue
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.repository.EventRepository
+import com.ticketqueue.event.repository.HallRepository
+import com.ticketqueue.event.repository.VenueRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.time.LocalDateTime
+import java.util.Optional
+import java.util.UUID
+
+class VenueServiceTest {
+
+    private lateinit var venueRepository: VenueRepository
+    private lateinit var hallRepository: HallRepository
+    private lateinit var eventRepository: EventRepository
+    private lateinit var venueService: VenueService
+
+    private val venueId = UUID.randomUUID()
+    private val now = LocalDateTime.now()
+
+    private fun createVenue(
+        id: UUID = venueId,
+        name: String = "올림픽공원",
+        address: String = "서울시 송파구",
+        city: String = "서울"
+    ): Venue = Venue(
+        id = id,
+        name = name,
+        address = address,
+        city = city,
+        createdAt = now,
+        updatedAt = now
+    )
+
+    @BeforeEach
+    fun setUp() {
+        venueRepository = mockk()
+        hallRepository = mockk()
+        eventRepository = mockk()
+        venueService = VenueService(venueRepository, hallRepository, eventRepository)
+    }
+
+    @Nested
+    @DisplayName("createVenue")
+    inner class CreateVenue {
+
+        @Test
+        @DisplayName("성공적으로 공연장을 생성한다")
+        fun success() {
+            val request = VenueDto.CreateRequest(
+                name = "올림픽공원",
+                address = "서울시 송파구",
+                city = "서울"
+            )
+            val venue = createVenue()
+            every { venueRepository.save(any()) } returns venue
+
+            val result = venueService.createVenue(request)
+
+            assertEquals(venueId, result.id)
+            assertEquals("올림픽공원", result.name)
+            assertEquals("서울시 송파구", result.address)
+            assertEquals("서울", result.city)
+            verify { venueRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("getVenues")
+    inner class GetVenues {
+
+        @Test
+        @DisplayName("필터 없이 공연장 목록을 조회한다")
+        fun withoutFilter() {
+            val venues = listOf(createVenue())
+            val pageable = PageRequest.of(0, 20)
+            every { venueRepository.findAll(pageable) } returns PageImpl(venues, pageable, 1)
+
+            val result = venueService.getVenues(0, 20, null)
+
+            assertEquals(1, result.totalElements)
+            assertEquals("올림픽공원", result.content[0].name)
+        }
+
+        @Test
+        @DisplayName("도시별 공연장 목록을 조회한다")
+        fun withCityFilter() {
+            val venues = listOf(createVenue())
+            val pageable = PageRequest.of(0, 20)
+            every { venueRepository.findByCity("서울", pageable) } returns PageImpl(venues, pageable, 1)
+
+            val result = venueService.getVenues(0, 20, "서울")
+
+            assertEquals(1, result.totalElements)
+            assertEquals("서울", result.content[0].city)
+        }
+    }
+
+    @Nested
+    @DisplayName("getVenue")
+    inner class GetVenue {
+
+        @Test
+        @DisplayName("공연장 상세를 조회한다")
+        fun success() {
+            val venue = createVenue()
+            val halls = listOf(
+                Hall(
+                    id = UUID.randomUUID(),
+                    venue = venue,
+                    name = "KSPO DOME",
+                    capacity = 15000,
+                    seatTemplate = "{}",
+                    createdAt = now,
+                    updatedAt = now
+                )
+            )
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.findByVenueId(venueId) } returns halls
+
+            val result = venueService.getVenue(venueId)
+
+            assertEquals(venueId, result.id)
+            assertEquals(1, result.halls.size)
+            assertEquals("KSPO DOME", result.halls[0].name)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 공연장 조회 시 예외가 발생한다")
+        fun notFound() {
+            every { venueRepository.findById(venueId) } returns Optional.empty()
+
+            val exception = assertThrows<EventException> {
+                venueService.getVenue(venueId)
+            }
+            assertEquals(ErrorCode.VENUE_NOT_FOUND, exception.errorCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("updateVenue")
+    inner class UpdateVenue {
+
+        @Test
+        @DisplayName("전체 필드를 업데이트한다")
+        fun fullUpdate() {
+            val venue = createVenue()
+            val request = VenueDto.UpdateRequest(
+                name = "고척스카이돔",
+                address = "서울시 구로구",
+                city = "서울"
+            )
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+
+            val result = venueService.updateVenue(venueId, request)
+
+            assertEquals("고척스카이돔", result.name)
+            assertEquals("서울시 구로구", result.address)
+        }
+
+        @Test
+        @DisplayName("부분 필드만 업데이트한다")
+        fun partialUpdate() {
+            val venue = createVenue()
+            val request = VenueDto.UpdateRequest(name = "고척스카이돔")
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+
+            val result = venueService.updateVenue(venueId, request)
+
+            assertEquals("고척스카이돔", result.name)
+            assertEquals("서울시 송파구", result.address)
+            assertEquals("서울", result.city)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 공연장 업데이트 시 예외가 발생한다")
+        fun notFound() {
+            val request = VenueDto.UpdateRequest(name = "고척스카이돔")
+            every { venueRepository.findById(venueId) } returns Optional.empty()
+
+            val exception = assertThrows<EventException> {
+                venueService.updateVenue(venueId, request)
+            }
+            assertEquals(ErrorCode.VENUE_NOT_FOUND, exception.errorCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteVenue")
+    inner class DeleteVenue {
+
+        @Test
+        @DisplayName("성공적으로 공연장을 삭제한다")
+        fun success() {
+            val venue = createVenue()
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { eventRepository.existsByVenueId(venueId) } returns false
+            every { hallRepository.existsByVenueId(venueId) } returns false
+            every { venueRepository.delete(venue) } returns Unit
+
+            val result = venueService.deleteVenue(venueId)
+
+            assertNotNull(result.message)
+            verify { venueRepository.delete(venue) }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 공연장 삭제 시 예외가 발생한다")
+        fun notFound() {
+            every { venueRepository.findById(venueId) } returns Optional.empty()
+
+            val exception = assertThrows<EventException> {
+                venueService.deleteVenue(venueId)
+            }
+            assertEquals(ErrorCode.VENUE_NOT_FOUND, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("공연이 존재하는 공연장 삭제 시 예외가 발생한다")
+        fun hasEvents() {
+            val venue = createVenue()
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { eventRepository.existsByVenueId(venueId) } returns true
+
+            val exception = assertThrows<EventException> {
+                venueService.deleteVenue(venueId)
+            }
+            assertEquals(ErrorCode.VENUE_HAS_EVENTS, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("홀이 존재하는 공연장 삭제 시 예외가 발생한다")
+        fun hasHalls() {
+            val venue = createVenue()
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { eventRepository.existsByVenueId(venueId) } returns false
+            every { hallRepository.existsByVenueId(venueId) } returns true
+
+            val exception = assertThrows<EventException> {
+                venueService.deleteVenue(venueId)
+            }
+            assertEquals(ErrorCode.VENUE_HAS_HALLS, exception.errorCode)
+        }
+    }
+}

--- a/backend/event-service/src/test/resources/application.yml
+++ b/backend/event-service/src/test/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: event-service-test
+  config:
+    import: ""
+  cloud:
+    aws:
+      secretsmanager:
+        enabled: false
+      region:
+        static: us-east-1
+  jpa:
+    hibernate:
+      ddl-auto: none
+    open-in-view: false
+  kafka:
+    bootstrap-servers: localhost:9092
+
+internal:
+  api:
+    key: test-api-key

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/config/SecurityConfig.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/config/SecurityConfig.kt
@@ -24,7 +24,7 @@ class SecurityConfig {
             .authorizeHttpRequests { auth ->
                 auth
                     .requestMatchers("/auth/signup", "/auth/login", "/auth/refresh").permitAll()
-                    .requestMatchers("/actuator/**").permitAll()
+                    .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                     .anyRequest().authenticated()
             }
             .build()


### PR DESCRIPTION
## Summary
Event Service의 공연장/홀 CRUD API 구현 및 QueryDSL 기반 쿼리 최적화

## Changes

**공연장 CRUD** (`/venues`)
- `POST /venues` — 공연장 생성
- `GET /venues` — 목록 조회 (페이징, city 필터)
- `GET /venues/{id}` — 상세 조회 (소속 홀 목록 포함) · QueryDSL fetch join으로 N+1 해결
- `PATCH /venues/{id}` — 부분 수정 (dirty checking)
- `DELETE /venues/{id}` — 삭제 (이벤트/홀 무결성 검증)

**홀 CRUD** (`/venues/{venueId}/halls`)
- `POST /venues/{venueId}/halls` — 홀 생성 (좌석 템플릿 JSONB 저장)
- `GET /venues/{venueId}/halls` — 홀 목록 조회
- `GET /venues/{venueId}/halls/{id}` — 홀 상세 조회
- `PATCH /venues/{venueId}/halls/{id}` — 부분 수정
- `DELETE /venues/{venueId}/halls/{id}` — 삭제

**QueryDSL 인프라**
- KSP 플러그인 추가로 Q클래스 자동 생성 (`QVenue`, `QHall` 등)
- `VenueRepositoryCustom` — LEFT JOIN FETCH 단일 쿼리로 N+1 해결
- `HallRepositoryCustom` — `existsByVenueIdAndNameExcluding` (파생 메서드명 가독성 개선)

**기타**
- `SecurityConfig` — ADMIN 권한 설정, `/internal/**` permitAll (Issue #38 기반 마련)
- `KafkaErrorHandlerConfig` — `KotlinLogging` import 누락 및 오타 수정

## Test plan
- [x] Controller 단위 테스트 (VenueControllerTest, HallControllerTest)
- [x] Service 단위 테스트 (VenueServiceTest, HallServiceTest)
- [x] `./gradlew :event-service:build` 빌드 성공

Closes #32 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Venue and hall management APIs: create, list (with pagination), retrieve, update (partial), delete; seat-template support; gateway-provided role-based auth for admin operations.

* **Bug Fixes**
  * More specific error responses for not-found, duplicates, constraint violations.

* **Documentation**
  * Project moved to Implementation Phase with updated security, data protection (encrypted personal data + hashing), and testing guidance.

* **Tests**
  * Added comprehensive unit and controller tests covering venue and hall workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->