### PR TITLE
feat: [Gateway] 타임아웃 및 Circuit Breaker 설정 #16

### DIFF
--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/controller/FallbackController.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/controller/FallbackController.kt
@@ -1,0 +1,70 @@
+package com.ticketqueue.gateway.controller
+
+import com.ticketqueue.gateway.filter.TraceIdWebFilter
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ServerWebExchange
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Circuit Breaker Fallback 컨트롤러
+ *
+ * 다운스트림 서비스 장애 시 503 Service Unavailable 응답을 반환합니다.
+ * Circuit Breaker 필터의 `fallbackUri: forward:/fallback/{serviceName}`으로 내부 포워드 호출됩니다.
+ *
+ * forward: 방식은 WebFilter 체인을 재실행하지 않으므로,
+ * JWT 검증이 이미 완료된 상태에서 이 컨트롤러가 호출됩니다.
+ *
+ * REQ-GW-006 (Circuit Breaker), REQ-GW-017 (Fallback 응답 503)
+ */
+@RestController
+@RequestMapping("/fallback")
+class FallbackController {
+
+    companion object {
+        private val TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+        private const val ERROR_CODE = "SERVICE_UNAVAILABLE"
+        private const val DEFAULT_MESSAGE = "서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요."
+
+        private val SERVICE_MESSAGES = mapOf(
+            "user" to "인증 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.",
+            "event" to "공연 정보 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.",
+            "queue" to "대기열 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.",
+            "reservation" to "예매 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.",
+            "payment" to "결제 서비스가 일시적으로 불안정합니다. 이중 결제를 방지하기 위해 결제 내역을 확인한 후 다시 시도해주세요.",
+        )
+    }
+
+    /**
+     * 모든 HTTP 메서드에 대해 서비스별 503 응답 반환
+     *
+     * @param serviceName 서비스명 (user, event, queue, reservation, payment)
+     * @param exchange 원본 요청 exchange (TraceId 헤더 추출용)
+     */
+    @RequestMapping("/{serviceName}")
+    fun fallback(
+        @PathVariable serviceName: String,
+        exchange: ServerWebExchange,
+    ): ResponseEntity<Map<String, Any>> {
+        val traceId = exchange.request.headers.getFirst(TraceIdWebFilter.TRACE_ID_HEADER) ?: "unknown"
+        val message = SERVICE_MESSAGES[serviceName] ?: DEFAULT_MESSAGE
+
+        val body: Map<String, Any> = mapOf(
+            "code" to ERROR_CODE,
+            "message" to message,
+            "timestamp" to LocalDateTime.now().format(TIMESTAMP_FORMATTER),
+            "traceId" to traceId,
+        )
+
+        log.warn { "Circuit Breaker fallback: service=$serviceName, traceId=$traceId, path=${exchange.request.path}" }
+
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(body)
+    }
+}

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/security/RouteValidator.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/security/RouteValidator.kt
@@ -34,6 +34,7 @@ class RouteValidator {
         RouteRule("/venues/*", HttpMethod.GET),
         RouteRule("/actuator/**", null), // ANY method
         RouteRule("/internal/**", null), // 게이트웨이 라우트(404)가 차단 담당
+        RouteRule("/fallback/**", null), // 서킷 브레이커 폴백 (내부 포워드 경로, 민감 데이터 없음)
     )
 
     /**

--- a/backend/api-gateway/src/main/resources/application.yml
+++ b/backend/api-gateway/src/main/resources/application.yml
@@ -15,6 +15,9 @@ spring:
     gateway:
       server:
         webflux:
+          httpclient:
+            connect-timeout: 5000    # 5초 연결 타임아웃
+            response-timeout: 30s    # 30초 글로벌 응답 타임아웃 (REQ-GW-007)
           routes:
             # /internal/** 차단 라우트 (최우선 순위)
             # 내부 API는 외부 접근 차단
@@ -26,41 +29,108 @@ spring:
                 - SetStatus=404
               order: -1
 
-            # 기본 라우트 구조 정의 (세부 필터는 향후 추가 예정)
             - id: user-service
               uri: ${SERVICE_URI_USER:http://192.168.50.111:8081}
               predicates:
                 - Path=/auth/**,/users/**
+              filters:
+                - name: CircuitBreaker
+                  args:
+                    name: userService
+                    fallbackUri: forward:/fallback/user
 
             - id: event-service
               uri: ${SERVICE_URI_EVENT:http://192.168.50.111:8082}
               predicates:
                 - Path=/events/**,/venues/**
+              filters:
+                - name: CircuitBreaker
+                  args:
+                    name: eventService
+                    fallbackUri: forward:/fallback/event
 
-            - id: queue-service
+            - id: queue-service                          # REQ-GW-008: 10초 타임아웃
               uri: ${SERVICE_URI_QUEUE:http://192.168.50.111:8083}
               predicates:
                 - Path=/queue/**
+              metadata:
+                response-timeout: 10000
+              filters:
+                - name: CircuitBreaker
+                  args:
+                    name: queueService
+                    fallbackUri: forward:/fallback/queue
 
             - id: reservation-service
               uri: ${SERVICE_URI_RESERVATION:http://192.168.50.111:8084}
               predicates:
                 - Path=/reservations/**
+              filters:
+                - name: CircuitBreaker
+                  args:
+                    name: reservationService
+                    fallbackUri: forward:/fallback/reservation
 
-            - id: payment-service
+            - id: payment-service                        # REQ-GW-008: 60초 타임아웃
               uri: ${SERVICE_URI_PAYMENT:http://192.168.50.111:8085}
               predicates:
                 - Path=/payments/**
+              metadata:
+                response-timeout: 60000
+              filters:
+                - name: CircuitBreaker
+                  args:
+                    name: paymentService
+                    fallbackUri: forward:/fallback/payment
 
 jwt:
   secret: ${jwt_secret}
 
-# 기본 Resilience4j 설정 구조
+# Resilience4j Circuit Breaker + TimeLimiter 설정 (REQ-GW-006)
+# TimeLimiter 필수 이유: ReactiveResilience4JCircuitBreakerFactory가 내부적으로 TimeLimiter를 함께 감싸며,
+# 미설정 시 기본 1초로 모든 요청이 타임아웃됨.
 resilience4j:
   circuitbreaker:
     configs:
       default:
         registerHealthIndicator: true
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 100
+        minimumNumberOfCalls: 20
+        failureRateThreshold: 50
+        waitDurationInOpenState: 60s
+        permittedNumberOfCallsInHalfOpenState: 10
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+    instances:
+      userService:
+        baseConfig: default
+      eventService:
+        baseConfig: default
+      queueService:
+        baseConfig: default
+      reservationService:
+        baseConfig: default
+      paymentService:
+        baseConfig: default
+
+  timelimiter:
+    configs:
+      default:
+        timeoutDuration: 30s
+        cancelRunningFuture: true
+    instances:
+      userService:
+        baseConfig: default
+      eventService:
+        baseConfig: default
+      queueService:
+        baseConfig: default
+        timeoutDuration: 10s     # REQ-GW-008: Queue 10초
+      reservationService:
+        baseConfig: default
+      paymentService:
+        baseConfig: default
+        timeoutDuration: 60s     # REQ-GW-008: Payment 60초
 
 management:
   endpoints:

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/config/CircuitBreakerConfigTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/config/CircuitBreakerConfigTest.kt
@@ -1,0 +1,108 @@
+package com.ticketqueue.gateway.config
+
+import com.ticketqueue.gateway.BaseIntegrationTest
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import io.github.resilience4j.timelimiter.TimeLimiterRegistry
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+/**
+ * CircuitBreaker + TimeLimiter 설정 검증 테스트
+ *
+ * Resilience4j CircuitBreakerRegistry / TimeLimiterRegistry에
+ * 5개 서비스 인스턴스가 application-test.yml에 정의된 설정으로
+ * 올바르게 등록되었는지 검증합니다.
+ *
+ * REQ-GW-006 (Circuit Breaker), REQ-GW-007/008 (Timeout)
+ */
+class CircuitBreakerConfigTest : BaseIntegrationTest() {
+
+    @Autowired
+    private lateinit var circuitBreakerRegistry: CircuitBreakerRegistry
+
+    @Autowired
+    private lateinit var timeLimiterRegistry: TimeLimiterRegistry
+
+    companion object {
+        private val SERVICE_NAMES = listOf(
+            "userService",
+            "eventService",
+            "queueService",
+            "reservationService",
+            "paymentService",
+        )
+    }
+
+    // ─── CircuitBreaker 검증 ───────────────────────────────────────────
+
+    @Test
+    fun `5개 CircuitBreaker 인스턴스가 레지스트리에서 생성 가능해야 한다`() {
+        SERVICE_NAMES.forEach { name ->
+            val cb = circuitBreakerRegistry.circuitBreaker(name)
+            cb shouldNotBe null
+            cb.name shouldBe name
+        }
+    }
+
+    @Test
+    fun `CircuitBreaker default 설정값이 application-test yml 기준으로 올바르게 적용되어야 한다`() {
+        val config = circuitBreakerRegistry.circuitBreaker("userService").circuitBreakerConfig
+
+        // application-test.yml: slidingWindowSize: 10
+        config.slidingWindowSize shouldBe 10
+        // application-test.yml: failureRateThreshold: 50
+        config.failureRateThreshold shouldBe 50f
+        // application-test.yml: minimumNumberOfCalls: 3
+        config.minimumNumberOfCalls shouldBe 3
+    }
+
+    @Test
+    fun `모든 서비스가 동일한 default 설정을 공유해야 한다`() {
+        SERVICE_NAMES.forEach { name ->
+            val config = circuitBreakerRegistry.circuitBreaker(name).circuitBreakerConfig
+            config.slidingWindowSize shouldBe 10
+            config.failureRateThreshold shouldBe 50f
+        }
+    }
+
+    // ─── TimeLimiter 검증 ──────────────────────────────────────────────
+
+    @Test
+    fun `5개 TimeLimiter 인스턴스가 레지스트리에서 생성 가능해야 한다`() {
+        SERVICE_NAMES.forEach { name ->
+            val tl = timeLimiterRegistry.timeLimiter(name)
+            tl shouldNotBe null
+        }
+    }
+
+    @Test
+    fun `TimeLimiter default timeoutDuration이 5초이어야 한다`() {
+        // application-test.yml default: 5s
+        val config = timeLimiterRegistry.timeLimiter("userService").timeLimiterConfig
+        config.timeoutDuration.toSeconds() shouldBe 5L
+    }
+
+    @Test
+    fun `queueService TimeLimiter timeoutDuration이 3초이어야 한다`() {
+        // application-test.yml queueService override: 3s (운영 10s → 테스트 축소)
+        val config = timeLimiterRegistry.timeLimiter("queueService").timeLimiterConfig
+        config.timeoutDuration.toSeconds() shouldBe 3L
+    }
+
+    @Test
+    fun `paymentService TimeLimiter timeoutDuration이 10초이어야 한다`() {
+        // application-test.yml paymentService override: 10s (운영 60s → 테스트 축소)
+        val config = timeLimiterRegistry.timeLimiter("paymentService").timeLimiterConfig
+        config.timeoutDuration.toSeconds() shouldBe 10L
+    }
+
+    @Test
+    fun `모든 서비스의 cancelRunningFuture가 true이어야 한다`() {
+        SERVICE_NAMES.forEach { name ->
+            val config = timeLimiterRegistry.timeLimiter(name).timeLimiterConfig
+            config.shouldCancelRunningFuture() shouldBe true
+        }
+    }
+}

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/config/GatewayBasicConfigTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/config/GatewayBasicConfigTest.kt
@@ -53,4 +53,27 @@ class GatewayBasicConfigTest {
         assertThat(routeMap["reservation-service"]).contains("localhost:8084")
         assertThat(routeMap["payment-service"]).contains("localhost:8085")
     }
+
+    @Test
+    fun `queue-service와 payment-service 라우트에 커스텀 response-timeout 메타데이터가 설정되어야 한다`() {
+        // when
+        val routes = routeLocator.routes.collectList().block()!!
+        val metaMap = routes.associate { it.id to it.metadata }
+
+        // then — REQ-GW-008: queue 10s, payment 60s
+        assertThat(metaMap["queue-service"]!!["response-timeout"]).isEqualTo(10000)
+        assertThat(metaMap["payment-service"]!!["response-timeout"]).isEqualTo(60000)
+    }
+
+    @Test
+    fun `user-service event-service reservation-service 라우트에는 커스텀 response-timeout 메타데이터가 없어야 한다`() {
+        // when
+        val routes = routeLocator.routes.collectList().block()!!
+        val metaMap = routes.associate { it.id to it.metadata }
+
+        // then — 글로벌 타임아웃(30s)만 적용되는 서비스
+        assertThat(metaMap["user-service"]!!).doesNotContainKey("response-timeout")
+        assertThat(metaMap["event-service"]!!).doesNotContainKey("response-timeout")
+        assertThat(metaMap["reservation-service"]!!).doesNotContainKey("response-timeout")
+    }
 }

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/controller/FallbackControllerTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/controller/FallbackControllerTest.kt
@@ -1,0 +1,69 @@
+package com.ticketqueue.gateway.controller
+
+import com.ticketqueue.gateway.BaseIntegrationTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+
+/**
+ * FallbackController 통합 테스트
+ *
+ * 실제 Spring 컨텍스트에서 /fallback/{service} 엔드포인트의 응답을 검증합니다.
+ * /fallback/{service} 는 RouteValidator에 public 경로로 등록되어 있어 JWT 없이 직접 호출 가능합니다.
+ */
+class FallbackControllerTest : BaseIntegrationTest() {
+
+    @Autowired
+    private lateinit var webTestClient: WebTestClient
+
+    // ─── GET 요청 ─────────────────────────────────────────────────────
+
+    @ParameterizedTest
+    @ValueSource(strings = ["user", "event", "queue", "reservation", "payment"])
+    fun `GET fallback 호출 시 503과 JSON 응답 반환`(serviceName: String) {
+        webTestClient.get()
+            .uri("/fallback/$serviceName")
+            .exchange()
+            .expectStatus().isEqualTo(503)
+            .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    }
+
+    // ─── POST 요청 ────────────────────────────────────────────────────
+
+    @ParameterizedTest
+    @ValueSource(strings = ["user", "event", "queue", "reservation", "payment"])
+    fun `POST fallback 호출 시 503과 JSON 응답 반환`(serviceName: String) {
+        webTestClient.post()
+            .uri("/fallback/$serviceName")
+            .exchange()
+            .expectStatus().isEqualTo(503)
+            .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    }
+
+    // ─── 응답 body 구조 ───────────────────────────────────────────────
+
+    @Test
+    fun `응답 body에 code, message, timestamp, traceId가 포함되어야 한다`() {
+        webTestClient.get()
+            .uri("/fallback/user")
+            .exchange()
+            .expectStatus().isEqualTo(503)
+            .expectBody()
+            .jsonPath("$.code").isEqualTo("SERVICE_UNAVAILABLE")
+            .jsonPath("$.message").isNotEmpty
+            .jsonPath("$.timestamp").isNotEmpty
+            .jsonPath("$.traceId").isNotEmpty
+    }
+
+    @Test
+    fun `Content-Type은 application-json이어야 한다`() {
+        webTestClient.get()
+            .uri("/fallback/event")
+            .exchange()
+            .expectStatus().isEqualTo(503)
+            .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    }
+}

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/controller/FallbackControllerUnitTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/controller/FallbackControllerUnitTest.kt
@@ -1,0 +1,101 @@
+package com.ticketqueue.gateway.controller
+
+import com.ticketqueue.gateway.filter.TraceIdWebFilter
+import io.kotest.matchers.maps.shouldContainKeys
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotBeBlank
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.http.HttpStatus
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+
+/**
+ * FallbackController 단위 테스트
+ *
+ * Spring 컨텍스트 없이 컨트롤러 메서드를 직접 호출하여 검증합니다.
+ * MockServerWebExchange로 요청 헤더를 제어합니다.
+ */
+class FallbackControllerUnitTest {
+
+    private val controller = FallbackController()
+
+    private fun makeExchange(serviceName: String, traceId: String? = null): MockServerWebExchange {
+        val builder = MockServerHttpRequest.get("/fallback/$serviceName")
+        traceId?.let { builder.header(TraceIdWebFilter.TRACE_ID_HEADER, it) }
+        return MockServerWebExchange.from(builder.build())
+    }
+
+    // ─── 503 상태 코드 ────────────────────────────────────────────────
+
+    @ParameterizedTest
+    @ValueSource(strings = ["user", "event", "queue", "reservation", "payment"])
+    fun `모든 서비스 fallback 호출 시 503 반환`(serviceName: String) {
+        val response = controller.fallback(serviceName, makeExchange(serviceName))
+
+        response.statusCode shouldBe HttpStatus.SERVICE_UNAVAILABLE
+    }
+
+    @Test
+    fun `미지원 서비스명 요청 시에도 503 반환`() {
+        val response = controller.fallback("unknown-service", makeExchange("unknown-service"))
+
+        response.statusCode shouldBe HttpStatus.SERVICE_UNAVAILABLE
+    }
+
+    // ─── 응답 body 구조 ───────────────────────────────────────────────
+
+    @Test
+    fun `응답 body에 code, message, timestamp, traceId 4개 필드가 존재해야 한다`() {
+        val response = controller.fallback("user", makeExchange("user"))
+        val body = response.body!!
+
+        body.shouldContainKeys("code", "message", "timestamp", "traceId")
+    }
+
+    @Test
+    fun `에러 코드는 SERVICE_UNAVAILABLE이어야 한다`() {
+        val response = controller.fallback("user", makeExchange("user"))
+        val body = response.body!!
+
+        body["code"] shouldBe "SERVICE_UNAVAILABLE"
+    }
+
+    // ─── traceId 매핑 ─────────────────────────────────────────────────
+
+    @Test
+    fun `X-Trace-Id 헤더 값이 응답 body의 traceId로 매핑되어야 한다`() {
+        val response = controller.fallback("user", makeExchange("user", "my-trace-123"))
+        val body = response.body!!
+
+        body["traceId"] shouldBe "my-trace-123"
+    }
+
+    @Test
+    fun `X-Trace-Id 헤더 없을 때 traceId는 unknown이어야 한다`() {
+        val response = controller.fallback("user", makeExchange("user"))
+        val body = response.body!!
+
+        body["traceId"] shouldBe "unknown"
+    }
+
+    // ─── 서비스별 메시지 ──────────────────────────────────────────────
+
+    @Test
+    fun `payment fallback 메시지에 이중 결제 경고가 포함되어야 한다`() {
+        val response = controller.fallback("payment", makeExchange("payment"))
+        val body = response.body!!
+
+        body["message"].toString() shouldContain "이중 결제"
+    }
+
+    @Test
+    fun `미지원 서비스명 요청 시 기본 메시지가 반환되어야 한다`() {
+        val response = controller.fallback("unknown-service", makeExchange("unknown-service"))
+        val body = response.body!!
+
+        body["message"].toString().shouldNotBeBlank()
+    }
+}

--- a/backend/api-gateway/src/test/resources/application-test.yml
+++ b/backend/api-gateway/src/test/resources/application-test.yml
@@ -24,26 +24,55 @@ spring:
               uri: http://localhost:8081
               predicates:
                 - Path=/auth/**,/users/**
+              filters:
+                - name: CircuitBreaker
+                  args:
+                    name: userService
+                    fallbackUri: forward:/fallback/user
 
             - id: event-service
               uri: http://localhost:8082
               predicates:
                 - Path=/events/**,/venues/**
+              filters:
+                - name: CircuitBreaker
+                  args:
+                    name: eventService
+                    fallbackUri: forward:/fallback/event
 
             - id: queue-service
               uri: http://localhost:8083
               predicates:
                 - Path=/queue/**
+              metadata:
+                response-timeout: 10000
+              filters:
+                - name: CircuitBreaker
+                  args:
+                    name: queueService
+                    fallbackUri: forward:/fallback/queue
 
             - id: reservation-service
               uri: http://localhost:8084
               predicates:
                 - Path=/reservations/**
+              filters:
+                - name: CircuitBreaker
+                  args:
+                    name: reservationService
+                    fallbackUri: forward:/fallback/reservation
 
             - id: payment-service
               uri: http://localhost:8085
               predicates:
                 - Path=/payments/**
+              metadata:
+                response-timeout: 60000
+              filters:
+                - name: CircuitBreaker
+                  args:
+                    name: paymentService
+                    fallbackUri: forward:/fallback/payment
 
           httpclient:
             connect-timeout: 1000
@@ -56,6 +85,50 @@ spring:
 
 jwt:
   secret: dGVzdC1zZWNyZXQta2V5LWZvci1qd3QtdG9rZW4tdmVyaWZpY2F0aW9uLXRlc3Rpbmc=
+
+# 테스트 환경용 Resilience4j 설정 (빠른 검증을 위해 축소된 값 사용)
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        registerHealthIndicator: true
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 3
+        failureRateThreshold: 50
+        waitDurationInOpenState: 5s
+        permittedNumberOfCallsInHalfOpenState: 5
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+    instances:
+      userService:
+        baseConfig: default
+      eventService:
+        baseConfig: default
+      queueService:
+        baseConfig: default
+      reservationService:
+        baseConfig: default
+      paymentService:
+        baseConfig: default
+
+  timelimiter:
+    configs:
+      default:
+        timeoutDuration: 5s
+        cancelRunningFuture: true
+    instances:
+      userService:
+        baseConfig: default
+      eventService:
+        baseConfig: default
+      queueService:
+        baseConfig: default
+        timeoutDuration: 3s      # Production: 10s → 테스트 축소
+      reservationService:
+        baseConfig: default
+      paymentService:
+        baseConfig: default
+        timeoutDuration: 10s     # Production: 60s → 테스트 축소
 
 management:
   endpoints:


### PR DESCRIPTION
## Summary
- API Gateway의 타임아웃 및 Circuit Breaker 설정 구현 (REQ-GW-006, REQ-GW-007, REQ-GW-008, REQ-GW-017)

## Changes
- **글로벌 타임아웃 설정**: HTTP 클라이언트 연결 타임아웃 5초, 응답 타임아웃 30초 (REQ-GW-007)
- **라우트별 타임아웃 커스터마이징**: Queue 10초, Payment 60초 (REQ-GW-008)
- **Circuit Breaker 필터 적용**: 5개 서비스(user, event, queue, reservation, payment) 라우트에 Resilience4j Circuit Breaker 필터 추가
- **Resilience4j 설정**: CircuitBreaker (슬라이딩 윈도우 100, 실패율 50% 초과 시 Open) / TimeLimiter 인스턴스 설정
- **FallbackController 구현**: Circuit Breaker Open 시 `/fallback/{serviceName}`으로 포워드하여 서비스별 503 응답 반환 (REQ-GW-017)
- **RouteValidator 수정**: `/fallback/**` 경로를 공개 경로로 추가 (forward: 내부 포워드이므로 JWT 재검증 불필요)

## Test plan
- [x] `CircuitBreakerConfigTest` — CircuitBreaker/TimeLimiter 레지스트리 인스턴스 등록 및 설정값 검증
- [x] `FallbackControllerTest` — 서비스별 fallback 엔드포인트 503 응답 및 응답 바디 검증 (통합 테스트)
- [x] `FallbackControllerUnitTest` — FallbackController 유닛 테스트 (알 수 없는 서비스명 기본 메시지 처리 포함)
- [x] `GatewayBasicConfigTest` — queue-service(10s), payment-service(60s) response-timeout 메타데이터 검증 테스트 추가

Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Circuit-breaker fallbacks added: unified 503 responses with service-specific messages, timestamps, and trace IDs; public fallback endpoint enabled for internal forwards.
  * Per-route and per-service timeout settings introduced to improve resilience (including shorter/longer overrides where needed).

* **Tests**
  * Added integration and unit tests covering circuit breaker/time limiter configs, fallback endpoint responses, and route timeout metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->