### PR TITLE
feat: [Gateway] JWT 토큰 검증 필터 구현 #14

### DIFF
--- a/backend/api-gateway/build.gradle.kts
+++ b/backend/api-gateway/build.gradle.kts
@@ -26,6 +26,12 @@ dependencies {
     // Context Propagation (Reactor Context ↔ MDC 자동 동기화)
     implementation(libs.micrometer.context.propagation)
 
+    // JWT
+    implementation(libs.bundles.jjwt)
+
+    // Redis Reactive (토큰 블랙리스트 조회)
+    implementation(libs.spring.boot.starter.data.redis.reactive)
+
     // Test
     testImplementation(libs.bundles.test.base)
     testImplementation(libs.reactor.test)

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/config/GatewayConfig.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/config/GatewayConfig.kt
@@ -1,5 +1,6 @@
 package com.ticketqueue.gateway.config
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 
 /**
@@ -8,10 +9,11 @@ import org.springframework.context.annotation.Configuration
  * 현재는 application.yml 기반 라우트 설정만 사용하며,
  * 향후 Issue #13~#19에서 필요한 Bean 추가 예정:
  * - Issue #13: 동적 라우팅 설정
- * - Issue #14: JWT 인증 필터
+ * - Issue #14: JWT 인증 필터 (완료)
  * - Issue #15: Queue Token 헤더 전달
  * - Issue #16: Circuit Breaker Fallback
  * - Issue #17: CORS 및 보안 헤더
  */
 @Configuration
+@EnableConfigurationProperties(JwtProperties::class)
 class GatewayConfig

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/config/JwtProperties.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/config/JwtProperties.kt
@@ -1,0 +1,14 @@
+package com.ticketqueue.gateway.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * JWT 설정 프로퍼티
+ *
+ * API Gateway에서는 서명 검증만 필요하므로 secret만 바인딩.
+ * 토큰 발급(expiry 등)은 User Service 담당.
+ */
+@ConfigurationProperties(prefix = "jwt")
+data class JwtProperties(
+    val secret: String,
+)

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilter.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilter.kt
@@ -1,0 +1,141 @@
+package com.ticketqueue.gateway.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.gateway.security.JwtTokenProvider
+import com.ticketqueue.gateway.security.ReactiveTokenBlacklistService
+import com.ticketqueue.gateway.security.RouteValidator
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.JwtException
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.WebFilter
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * JWT 토큰 검증 필터
+ *
+ * 처리 순서:
+ * 1. 공개 엔드포인트 → 통과
+ * 2. Authorization 헤더 없거나 Bearer 형식 아님 → 401
+ * 3. JWT 서명/파싱 검증 → 실패 시 401 (만료: EXPIRED_TOKEN, 기타: INVALID_TOKEN)
+ * 4. Redis 블랙리스트 확인 → 등록된 토큰 → 401 INVALID_TOKEN
+ * 5. 관리자 전용 엔드포인트 + role != ADMIN → 403
+ * 6. X-User-Id, X-User-Role 헤더 추가 후 downstream 전달
+ *
+ * REQ-GW-002 (JWT 검증), REQ-GW-003 (공개 엔드포인트), REQ-GW-015 (관리자 인가)
+ *
+ * @Order(HIGHEST_PRECEDENCE + 1): TraceIdWebFilter(HIGHEST_PRECEDENCE) 바로 다음 실행
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)
+class JwtAuthenticationWebFilter(
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val tokenBlacklistService: ReactiveTokenBlacklistService,
+    private val routeValidator: RouteValidator,
+    private val objectMapper: ObjectMapper,
+) : WebFilter {
+
+    companion object {
+        private const val BEARER_PREFIX = "Bearer "
+        private const val AUTHORIZATION_HEADER = "Authorization"
+        const val USER_ID_HEADER = "X-User-Id"
+        const val USER_ROLE_HEADER = "X-User-Role"
+
+        // 에러 코드 상수 (common 모듈 의존 불가로 인라인 정의)
+        private const val CODE_UNAUTHORIZED = "UNAUTHORIZED"
+        private const val CODE_INVALID_TOKEN = "INVALID_TOKEN"
+        private const val CODE_EXPIRED_TOKEN = "EXPIRED_TOKEN"
+        private const val CODE_FORBIDDEN = "FORBIDDEN"
+
+        private val TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+    }
+
+    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
+        // 1. 공개 엔드포인트 통과
+        if (routeValidator.isPublic(exchange)) {
+            return chain.filter(exchange)
+        }
+
+        // 2. Authorization 헤더 추출
+        val authHeader = exchange.request.headers.getFirst(AUTHORIZATION_HEADER)
+        if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+            log.debug { "Missing or invalid Authorization header: ${exchange.request.path}" }
+            return writeErrorResponse(exchange, HttpStatus.UNAUTHORIZED, CODE_UNAUTHORIZED, "인증이 필요합니다.")
+        }
+
+        val token = authHeader.removePrefix(BEARER_PREFIX)
+
+        // 3. JWT 검증
+        val claims = try {
+            jwtTokenProvider.validateAndExtract(token)
+        } catch (e: ExpiredJwtException) {
+            log.debug { "Expired JWT token: ${exchange.request.path}" }
+            return writeErrorResponse(exchange, HttpStatus.UNAUTHORIZED, CODE_EXPIRED_TOKEN, "토큰이 만료되었습니다.")
+        } catch (e: JwtException) {
+            log.debug { "Invalid JWT token: ${e.message}" }
+            return writeErrorResponse(exchange, HttpStatus.UNAUTHORIZED, CODE_INVALID_TOKEN, "유효하지 않은 토큰입니다.")
+        } catch (e: IllegalArgumentException) {
+            log.debug { "Invalid JWT token argument: ${e.message}" }
+            return writeErrorResponse(exchange, HttpStatus.UNAUTHORIZED, CODE_INVALID_TOKEN, "유효하지 않은 토큰입니다.")
+        }
+
+        // 4. 블랙리스트 확인 (Redis non-blocking)
+        return tokenBlacklistService.isBlacklisted(claims.jti)
+            .flatMap { isBlacklisted ->
+                if (isBlacklisted) {
+                    log.debug { "Blacklisted token jti=${claims.jti}" }
+                    writeErrorResponse(exchange, HttpStatus.UNAUTHORIZED, CODE_INVALID_TOKEN, "유효하지 않은 토큰입니다.")
+                } else {
+                    // 5. 관리자 전용 엔드포인트 인가 검사
+                    if (routeValidator.isAdminOnly(exchange) && claims.role != "ADMIN") {
+                        log.debug { "Forbidden: role=${claims.role} path=${exchange.request.path}" }
+                        return@flatMap writeErrorResponse(exchange, HttpStatus.FORBIDDEN, CODE_FORBIDDEN, "접근 권한이 없습니다.")
+                    }
+
+                    // 6. 사용자 정보 헤더 추가 후 downstream 전달
+                    val mutatedRequest = exchange.request.mutate()
+                        .header(USER_ID_HEADER, claims.userId)
+                        .header(USER_ROLE_HEADER, claims.role)
+                        .build()
+
+                    chain.filter(exchange.mutate().request(mutatedRequest).build())
+                }
+            }
+    }
+
+    private fun writeErrorResponse(
+        exchange: ServerWebExchange,
+        status: HttpStatus,
+        code: String,
+        message: String,
+    ): Mono<Void> {
+        val traceId = exchange.request.headers.getFirst(TraceIdWebFilter.TRACE_ID_HEADER)
+            ?: exchange.response.headers.getFirst(TraceIdWebFilter.TRACE_ID_HEADER)
+            ?: "unknown"
+
+        val body = mapOf(
+            "code" to code,
+            "message" to message,
+            "timestamp" to LocalDateTime.now().format(TIMESTAMP_FORMATTER),
+            "traceId" to traceId,
+        )
+
+        val bytes = objectMapper.writeValueAsBytes(body)
+        val buffer = exchange.response.bufferFactory().wrap(bytes)
+
+        exchange.response.statusCode = status
+        exchange.response.headers.contentType = MediaType.APPLICATION_JSON
+
+        return exchange.response.writeWith(Mono.just(buffer))
+    }
+}

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilter.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilter.kt
@@ -91,6 +91,10 @@ class JwtAuthenticationWebFilter(
 
         // 4. 블랙리스트 확인 (Redis non-blocking)
         return tokenBlacklistService.isBlacklisted(claims.jti)
+            .onErrorResume { ex ->
+                log.error(ex) { "Redis blacklist check failed for jti=${claims.jti}" }
+                Mono.just(true)
+            }
             .flatMap { isBlacklisted ->
                 if (isBlacklisted) {
                     log.debug { "Blacklisted token jti=${claims.jti}" }

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/security/JwtTokenProvider.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/security/JwtTokenProvider.kt
@@ -1,0 +1,57 @@
+package com.ticketqueue.gateway.security
+
+import com.ticketqueue.gateway.config.JwtProperties
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.stereotype.Component
+import java.util.Base64
+
+/**
+ * JWT 파싱 및 서명 검증 담당
+ *
+ * jjwt 0.12.6 API 사용.
+ * Gateway에서는 검증 + claims 추출만 수행 (토큰 발급은 User Service 담당).
+ */
+@Component
+class JwtTokenProvider(private val jwtProperties: JwtProperties) {
+
+    private val secretKey by lazy {
+        val decoded = Base64.getDecoder().decode(jwtProperties.secret)
+        Keys.hmacShaKeyFor(decoded)
+    }
+
+    /**
+     * 토큰 검증 및 claims 추출
+     *
+     * @throws ExpiredJwtException 토큰 만료
+     * @throws JwtException 서명 불일치, 파싱 오류 등
+     */
+    fun validateAndExtract(token: String): JwtClaims {
+        val claims = Jwts.parser()
+            .verifyWith(secretKey)
+            .build()
+            .parseSignedClaims(token)
+            .payload
+
+        return JwtClaims(
+            userId = claims.subject,
+            role = claims["role"] as String,
+            jti = claims.id,
+        )
+    }
+}
+
+/**
+ * JWT에서 추출한 사용자 정보
+ *
+ * @property userId 사용자 ID (JWT sub 클레임)
+ * @property role 사용자 권한 (USER / ADMIN)
+ * @property jti JWT ID (블랙리스트 조회 키)
+ */
+data class JwtClaims(
+    val userId: String,
+    val role: String,
+    val jti: String,
+)

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/security/JwtTokenProvider.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/security/JwtTokenProvider.kt
@@ -35,11 +35,12 @@ class JwtTokenProvider(private val jwtProperties: JwtProperties) {
             .parseSignedClaims(token)
             .payload
 
-        return JwtClaims(
-            userId = claims.subject,
-            role = claims["role"] as String,
-            jti = claims.id,
-        )
+        val userId = claims.subject ?: throw JwtException("Missing sub claim")
+        val role = claims.get("role", String::class.java)
+            ?: throw JwtException("Missing role claim")
+        val jti = claims.id ?: throw JwtException("Missing jti claim")
+
+        return JwtClaims(userId = userId, role = role, jti = jti)
     }
 }
 

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/security/ReactiveTokenBlacklistService.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/security/ReactiveTokenBlacklistService.kt
@@ -1,0 +1,31 @@
+package com.ticketqueue.gateway.security
+
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+
+/**
+ * Redis에서 Access Token 블랙리스트 여부 확인
+ *
+ * User Service 로그아웃 시 `token:blacklist:{jti}` 키를 Redis에 저장.
+ * Gateway는 해당 키 존재 여부만 확인하여 폐기된 토큰 차단.
+ *
+ * WebFlux 환경에서 non-blocking I/O를 위해 ReactiveStringRedisTemplate 사용.
+ */
+@Component
+class ReactiveTokenBlacklistService(
+    private val redisTemplate: ReactiveStringRedisTemplate,
+) {
+
+    companion object {
+        private const val BLACKLIST_KEY_PREFIX = "token:blacklist:"
+    }
+
+    /**
+     * jti(JWT ID)로 블랙리스트 등록 여부 확인
+     *
+     * @return true면 블랙리스트에 등록된 토큰 (요청 거부 필요)
+     */
+    fun isBlacklisted(jti: String): Mono<Boolean> =
+        redisTemplate.hasKey("$BLACKLIST_KEY_PREFIX$jti")
+}

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/security/RouteValidator.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/security/RouteValidator.kt
@@ -1,0 +1,82 @@
+package com.ticketqueue.gateway.security
+
+import org.springframework.http.HttpMethod
+import org.springframework.stereotype.Component
+import org.springframework.util.AntPathMatcher
+import org.springframework.web.server.ServerWebExchange
+
+/**
+ * 공개/관리자 전용 엔드포인트 판별
+ *
+ * REQ-GW-003 (공개 엔드포인트 허용), REQ-GW-015 (관리자 엔드포인트 인가)
+ */
+@Component
+class RouteValidator {
+
+    private val pathMatcher = AntPathMatcher()
+
+    /**
+     * JWT 검증 없이 통과시킬 공개 엔드포인트 (path + method 조합)
+     *
+     * internal 경로 포함 이유:
+     * JWT 필터는 WebFilter로 게이트웨이 라우트 처리보다 먼저 실행됨.
+     * 내부 API는 게이트웨이 라우트 설정(SetStatus=404)이 차단을 담당하므로,
+     * JWT 필터가 개입하지 않아야 기존 404 동작이 보존됨.
+     */
+    private val publicRoutes: List<RouteRule> = listOf(
+        RouteRule("/auth/signup", HttpMethod.POST),
+        RouteRule("/auth/login", HttpMethod.POST),
+        RouteRule("/auth/refresh", HttpMethod.POST),
+        RouteRule("/events", HttpMethod.GET),
+        RouteRule("/events/*", HttpMethod.GET),
+        RouteRule("/events/schedules/*/seats", HttpMethod.GET),
+        RouteRule("/venues", HttpMethod.GET),
+        RouteRule("/venues/*", HttpMethod.GET),
+        RouteRule("/actuator/**", null), // ANY method
+        RouteRule("/internal/**", null), // 게이트웨이 라우트(404)가 차단 담당
+    )
+
+    /**
+     * ADMIN 권한만 접근 가능한 엔드포인트 (role=ADMIN 아니면 403)
+     */
+    private val adminOnlyRoutes: List<RouteRule> = listOf(
+        RouteRule("/events", HttpMethod.POST),
+        RouteRule("/events/*", HttpMethod.PUT),
+        RouteRule("/events/*", HttpMethod.DELETE),
+        RouteRule("/venues", HttpMethod.POST),
+        RouteRule("/venues/*", HttpMethod.PUT),
+        RouteRule("/venues/*", HttpMethod.DELETE),
+        RouteRule("/venues/*/halls", HttpMethod.POST),
+        RouteRule("/venues/*/halls/*", HttpMethod.PUT),
+        RouteRule("/venues/*/halls/*", HttpMethod.DELETE),
+        RouteRule("/queue/admin/**", null), // ANY method
+    )
+
+    /**
+     * 공개 엔드포인트 여부 확인 (JWT 검증 스킵)
+     */
+    fun isPublic(exchange: ServerWebExchange): Boolean {
+        val path = exchange.request.path.value()
+        val method = exchange.request.method
+        return publicRoutes.any { it.matches(path, method, pathMatcher) }
+    }
+
+    /**
+     * 관리자 전용 엔드포인트 여부 확인 (role=ADMIN 필수)
+     */
+    fun isAdminOnly(exchange: ServerWebExchange): Boolean {
+        val path = exchange.request.path.value()
+        val method = exchange.request.method
+        return adminOnlyRoutes.any { it.matches(path, method, pathMatcher) }
+    }
+
+    private data class RouteRule(
+        val pattern: String,
+        val method: HttpMethod?, // null이면 모든 HTTP 메서드에 적용
+    ) {
+        fun matches(path: String, requestMethod: HttpMethod, matcher: AntPathMatcher): Boolean {
+            if (!matcher.match(pattern, path)) return false
+            return method == null || method == requestMethod
+        }
+    }
+}

--- a/backend/api-gateway/src/main/resources/application.yml
+++ b/backend/api-gateway/src/main/resources/application.yml
@@ -5,6 +5,12 @@ spring:
   application:
     name: api-gateway
 
+  data:
+    redis:
+      host: ${REDIS_HOST:192.168.50.111}
+      port: ${REDIS_PORT:6379}
+      password: ${valkey_password}
+
   cloud:
     gateway:
       server:
@@ -45,6 +51,9 @@ spring:
               uri: ${SERVICE_URI_PAYMENT:http://192.168.50.111:8085}
               predicates:
                 - Path=/payments/**
+
+jwt:
+  secret: ${jwt_secret}
 
 # 기본 Resilience4j 설정 구조
 resilience4j:

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/config/InternalPathBlockFilterTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/config/InternalPathBlockFilterTest.kt
@@ -60,7 +60,8 @@ class InternalPathBlockFilterTest : BaseIntegrationTest() {
 
     @Test
     fun `public route should not be blocked - auth`() {
-        webTestClient.get()
+        // POST /auth/login은 공개 엔드포인트 (JWT 필터 스킵 → downstream 없어 5xx)
+        webTestClient.post()
             .uri("/auth/login")
             .exchange()
             .expectStatus().is5xxServerError
@@ -76,9 +77,11 @@ class InternalPathBlockFilterTest : BaseIntegrationTest() {
 
     @Test
     fun `public route should not be blocked - queue`() {
+        // GET /queue/status는 인증 필요 엔드포인트 → JWT 필터가 401 반환
+        // 내부 경로 차단(404)이 아님을 검증
         webTestClient.get()
             .uri("/queue/status")
             .exchange()
-            .expectStatus().is5xxServerError
+            .expectStatus().isUnauthorized
     }
 }

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/config/InternalPathBlockFilterTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/config/InternalPathBlockFilterTest.kt
@@ -76,7 +76,7 @@ class InternalPathBlockFilterTest : BaseIntegrationTest() {
     }
 
     @Test
-    fun `public route should not be blocked - queue`() {
+    fun `non-internal route should not be blocked - queue`() {
         // GET /queue/status는 인증 필요 엔드포인트 → JWT 필터가 401 반환
         // 내부 경로 차단(404)이 아님을 검증
         webTestClient.get()

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterTest.kt
@@ -1,0 +1,116 @@
+package com.ticketqueue.gateway.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.ticketqueue.gateway.BaseIntegrationTest
+import com.ticketqueue.gateway.security.ReactiveTokenBlacklistService
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.test.web.reactive.server.WebTestClient
+import reactor.core.publisher.Mono
+import java.util.Base64
+import java.util.Date
+import java.util.UUID
+
+/**
+ * JwtAuthenticationWebFilter 통합 테스트
+ *
+ * - ReactiveTokenBlacklistService: @MockkBean (Redis 불필요)
+ * - 실제 JWT 토큰 생성하여 검증
+ * - BaseIntegrationTest 상속 (SpringBootTest + test 프로파일)
+ */
+class JwtAuthenticationWebFilterTest : BaseIntegrationTest() {
+
+    @Autowired
+    private lateinit var webTestClient: WebTestClient
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockkBean
+    private lateinit var tokenBlacklistService: ReactiveTokenBlacklistService
+
+    @Value("\${jwt.secret}")
+    private lateinit var jwtSecret: String
+
+    // ─── 공개 엔드포인트 ───────────────────────────────────────────────
+
+    @Test
+    fun `공개 엔드포인트는 토큰 없이 요청 시 401이 아닌 다른 응답 반환 (downstream 없어 5xx)`() {
+        webTestClient.get()
+            .uri("/events")
+            .exchange()
+            .expectStatus().is5xxServerError // Downstream 없으므로 502/503, 401 아님
+    }
+
+    // ─── 인증 실패 ─────────────────────────────────────────────────────
+
+    @Test
+    fun `보호 엔드포인트에 토큰 없이 요청하면 401과 JSON 에러 응답 반환`() {
+        val responseBody = webTestClient.get()
+            .uri("/reservations/seats/1")
+            .exchange()
+            .expectStatus().isUnauthorized
+            .expectHeader().contentType("application/json")
+            .expectBody(String::class.java)
+            .returnResult()
+            .responseBody!!
+
+        responseBody shouldContain "\"code\":\"UNAUTHORIZED\""
+        responseBody shouldContain "\"message\""
+        responseBody shouldContain "\"timestamp\""
+        responseBody shouldContain "\"traceId\""
+    }
+
+    @Test
+    fun `보호 엔드포인트에 잘못된 토큰으로 요청하면 401 반환`() {
+        webTestClient.post()
+            .uri("/reservations/hold")
+            .header("Authorization", "Bearer this.is.invalid.token")
+            .exchange()
+            .expectStatus().isUnauthorized
+            .expectBody(String::class.java)
+            .value { body ->
+                body shouldContain "\"code\":\"INVALID_TOKEN\""
+            }
+    }
+
+    @Test
+    fun `유효한 토큰으로 보호 엔드포인트 접근 시 downstream으로 전달 (5xx는 downstream 부재 때문)`() {
+        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
+
+        val token = createValidToken(userId = "user-1", role = "USER")
+
+        webTestClient.post()
+            .uri("/reservations/hold")
+            .header("Authorization", "Bearer $token")
+            .exchange()
+            .expectStatus().is5xxServerError // JWT 필터 통과 후 downstream 없어서 5xx
+    }
+
+    // ─── 헬퍼 ─────────────────────────────────────────────────────────
+
+    private fun createValidToken(
+        userId: String,
+        role: String,
+        expirationMs: Long = 3_600_000L, // 1시간
+    ): String {
+        val decoded = Base64.getDecoder().decode(jwtSecret)
+        val key = Keys.hmacShaKeyFor(decoded)
+
+        return Jwts.builder()
+            .subject(userId)
+            .claim("role", role)
+            .id(UUID.randomUUID().toString())
+            .issuedAt(Date())
+            .expiration(Date(System.currentTimeMillis() + expirationMs))
+            .signWith(key)
+            .compact()
+    }
+}

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterUnitTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterUnitTest.kt
@@ -204,6 +204,23 @@ class JwtAuthenticationWebFilterUnitTest {
         body shouldContain "\"code\":\"INVALID_TOKEN\""
     }
 
+    @Test
+    fun `Redis 오류 시 fail-closed 전략으로 401 INVALID_TOKEN 반환`() {
+        val claims = JwtClaims(userId = "user-1", role = "USER", jti = "some-jti")
+        every { jwtTokenProvider.validateAndExtract(any()) } returns claims
+        every { tokenBlacklistService.isBlacklisted("some-jti") } returns
+            Mono.error(RuntimeException("Redis connection refused"))
+
+        val exchange = exchangeWithBearer(HttpMethod.GET, "/reservations/seats/1", "valid.token")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"INVALID_TOKEN\""
+    }
+
     // ─── 인가 실패 ─────────────────────────────────────────────────────
 
     @Test
@@ -280,7 +297,7 @@ class JwtAuthenticationWebFilterUnitTest {
             HttpMethod.POST -> MockServerHttpRequest.post(path)
             HttpMethod.PUT -> MockServerHttpRequest.put(path)
             HttpMethod.DELETE -> MockServerHttpRequest.delete(path)
-            else -> MockServerHttpRequest.get(path)
+            else -> error("Unsupported HTTP method: $method")
         }
         block(builder)
         return MockServerWebExchange.from(builder.build())

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterUnitTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterUnitTest.kt
@@ -1,0 +1,301 @@
+package com.ticketqueue.gateway.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.gateway.config.JwtProperties
+import com.ticketqueue.gateway.security.JwtClaims
+import com.ticketqueue.gateway.security.JwtTokenProvider
+import com.ticketqueue.gateway.security.ReactiveTokenBlacklistService
+import com.ticketqueue.gateway.security.RouteValidator
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.JwtException
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+/**
+ * JwtAuthenticationWebFilter 단위 테스트
+ *
+ * MockK로 JwtTokenProvider, ReactiveTokenBlacklistService를 mock.
+ * RouteValidator는 실제 인스턴스 사용.
+ */
+class JwtAuthenticationWebFilterUnitTest {
+
+    private val jwtTokenProvider: JwtTokenProvider = mockk()
+    private val tokenBlacklistService: ReactiveTokenBlacklistService = mockk()
+    private val routeValidator = RouteValidator()
+    private val objectMapper = ObjectMapper()
+
+    private val filter = JwtAuthenticationWebFilter(
+        jwtTokenProvider,
+        tokenBlacklistService,
+        routeValidator,
+        objectMapper,
+    )
+
+    private val passChain = WebFilterChain { Mono.empty() }
+
+    // 다운스트림으로 전달된 요청 헤더를 캡처하는 체인
+    private var capturedHeaders: org.springframework.http.HttpHeaders? = null
+    private val capturingChain = WebFilterChain { exchange ->
+        capturedHeaders = exchange.request.headers
+        Mono.empty()
+    }
+
+    @BeforeEach
+    fun setUp() {
+        capturedHeaders = null
+    }
+
+    // ─── 공개 엔드포인트 통과 ───────────────────────────────────────────
+
+    @Test
+    fun `POST auth-login은 JWT 검증 없이 통과`() {
+        val exchange = exchange(HttpMethod.POST, "/auth/login")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null // 필터가 응답 쓰지 않음
+    }
+
+    @Test
+    fun `POST auth-signup은 JWT 검증 없이 통과`() {
+        val exchange = exchange(HttpMethod.POST, "/auth/signup")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null
+    }
+
+    @Test
+    fun `POST auth-refresh는 JWT 검증 없이 통과`() {
+        val exchange = exchange(HttpMethod.POST, "/auth/refresh")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null
+    }
+
+    @Test
+    fun `GET events는 JWT 검증 없이 통과`() {
+        val exchange = exchange(HttpMethod.GET, "/events")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null
+    }
+
+    @Test
+    fun `GET events-id는 JWT 검증 없이 통과`() {
+        val exchange = exchange(HttpMethod.GET, "/events/123")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null
+    }
+
+    @Test
+    fun `GET events-schedules-id-seats는 JWT 검증 없이 통과`() {
+        val exchange = exchange(HttpMethod.GET, "/events/schedules/456/seats")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null
+    }
+
+    @Test
+    fun `GET actuator-health는 JWT 검증 없이 통과`() {
+        val exchange = exchange(HttpMethod.GET, "/actuator/health")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null
+    }
+
+    // ─── 인증 실패 ─────────────────────────────────────────────────────
+
+    @Test
+    fun `Authorization 헤더 없으면 401 UNAUTHORIZED 반환`() {
+        val exchange = exchange(HttpMethod.GET, "/reservations/seats/1")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"UNAUTHORIZED\""
+        body shouldContain "\"traceId\""
+        body shouldContain "\"timestamp\""
+    }
+
+    @Test
+    fun `Bearer 접두사 없는 헤더는 401 반환`() {
+        val exchange = exchange(HttpMethod.GET, "/reservations/seats/1") {
+            header(HttpHeaders.AUTHORIZATION, "Basic sometoken")
+        }
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+    }
+
+    @Test
+    fun `만료된 토큰은 401 EXPIRED_TOKEN 반환`() {
+        every { jwtTokenProvider.validateAndExtract(any()) } throws
+            ExpiredJwtException(null, null, "expired")
+
+        val exchange = exchangeWithBearer(HttpMethod.GET, "/reservations/seats/1", "expired.token")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"EXPIRED_TOKEN\""
+        body shouldContain "토큰이 만료되었습니다"
+    }
+
+    @Test
+    fun `변조된 토큰은 401 INVALID_TOKEN 반환`() {
+        every { jwtTokenProvider.validateAndExtract(any()) } throws
+            JwtException("invalid signature")
+
+        val exchange = exchangeWithBearer(HttpMethod.GET, "/reservations/seats/1", "tampered.token")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"INVALID_TOKEN\""
+    }
+
+    @Test
+    fun `블랙리스트 토큰은 401 INVALID_TOKEN 반환`() {
+        val claims = JwtClaims(userId = "user-1", role = "USER", jti = "blacklisted-jti")
+        every { jwtTokenProvider.validateAndExtract(any()) } returns claims
+        every { tokenBlacklistService.isBlacklisted("blacklisted-jti") } returns Mono.just(true)
+
+        val exchange = exchangeWithBearer(HttpMethod.GET, "/reservations/seats/1", "valid.token")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"INVALID_TOKEN\""
+    }
+
+    // ─── 인가 실패 ─────────────────────────────────────────────────────
+
+    @Test
+    fun `일반 사용자가 관리자 엔드포인트 접근 시 403 FORBIDDEN 반환`() {
+        val claims = JwtClaims(userId = "user-1", role = "USER", jti = "jti-1")
+        every { jwtTokenProvider.validateAndExtract(any()) } returns claims
+        every { tokenBlacklistService.isBlacklisted("jti-1") } returns Mono.just(false)
+
+        val exchange = exchangeWithBearer(HttpMethod.POST, "/events", "valid.token")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.FORBIDDEN
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"FORBIDDEN\""
+        body shouldContain "접근 권한이 없습니다"
+    }
+
+    // ─── 성공 케이스 ───────────────────────────────────────────────────
+
+    @Test
+    fun `관리자가 관리자 엔드포인트 접근 시 통과`() {
+        val claims = JwtClaims(userId = "admin-1", role = "ADMIN", jti = "jti-admin")
+        every { jwtTokenProvider.validateAndExtract(any()) } returns claims
+        every { tokenBlacklistService.isBlacklisted("jti-admin") } returns Mono.just(false)
+
+        val exchange = exchangeWithBearer(HttpMethod.POST, "/events", "valid.token")
+
+        StepVerifier.create(filter.filter(exchange, capturingChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null // 필터가 응답 쓰지 않음
+    }
+
+    @Test
+    fun `유효한 토큰 요청 시 X-User-Id, X-User-Role 헤더 downstream에 추가`() {
+        val claims = JwtClaims(userId = "user-42", role = "USER", jti = "jti-42")
+        every { jwtTokenProvider.validateAndExtract(any()) } returns claims
+        every { tokenBlacklistService.isBlacklisted("jti-42") } returns Mono.just(false)
+
+        val exchange = exchangeWithBearer(HttpMethod.POST, "/reservations/hold", "valid.token")
+
+        StepVerifier.create(filter.filter(exchange, capturingChain))
+            .verifyComplete()
+
+        capturedHeaders?.getFirst(JwtAuthenticationWebFilter.USER_ID_HEADER) shouldBe "user-42"
+        capturedHeaders?.getFirst(JwtAuthenticationWebFilter.USER_ROLE_HEADER) shouldBe "USER"
+    }
+
+    @Test
+    fun `에러 응답 JSON에 code, message, timestamp, traceId 모두 포함`() {
+        val exchange = exchange(HttpMethod.GET, "/reservations/seats/1")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        val body = responseBody(exchange)
+        body shouldContain "\"code\""
+        body shouldContain "\"message\""
+        body shouldContain "\"timestamp\""
+        body shouldContain "\"traceId\""
+    }
+
+    // ─── 헬퍼 ─────────────────────────────────────────────────────────
+
+    private fun exchange(
+        method: HttpMethod,
+        path: String,
+        block: MockServerHttpRequest.BaseBuilder<*>.() -> Unit = {},
+    ): MockServerWebExchange {
+        val builder = when (method) {
+            HttpMethod.GET -> MockServerHttpRequest.get(path)
+            HttpMethod.POST -> MockServerHttpRequest.post(path)
+            HttpMethod.PUT -> MockServerHttpRequest.put(path)
+            HttpMethod.DELETE -> MockServerHttpRequest.delete(path)
+            else -> MockServerHttpRequest.get(path)
+        }
+        block(builder)
+        return MockServerWebExchange.from(builder.build())
+    }
+
+    private fun exchangeWithBearer(
+        method: HttpMethod,
+        path: String,
+        token: String,
+    ): MockServerWebExchange = exchange(method, path) {
+        header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+    }
+
+    private fun responseBody(exchange: MockServerWebExchange): String {
+        val body = exchange.response.bodyAsString.block() ?: ""
+        return body
+    }
+}

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/TraceIdWebFilterTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/TraceIdWebFilterTest.kt
@@ -96,19 +96,23 @@ class TraceIdWebFilterTest : BaseIntegrationTest() {
 
     @Test
     fun `PUT 요청에도 TraceId 적용`() {
+        // PUT /reservations/1은 인증 필요 → JWT 필터가 401 반환
+        // TraceId 필터는 JWT 필터보다 먼저 실행되므로 401 응답에도 TraceId 헤더 존재
         webTestClient.put()
             .uri("/reservations/1")
             .exchange()
-            .expectStatus().is5xxServerError
+            .expectStatus().isUnauthorized
             .expectHeader().exists(TraceIdWebFilter.TRACE_ID_HEADER)
     }
 
     @Test
     fun `DELETE 요청에도 TraceId 적용`() {
+        // DELETE /reservations/1은 인증 필요 → JWT 필터가 401 반환
+        // TraceId 필터는 JWT 필터보다 먼저 실행되므로 401 응답에도 TraceId 헤더 존재
         webTestClient.delete()
             .uri("/reservations/1")
             .exchange()
-            .expectStatus().is5xxServerError
+            .expectStatus().isUnauthorized
             .expectHeader().exists(TraceIdWebFilter.TRACE_ID_HEADER)
     }
 

--- a/backend/api-gateway/src/test/resources/application-test.yml
+++ b/backend/api-gateway/src/test/resources/application-test.yml
@@ -49,11 +49,13 @@ spring:
             connect-timeout: 1000
             response-timeout: 5s
 
-  # Disable Redis for tests - use embedded or mock
   data:
     redis:
       host: localhost
       port: 6379
+
+jwt:
+  secret: dGVzdC1zZWNyZXQta2V5LWZvci1qd3QtdG9rZW4tdmVyaWZpY2F0aW9uLXRlc3Rpbmc=
 
 management:
   endpoints:

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-start
 spring-boot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux" }
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
 spring-boot-starter-data-redis = { module = "org.springframework.boot:spring-boot-starter-data-redis" }
+spring-boot-starter-data-redis-reactive = { module = "org.springframework.boot:spring-boot-starter-data-redis-reactive" }
 spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
 spring-boot-starter-validation = { module = "org.springframework.boot:spring-boot-starter-validation" }
 spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }


### PR DESCRIPTION
## Summary
- API Gateway에서 JWT 토큰 검증 필터(`JwtAuthenticationWebFilter`) 구현
- REQ-GW-002(JWT 검증), REQ-GW-003(공개 엔드포인트 허용), REQ-GW-015(관리자 엔드포인트 인가) 충족

## Changes
- `libs.versions.toml` / `build.gradle.kts`: Redis Reactive, jjwt 의존성 추가
- `application.yml`: Redis, JWT secret 설정 추가
- `JwtProperties`: `@ConfigurationProperties(prefix = "jwt")` — secret 바인딩
- `GatewayConfig`: `@EnableConfigurationProperties(JwtProperties::class)` 추가
- `JwtTokenProvider`: jjwt 0.12.6 기반 HS256 서명 검증 및 `JwtClaims(userId, role, jti)` 추출
- `ReactiveTokenBlacklistService`: Redis `token:blacklist:{jti}` 키 존재 여부 non-blocking 조회
- `RouteValidator`: 공개/관리자 전용 엔드포인트 판별 (AntPathMatcher, path + method 조합)
- `JwtAuthenticationWebFilter`: `@Order(HIGHEST_PRECEDENCE + 1)`, TraceIdWebFilter 바로 다음 실행
  - 공개 엔드포인트 → 통과
  - Authorization 헤더 누락/형식 불일치 → 401 UNAUTHORIZED
  - 만료 토큰 → 401 EXPIRED_TOKEN
  - 변조/잘못된 토큰 → 401 INVALID_TOKEN
  - Redis 블랙리스트 토큰 → 401 INVALID_TOKEN
  - role != ADMIN인 관리자 엔드포인트 접근 → 403 FORBIDDEN
  - 성공 시 `X-User-Id`, `X-User-Role` 헤더 추가 후 downstream 전달

## Test plan
- [x] `JwtAuthenticationWebFilterUnitTest`: 16개 단위 테스트 (MockK, MockServerWebExchange)
  - 공개 엔드포인트 7개 케이스 통과 확인
  - 401/403 에러 케이스 확인
  - downstream 헤더 전달 확인
  - 에러 응답 JSON 포맷 확인
- [x] `JwtAuthenticationWebFilterTest`: 4개 통합 테스트 (WebTestClient, @MockkBean)
  - 공개 엔드포인트 5xx 응답 (downstream 부재)
  - 보호 엔드포인트 401 + JSON 에러 응답
  - 잘못된 토큰 401 응답
  - 유효 토큰으로 downstream 통과 확인
- [x] 기존 테스트 회귀 없음 (48개 전체 통과)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API Gateway enforces JWT authentication for protected endpoints; public endpoints remain open.
  * Admin-only routes are restricted; valid tokens inject X-User-Id and X-User-Role headers downstream.
  * Error responses standardized as JSON with code, message, timestamp, and traceId.

* **Tests**
  * Integration and unit tests added to validate JWT flows, blacklist handling, admin checks, and error responses.

* **Chores**
  * Added Redis and JWT libraries and configuration for token validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #14 