### PR TITLE
feat: [Gateway] Queue Token 검증 필터 구현 및 코드 품질 개선 #15

### DIFF
--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilter.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilter.kt
@@ -11,14 +11,11 @@ import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.server.WebFilter
 import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Mono
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 private val log = KotlinLogging.logger {}
 
@@ -58,8 +55,6 @@ class JwtAuthenticationWebFilter(
         private const val CODE_INVALID_TOKEN = "INVALID_TOKEN"
         private const val CODE_EXPIRED_TOKEN = "EXPIRED_TOKEN"
         private const val CODE_FORBIDDEN = "FORBIDDEN"
-
-        private val TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
     }
 
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
@@ -130,24 +125,5 @@ class JwtAuthenticationWebFilter(
         status: HttpStatus,
         code: String,
         message: String,
-    ): Mono<Void> {
-        val traceId = exchange.request.headers.getFirst(TraceIdWebFilter.TRACE_ID_HEADER)
-            ?: exchange.response.headers.getFirst(TraceIdWebFilter.TRACE_ID_HEADER)
-            ?: "unknown"
-
-        val body = mapOf(
-            "code" to code,
-            "message" to message,
-            "timestamp" to LocalDateTime.now().format(TIMESTAMP_FORMATTER),
-            "traceId" to traceId,
-        )
-
-        val bytes = objectMapper.writeValueAsBytes(body)
-        val buffer = exchange.response.bufferFactory().wrap(bytes)
-
-        exchange.response.statusCode = status
-        exchange.response.headers.contentType = MediaType.APPLICATION_JSON
-
-        return exchange.response.writeWith(Mono.just(buffer))
-    }
+    ): Mono<Void> = WebFilterErrorResponseWriter.write(exchange, objectMapper, status, code, message)
 }

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/QueueTokenWebFilter.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/QueueTokenWebFilter.kt
@@ -1,0 +1,99 @@
+package com.ticketqueue.gateway.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.gateway.security.RouteValidator
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.WebFilter
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Queue Token(X-Queue-Token) 형식 검증 필터 (Layer 1)
+ *
+ * 처리 순서:
+ * 1. OPTIONS 요청 → 통과
+ * 2. Queue Token 불필요 경로 → 통과
+ * 3. X-Queue-Token 헤더 없거나 빈 값 → 401 QUEUE_TOKEN_MISSING
+ * 4. 형식 검증 실패 (qr_ prefix + 소문자 UUID 불일치) → 401 QUEUE_TOKEN_INVALID
+ * 5. 통과 → chain.filter() (헤더는 Gateway가 자동 downstream 전달)
+ *
+ * Layer 2 (Redis 직접 조회로 유효성 검증)는 각 downstream 서비스 담당.
+ * 아키텍처 결정: docs/architecture/06_api_security.md 1.2.4 참고
+ *
+ * REQ-GW-016 (Queue Token 헤더 전달), REQ-QUEUE-010 (Queue Token 검증)
+ *
+ * @Order(HIGHEST_PRECEDENCE + 3): JWT 필터(+2) 이후 실행
+ * Queue Token 경로는 모두 인증 필수이므로 JWT 검증 실패 시 Queue Token 체크 불필요
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 3)
+class QueueTokenWebFilter(
+    private val routeValidator: RouteValidator,
+    private val objectMapper: ObjectMapper,
+) : WebFilter {
+
+    companion object {
+        const val QUEUE_TOKEN_HEADER = "X-Queue-Token"
+
+        // 에러 코드 상수 (common 모듈 의존 불가로 인라인 정의 — WebFlux vs Servlet)
+        private const val CODE_QUEUE_TOKEN_MISSING = "QUEUE_TOKEN_MISSING"
+        private const val CODE_QUEUE_TOKEN_INVALID = "QUEUE_TOKEN_INVALID"
+
+        // qr_ prefix + 소문자 UUID 형식 (UUID.randomUUID().toString() 출력 형식)
+        private val QUEUE_TOKEN_PATTERN =
+            Regex("^qr_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+    }
+
+    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
+        // CORS preflight (OPTIONS) 요청은 Queue Token 검증 없이 통과
+        if (exchange.request.method == HttpMethod.OPTIONS) {
+            return chain.filter(exchange)
+        }
+
+        // Queue Token이 불필요한 경로는 통과
+        if (!routeValidator.isQueueTokenRequired(exchange)) {
+            return chain.filter(exchange)
+        }
+
+        // X-Queue-Token 헤더 추출
+        val queueToken = exchange.request.headers.getFirst(QUEUE_TOKEN_HEADER)
+        if (queueToken.isNullOrBlank()) {
+            log.debug { "Missing X-Queue-Token header: ${exchange.request.path}" }
+            return writeErrorResponse(
+                exchange,
+                HttpStatus.UNAUTHORIZED,
+                CODE_QUEUE_TOKEN_MISSING,
+                "대기열 토큰이 필요합니다.",
+            )
+        }
+
+        // 형식 검증: qr_ prefix + 소문자 UUID
+        if (!QUEUE_TOKEN_PATTERN.matches(queueToken)) {
+            log.debug { "Invalid X-Queue-Token format: path=${exchange.request.path}" }
+            return writeErrorResponse(
+                exchange,
+                HttpStatus.UNAUTHORIZED,
+                CODE_QUEUE_TOKEN_INVALID,
+                "유효하지 않은 대기열 토큰입니다.",
+            )
+        }
+
+        // 통과 — X-Queue-Token 헤더는 Gateway가 자동으로 downstream에 전달
+        return chain.filter(exchange)
+    }
+
+    private fun writeErrorResponse(
+        exchange: ServerWebExchange,
+        status: HttpStatus,
+        code: String,
+        message: String,
+    ): Mono<Void> = WebFilterErrorResponseWriter.write(exchange, objectMapper, status, code, message)
+}

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/WebFilterErrorResponseWriter.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/WebFilterErrorResponseWriter.kt
@@ -1,0 +1,47 @@
+package com.ticketqueue.gateway.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * WebFilter 에러 응답 공통 유틸리티
+ *
+ * JwtAuthenticationWebFilter와 QueueTokenWebFilter의 writeErrorResponse 로직을
+ * 추출하여 DRY 원칙 적용.
+ */
+internal object WebFilterErrorResponseWriter {
+
+    private val TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+
+    fun write(
+        exchange: ServerWebExchange,
+        objectMapper: ObjectMapper,
+        status: HttpStatus,
+        code: String,
+        message: String,
+    ): Mono<Void> {
+        val traceId = exchange.request.headers.getFirst(TraceIdWebFilter.TRACE_ID_HEADER)
+            ?: exchange.response.headers.getFirst(TraceIdWebFilter.TRACE_ID_HEADER)
+            ?: "unknown"
+
+        val body = mapOf(
+            "code" to code,
+            "message" to message,
+            "timestamp" to LocalDateTime.now().format(TIMESTAMP_FORMATTER),
+            "traceId" to traceId,
+        )
+
+        val bytes = objectMapper.writeValueAsBytes(body)
+        val buffer = exchange.response.bufferFactory().wrap(bytes)
+
+        exchange.response.statusCode = status
+        exchange.response.headers.contentType = MediaType.APPLICATION_JSON
+
+        return exchange.response.writeWith(Mono.just(buffer))
+    }
+}

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/security/RouteValidator.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/security/RouteValidator.kt
@@ -38,6 +38,20 @@ class RouteValidator {
     )
 
     /**
+     * Queue Token(X-Queue-Token)이 필수인 엔드포인트 (토큰 없으면 401)
+     *
+     * REQ-GW-016 (Queue Token 헤더 전달), REQ-QUEUE-010 (Queue Token 검증)
+     * 출처: docs/specification/04_reservation_service.md, 05_payment_service.md
+     */
+    private val queueTokenRequiredRoutes: List<RouteRule> = listOf(
+        RouteRule("/reservations/seats/*", HttpMethod.GET),
+        RouteRule("/reservations/hold", HttpMethod.POST),
+        RouteRule("/reservations/hold/*", HttpMethod.PUT),
+        RouteRule("/payments", HttpMethod.POST),
+        RouteRule("/payments/confirm", HttpMethod.POST),
+    )
+
+    /**
      * ADMIN 권한만 접근 가능한 엔드포인트 (role=ADMIN 아니면 403)
      */
     private val adminOnlyRoutes: List<RouteRule> = listOf(
@@ -60,6 +74,15 @@ class RouteValidator {
         val path = exchange.request.path.value()
         val method = exchange.request.method
         return publicRoutes.any { it.matches(path, method, pathMatcher) }
+    }
+
+    /**
+     * Queue Token 필수 엔드포인트 여부 확인 (X-Queue-Token 검증 필요)
+     */
+    fun isQueueTokenRequired(exchange: ServerWebExchange): Boolean {
+        val path = exchange.request.path.value()
+        val method = exchange.request.method
+        return queueTokenRequiredRoutes.any { it.matches(path, method, pathMatcher) }
     }
 
     /**

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterTest.kt
@@ -4,8 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import com.ticketqueue.gateway.BaseIntegrationTest
 import com.ticketqueue.gateway.security.ReactiveTokenBlacklistService
-import io.jsonwebtoken.Jwts
-import io.jsonwebtoken.security.Keys
+import com.ticketqueue.gateway.support.createValidToken
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
@@ -14,9 +13,9 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.test.web.reactive.server.WebTestClient
 import reactor.core.publisher.Mono
-import java.util.Base64
-import java.util.Date
 import java.util.UUID
+
+private val VALID_QUEUE_TOKEN = "qr_${UUID.randomUUID()}"
 
 /**
  * JwtAuthenticationWebFilter 통합 테스트
@@ -85,32 +84,14 @@ class JwtAuthenticationWebFilterTest : BaseIntegrationTest() {
     fun `유효한 토큰으로 보호 엔드포인트 접근 시 downstream으로 전달 (5xx는 downstream 부재 때문)`() {
         every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
 
-        val token = createValidToken(userId = "user-1", role = "USER")
+        val token = createValidToken(jwtSecret, userId = "user-1", role = "USER")
 
         webTestClient.post()
             .uri("/reservations/hold")
             .header("Authorization", "Bearer $token")
+            .header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, VALID_QUEUE_TOKEN) // Queue Token 필수 경로
             .exchange()
-            .expectStatus().is5xxServerError // JWT 필터 통과 후 downstream 없어서 5xx
+            .expectStatus().is5xxServerError // JWT + Queue Token 필터 모두 통과, downstream 없어서 5xx
     }
 
-    // ─── 헬퍼 ─────────────────────────────────────────────────────────
-
-    private fun createValidToken(
-        userId: String,
-        role: String,
-        expirationMs: Long = 3_600_000L, // 1시간
-    ): String {
-        val decoded = Base64.getDecoder().decode(jwtSecret)
-        val key = Keys.hmacShaKeyFor(decoded)
-
-        return Jwts.builder()
-            .subject(userId)
-            .claim("role", role)
-            .id(UUID.randomUUID().toString())
-            .issuedAt(Date())
-            .expiration(Date(System.currentTimeMillis() + expirationMs))
-            .signWith(key)
-            .compact()
-    }
 }

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterUnitTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterUnitTest.kt
@@ -6,6 +6,8 @@ import com.ticketqueue.gateway.security.JwtClaims
 import com.ticketqueue.gateway.security.JwtTokenProvider
 import com.ticketqueue.gateway.security.ReactiveTokenBlacklistService
 import com.ticketqueue.gateway.security.RouteValidator
+import com.ticketqueue.gateway.support.exchange
+import com.ticketqueue.gateway.support.responseBody
 import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.JwtException
 import io.kotest.matchers.shouldBe
@@ -17,7 +19,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
-import org.springframework.mock.http.server.reactive.MockServerHttpRequest
 import org.springframework.mock.web.server.MockServerWebExchange
 import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Mono
@@ -287,32 +288,11 @@ class JwtAuthenticationWebFilterUnitTest {
 
     // ─── 헬퍼 ─────────────────────────────────────────────────────────
 
-    private fun exchange(
-        method: HttpMethod,
-        path: String,
-        block: MockServerHttpRequest.BaseBuilder<*>.() -> Unit = {},
-    ): MockServerWebExchange {
-        val builder = when (method) {
-            HttpMethod.GET -> MockServerHttpRequest.get(path)
-            HttpMethod.POST -> MockServerHttpRequest.post(path)
-            HttpMethod.PUT -> MockServerHttpRequest.put(path)
-            HttpMethod.DELETE -> MockServerHttpRequest.delete(path)
-            else -> error("Unsupported HTTP method: $method")
-        }
-        block(builder)
-        return MockServerWebExchange.from(builder.build())
-    }
-
     private fun exchangeWithBearer(
         method: HttpMethod,
         path: String,
         token: String,
     ): MockServerWebExchange = exchange(method, path) {
         header(HttpHeaders.AUTHORIZATION, "Bearer $token")
-    }
-
-    private fun responseBody(exchange: MockServerWebExchange): String {
-        val body = exchange.response.bodyAsString.block() ?: ""
-        return body
     }
 }

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/QueueTokenWebFilterTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/QueueTokenWebFilterTest.kt
@@ -6,6 +6,7 @@ import com.ticketqueue.gateway.security.ReactiveTokenBlacklistService
 import com.ticketqueue.gateway.support.createValidToken
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -34,12 +35,15 @@ class QueueTokenWebFilterTest : BaseIntegrationTest() {
     @Value("\${jwt.secret}")
     private lateinit var jwtSecret: String
 
+    @BeforeEach
+    fun setUp() {
+        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
+    }
+
     // ─── JWT 유효 + Queue Token 누락 ──────────────────────────────────
 
     @Test
     fun `JWT 유효하고 Queue Token 없으면 401 QUEUE_TOKEN_MISSING 반환`() {
-        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
-
         val token = createValidToken(jwtSecret, userId = "user-1", role = "USER")
 
         val body = webTestClient.post()
@@ -58,8 +62,6 @@ class QueueTokenWebFilterTest : BaseIntegrationTest() {
 
     @Test
     fun `JWT 유효하고 Queue Token 형식 오류면 401 QUEUE_TOKEN_INVALID 반환`() {
-        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
-
         val token = createValidToken(jwtSecret, userId = "user-1", role = "USER")
 
         val body = webTestClient.post()
@@ -79,8 +81,6 @@ class QueueTokenWebFilterTest : BaseIntegrationTest() {
 
     @Test
     fun `JWT 유효하고 유효한 Queue Token이면 downstream으로 전달 (5xx는 downstream 부재 때문)`() {
-        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
-
         val token = createValidToken(jwtSecret, userId = "user-1", role = "USER")
         val queueToken = "qr_${UUID.randomUUID()}"
 
@@ -114,8 +114,6 @@ class QueueTokenWebFilterTest : BaseIntegrationTest() {
 
     @Test
     fun `Queue Token 불필요 경로는 Queue Token 없어도 downstream으로 전달 (5xx는 downstream 부재)`() {
-        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
-
         val token = createValidToken(jwtSecret, userId = "user-1", role = "USER")
 
         webTestClient.get()
@@ -129,8 +127,6 @@ class QueueTokenWebFilterTest : BaseIntegrationTest() {
 
     @Test
     fun `JWT 유효하고 유효한 Queue Token으로 POST payments-confirm 요청 시 downstream 전달 (5xx는 downstream 부재)`() {
-        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
-
         val token = createValidToken(jwtSecret, userId = "user-1", role = "USER")
         val queueToken = "qr_${UUID.randomUUID()}"
 
@@ -144,8 +140,6 @@ class QueueTokenWebFilterTest : BaseIntegrationTest() {
 
     @Test
     fun `JWT 유효하고 Queue Token 없으면 GET reservations-seats-id에서 401 QUEUE_TOKEN_MISSING 반환`() {
-        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
-
         val token = createValidToken(jwtSecret, userId = "user-1", role = "USER")
 
         val body = webTestClient.get()
@@ -162,8 +156,6 @@ class QueueTokenWebFilterTest : BaseIntegrationTest() {
 
     @Test
     fun `JWT 유효하고 유효한 Queue Token으로 PUT reservations-hold-id 요청 시 downstream 전달 (5xx는 downstream 부재)`() {
-        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
-
         val token = createValidToken(jwtSecret, userId = "user-1", role = "USER")
         val queueToken = "qr_${UUID.randomUUID()}"
 

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/QueueTokenWebFilterTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/QueueTokenWebFilterTest.kt
@@ -1,0 +1,177 @@
+package com.ticketqueue.gateway.filter
+
+import com.ninjasquad.springmockk.MockkBean
+import com.ticketqueue.gateway.BaseIntegrationTest
+import com.ticketqueue.gateway.security.ReactiveTokenBlacklistService
+import com.ticketqueue.gateway.support.createValidToken
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.test.web.reactive.server.WebTestClient
+import reactor.core.publisher.Mono
+import java.util.UUID
+
+/**
+ * QueueTokenWebFilter 통합 테스트
+ *
+ * - ReactiveTokenBlacklistService: @MockkBean (Redis 불필요)
+ * - 실제 JWT 토큰 생성하여 JWT 필터와 Queue Token 필터 연계 검증
+ * - BaseIntegrationTest 상속 (SpringBootTest + test 프로파일)
+ *
+ * 필터 실행 순서: TraceId → SecurityHeaders → JWT(+2) → QueueToken(+3)
+ * JWT 없음 → JWT 필터가 먼저 401 반환, Queue Token 필터 미실행
+ */
+class QueueTokenWebFilterTest : BaseIntegrationTest() {
+
+    @Autowired
+    private lateinit var webTestClient: WebTestClient
+
+    @MockkBean
+    private lateinit var tokenBlacklistService: ReactiveTokenBlacklistService
+
+    @Value("\${jwt.secret}")
+    private lateinit var jwtSecret: String
+
+    // ─── JWT 유효 + Queue Token 누락 ──────────────────────────────────
+
+    @Test
+    fun `JWT 유효하고 Queue Token 없으면 401 QUEUE_TOKEN_MISSING 반환`() {
+        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
+
+        val token = createValidToken(jwtSecret, userId = "user-1", role = "USER")
+
+        val body = webTestClient.post()
+            .uri("/reservations/hold")
+            .header("Authorization", "Bearer $token")
+            .exchange()
+            .expectStatus().isUnauthorized
+            .expectBody(String::class.java)
+            .returnResult()
+            .responseBody!!
+
+        body shouldContain "\"code\":\"QUEUE_TOKEN_MISSING\""
+    }
+
+    // ─── JWT 유효 + Queue Token 형식 오류 ─────────────────────────────
+
+    @Test
+    fun `JWT 유효하고 Queue Token 형식 오류면 401 QUEUE_TOKEN_INVALID 반환`() {
+        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
+
+        val token = createValidToken(jwtSecret, userId = "user-1", role = "USER")
+
+        val body = webTestClient.post()
+            .uri("/payments")
+            .header("Authorization", "Bearer $token")
+            .header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, "invalid-token-format")
+            .exchange()
+            .expectStatus().isUnauthorized
+            .expectBody(String::class.java)
+            .returnResult()
+            .responseBody!!
+
+        body shouldContain "\"code\":\"QUEUE_TOKEN_INVALID\""
+    }
+
+    // ─── JWT 유효 + Queue Token 유효 ──────────────────────────────────
+
+    @Test
+    fun `JWT 유효하고 유효한 Queue Token이면 downstream으로 전달 (5xx는 downstream 부재 때문)`() {
+        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
+
+        val token = createValidToken(jwtSecret, userId = "user-1", role = "USER")
+        val queueToken = "qr_${UUID.randomUUID()}"
+
+        webTestClient.post()
+            .uri("/reservations/hold")
+            .header("Authorization", "Bearer $token")
+            .header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, queueToken)
+            .exchange()
+            .expectStatus().is5xxServerError // 두 필터 모두 통과, downstream 없어서 5xx
+    }
+
+    // ─── JWT 없음 + Queue Token 있음 ──────────────────────────────────
+
+    @Test
+    fun `JWT 없고 Queue Token 있어도 JWT 필터가 먼저 401 반환`() {
+        val queueToken = "qr_${UUID.randomUUID()}"
+
+        val body = webTestClient.post()
+            .uri("/reservations/hold")
+            .header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, queueToken)
+            .exchange()
+            .expectStatus().isUnauthorized
+            .expectBody(String::class.java)
+            .returnResult()
+            .responseBody!!
+
+        body shouldContain "\"code\":\"UNAUTHORIZED\""
+    }
+
+    // ─── Queue Token 불필요 경로 ──────────────────────────────────────
+
+    @Test
+    fun `Queue Token 불필요 경로는 Queue Token 없어도 downstream으로 전달 (5xx는 downstream 부재)`() {
+        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
+
+        val token = createValidToken(jwtSecret, userId = "user-1", role = "USER")
+
+        webTestClient.get()
+            .uri("/reservations")
+            .header("Authorization", "Bearer $token")
+            .exchange()
+            .expectStatus().is5xxServerError // Queue Token 필터 미개입, downstream 없어서 5xx
+    }
+
+    // ─── JWT 유효 + Queue Token 유효 (추가 경로) ──────────────────────
+
+    @Test
+    fun `JWT 유효하고 유효한 Queue Token으로 POST payments-confirm 요청 시 downstream 전달 (5xx는 downstream 부재)`() {
+        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
+
+        val token = createValidToken(jwtSecret, userId = "user-1", role = "USER")
+        val queueToken = "qr_${UUID.randomUUID()}"
+
+        webTestClient.post()
+            .uri("/payments/confirm")
+            .header("Authorization", "Bearer $token")
+            .header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, queueToken)
+            .exchange()
+            .expectStatus().is5xxServerError // 두 필터 모두 통과, downstream 없어서 5xx
+    }
+
+    @Test
+    fun `JWT 유효하고 Queue Token 없으면 GET reservations-seats-id에서 401 QUEUE_TOKEN_MISSING 반환`() {
+        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
+
+        val token = createValidToken(jwtSecret, userId = "user-1", role = "USER")
+
+        val body = webTestClient.get()
+            .uri("/reservations/seats/123")
+            .header("Authorization", "Bearer $token")
+            .exchange()
+            .expectStatus().isUnauthorized
+            .expectBody(String::class.java)
+            .returnResult()
+            .responseBody!!
+
+        body shouldContain "\"code\":\"QUEUE_TOKEN_MISSING\""
+    }
+
+    @Test
+    fun `JWT 유효하고 유효한 Queue Token으로 PUT reservations-hold-id 요청 시 downstream 전달 (5xx는 downstream 부재)`() {
+        every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)
+
+        val token = createValidToken(jwtSecret, userId = "user-1", role = "USER")
+        val queueToken = "qr_${UUID.randomUUID()}"
+
+        webTestClient.put()
+            .uri("/reservations/hold/456")
+            .header("Authorization", "Bearer $token")
+            .header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, queueToken)
+            .exchange()
+            .expectStatus().is5xxServerError // 두 필터 모두 통과, downstream 없어서 5xx
+    }
+}

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/QueueTokenWebFilterUnitTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/QueueTokenWebFilterUnitTest.kt
@@ -1,0 +1,305 @@
+package com.ticketqueue.gateway.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.gateway.security.RouteValidator
+import com.ticketqueue.gateway.support.exchange
+import com.ticketqueue.gateway.support.responseBody
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.server.MockServerWebExchange
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+import java.util.UUID
+
+/**
+ * QueueTokenWebFilter 단위 테스트
+ *
+ * RouteValidator는 실제 인스턴스 사용 (JwtAuthenticationWebFilterUnitTest 패턴 준수).
+ * ObjectMapper는 직접 생성.
+ * MockServerWebExchange + StepVerifier 사용.
+ */
+class QueueTokenWebFilterUnitTest {
+
+    private val routeValidator = RouteValidator()
+    private val objectMapper = ObjectMapper()
+
+    private val filter = QueueTokenWebFilter(routeValidator, objectMapper)
+
+    private val passChain = WebFilterChain { Mono.empty() }
+
+    // ─── Queue Token 불필요 경로 통과 ──────────────────────────────────
+
+    @Test
+    fun `GET events는 Queue Token 없이 통과`() {
+        val exchange = exchange(HttpMethod.GET, "/events")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null // 필터가 응답 쓰지 않음
+    }
+
+    @Test
+    fun `GET reservations는 Queue Token 없이 통과`() {
+        val exchange = exchange(HttpMethod.GET, "/reservations")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null
+    }
+
+    @Test
+    fun `GET payments-id는 Queue Token 없이 통과`() {
+        val exchange = exchange(HttpMethod.GET, "/payments/123")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null
+    }
+
+    @Test
+    fun `DELETE reservations-hold-id는 Queue Token 없이 통과`() {
+        val exchange = exchange(HttpMethod.DELETE, "/reservations/hold/123")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null
+    }
+
+    @Test
+    fun `OPTIONS reservations-hold는 Queue Token 없이 통과`() {
+        val exchange = exchange(HttpMethod.OPTIONS, "/reservations/hold")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null
+    }
+
+    // ─── Queue Token 누락 → 401 QUEUE_TOKEN_MISSING ──────────────────
+
+    @Test
+    fun `POST reservations-hold에 Queue Token 없으면 401 QUEUE_TOKEN_MISSING 반환`() {
+        val exchange = exchange(HttpMethod.POST, "/reservations/hold")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"QUEUE_TOKEN_MISSING\""
+        body shouldContain "대기열 토큰이 필요합니다"
+    }
+
+    @Test
+    fun `GET reservations-seats-id에 Queue Token 없으면 401 QUEUE_TOKEN_MISSING 반환`() {
+        val exchange = exchange(HttpMethod.GET, "/reservations/seats/123")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"QUEUE_TOKEN_MISSING\""
+    }
+
+    @Test
+    fun `PUT reservations-hold-id에 Queue Token 없으면 401 QUEUE_TOKEN_MISSING 반환`() {
+        val exchange = exchange(HttpMethod.PUT, "/reservations/hold/456")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"QUEUE_TOKEN_MISSING\""
+    }
+
+    @Test
+    fun `POST payments에 Queue Token 없으면 401 QUEUE_TOKEN_MISSING 반환`() {
+        val exchange = exchange(HttpMethod.POST, "/payments")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"QUEUE_TOKEN_MISSING\""
+    }
+
+    @Test
+    fun `POST payments-confirm에 Queue Token 없으면 401 QUEUE_TOKEN_MISSING 반환`() {
+        val exchange = exchange(HttpMethod.POST, "/payments/confirm")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"QUEUE_TOKEN_MISSING\""
+    }
+
+    @Test
+    fun `빈 문자열 Queue Token이면 401 QUEUE_TOKEN_MISSING 반환`() {
+        val exchange = exchange(HttpMethod.POST, "/reservations/hold") {
+            header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, "")
+        }
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"QUEUE_TOKEN_MISSING\""
+    }
+
+    // ─── 형식 오류 → 401 QUEUE_TOKEN_INVALID ─────────────────────────
+
+    @Test
+    fun `qr_ prefix 없는 토큰은 401 QUEUE_TOKEN_INVALID 반환`() {
+        val exchange = exchange(HttpMethod.POST, "/reservations/hold") {
+            header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, "abc-def")
+        }
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"QUEUE_TOKEN_INVALID\""
+        body shouldContain "유효하지 않은 대기열 토큰입니다"
+    }
+
+    @Test
+    fun `qr_ prefix만 있고 UUID 형식 아닌 토큰은 401 QUEUE_TOKEN_INVALID 반환`() {
+        val exchange = exchange(HttpMethod.POST, "/reservations/hold") {
+            header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, "qr_not-a-uuid")
+        }
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"QUEUE_TOKEN_INVALID\""
+    }
+
+    @Test
+    fun `대문자 UUID 포함 토큰은 401 QUEUE_TOKEN_INVALID 반환`() {
+        val exchange = exchange(HttpMethod.POST, "/reservations/hold") {
+            header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, "qr_550E8400-E29B-41D4-A716-446655440000")
+        }
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"QUEUE_TOKEN_INVALID\""
+    }
+
+    // ─── 통과 케이스 ──────────────────────────────────────────────────
+
+    @Test
+    fun `유효한 qr_ + UUID 토큰으로 POST reservations-hold 요청 시 통과`() {
+        val validToken = "qr_${UUID.randomUUID()}"
+        val exchange = exchange(HttpMethod.POST, "/reservations/hold") {
+            header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, validToken)
+        }
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null // 필터가 응답 쓰지 않음
+    }
+
+    @Test
+    fun `유효한 토큰으로 POST payments 요청 시 통과`() {
+        val validToken = "qr_${UUID.randomUUID()}"
+        val exchange = exchange(HttpMethod.POST, "/payments") {
+            header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, validToken)
+        }
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null
+    }
+
+    @Test
+    fun `유효한 토큰으로 GET reservations-seats-id 요청 시 통과`() {
+        val validToken = "qr_${UUID.randomUUID()}"
+        val exchange = exchange(HttpMethod.GET, "/reservations/seats/123") {
+            header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, validToken)
+        }
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null
+    }
+
+    @Test
+    fun `유효한 토큰으로 PUT reservations-hold-id 요청 시 통과`() {
+        val validToken = "qr_${UUID.randomUUID()}"
+        val exchange = exchange(HttpMethod.PUT, "/reservations/hold/456") {
+            header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, validToken)
+        }
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null
+    }
+
+    @Test
+    fun `유효한 토큰으로 POST payments-confirm 요청 시 통과`() {
+        val validToken = "qr_${UUID.randomUUID()}"
+        val exchange = exchange(HttpMethod.POST, "/payments/confirm") {
+            header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, validToken)
+        }
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe null
+    }
+
+    @Test
+    fun `공백 문자열 Queue Token이면 401 QUEUE_TOKEN_MISSING 반환`() {
+        val exchange = exchange(HttpMethod.POST, "/reservations/hold") {
+            header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, "   ")
+        }
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"QUEUE_TOKEN_MISSING\""
+    }
+
+    // ─── 에러 응답 형식 ───────────────────────────────────────────────
+
+    @Test
+    fun `에러 응답 JSON에 code, message, timestamp, traceId 모두 포함`() {
+        val exchange = exchange(HttpMethod.POST, "/reservations/hold")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        val body = responseBody(exchange)
+        body shouldContain "\"code\""
+        body shouldContain "\"message\""
+        body shouldContain "\"timestamp\""
+        body shouldContain "\"traceId\""
+    }
+
+}

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/security/RouteValidatorTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/security/RouteValidatorTest.kt
@@ -1,0 +1,186 @@
+package com.ticketqueue.gateway.security
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+
+/**
+ * RouteValidator 단위 테스트
+ *
+ * 각 라우트 목록(publicRoutes, queueTokenRequiredRoutes, adminOnlyRoutes)과
+ * Ant 패턴 매칭 로직을 직접 검증.
+ */
+class RouteValidatorTest {
+
+    private val routeValidator = RouteValidator()
+
+    private fun exchange(method: HttpMethod, path: String): MockServerWebExchange {
+        val builder = when (method) {
+            HttpMethod.GET -> MockServerHttpRequest.get(path)
+            HttpMethod.POST -> MockServerHttpRequest.post(path)
+            HttpMethod.PUT -> MockServerHttpRequest.put(path)
+            HttpMethod.DELETE -> MockServerHttpRequest.delete(path)
+            HttpMethod.OPTIONS -> MockServerHttpRequest.options(path)
+            else -> error("Unsupported HTTP method: $method")
+        }
+        return MockServerWebExchange.from(builder.build())
+    }
+
+    // ─── isQueueTokenRequired: positive (5개 필수 경로 모두) ────────────
+
+    @Test
+    fun `GET reservations-seats-id는 Queue Token 필수`() {
+        routeValidator.isQueueTokenRequired(exchange(HttpMethod.GET, "/reservations/seats/123")) shouldBe true
+    }
+
+    @Test
+    fun `POST reservations-hold는 Queue Token 필수`() {
+        routeValidator.isQueueTokenRequired(exchange(HttpMethod.POST, "/reservations/hold")) shouldBe true
+    }
+
+    @Test
+    fun `PUT reservations-hold-id는 Queue Token 필수`() {
+        routeValidator.isQueueTokenRequired(exchange(HttpMethod.PUT, "/reservations/hold/456")) shouldBe true
+    }
+
+    @Test
+    fun `POST payments는 Queue Token 필수`() {
+        routeValidator.isQueueTokenRequired(exchange(HttpMethod.POST, "/payments")) shouldBe true
+    }
+
+    @Test
+    fun `POST payments-confirm는 Queue Token 필수`() {
+        routeValidator.isQueueTokenRequired(exchange(HttpMethod.POST, "/payments/confirm")) shouldBe true
+    }
+
+    // ─── isQueueTokenRequired: negative ────────────────────────────────
+
+    @Test
+    fun `GET reservations는 Queue Token 불필요`() {
+        routeValidator.isQueueTokenRequired(exchange(HttpMethod.GET, "/reservations")) shouldBe false
+    }
+
+    @Test
+    fun `DELETE reservations-hold-id는 Queue Token 불필요`() {
+        routeValidator.isQueueTokenRequired(exchange(HttpMethod.DELETE, "/reservations/hold/123")) shouldBe false
+    }
+
+    @Test
+    fun `GET payments-id는 Queue Token 불필요`() {
+        routeValidator.isQueueTokenRequired(exchange(HttpMethod.GET, "/payments/123")) shouldBe false
+    }
+
+    // ─── isQueueTokenRequired: 경계값 ──────────────────────────────────
+
+    @Test
+    fun `GET reservations-seats (path variable 없음)는 Queue Token 불필요`() {
+        // queueTokenRequiredRoutes 패턴: /reservations/seats/* (와일드카드 필수)
+        routeValidator.isQueueTokenRequired(exchange(HttpMethod.GET, "/reservations/seats")) shouldBe false
+    }
+
+    @Test
+    fun `POST payments-confirm-extra (추가 세그먼트)는 Queue Token 불필요`() {
+        // payments/confirm 이후 추가 세그먼트는 패턴 불일치
+        routeValidator.isQueueTokenRequired(exchange(HttpMethod.POST, "/payments/confirm/extra")) shouldBe false
+    }
+
+    // ─── isPublic: positive ────────────────────────────────────────────
+
+    @Test
+    fun `POST auth-login은 공개 엔드포인트`() {
+        routeValidator.isPublic(exchange(HttpMethod.POST, "/auth/login")) shouldBe true
+    }
+
+    @Test
+    fun `POST auth-signup은 공개 엔드포인트`() {
+        routeValidator.isPublic(exchange(HttpMethod.POST, "/auth/signup")) shouldBe true
+    }
+
+    @Test
+    fun `POST auth-refresh는 공개 엔드포인트`() {
+        routeValidator.isPublic(exchange(HttpMethod.POST, "/auth/refresh")) shouldBe true
+    }
+
+    @Test
+    fun `GET events는 공개 엔드포인트`() {
+        routeValidator.isPublic(exchange(HttpMethod.GET, "/events")) shouldBe true
+    }
+
+    @Test
+    fun `GET events-id는 공개 엔드포인트`() {
+        routeValidator.isPublic(exchange(HttpMethod.GET, "/events/123")) shouldBe true
+    }
+
+    @Test
+    fun `GET actuator-health는 공개 엔드포인트`() {
+        routeValidator.isPublic(exchange(HttpMethod.GET, "/actuator/health")) shouldBe true
+    }
+
+    @Test
+    fun `GET internal 경로는 공개 엔드포인트 (Gateway 라우트가 404 차단 담당)`() {
+        routeValidator.isPublic(exchange(HttpMethod.GET, "/internal/seats/status/1")) shouldBe true
+    }
+
+    // ─── isPublic: negative ────────────────────────────────────────────
+
+    @Test
+    fun `GET reservations는 공개 엔드포인트 아님`() {
+        routeValidator.isPublic(exchange(HttpMethod.GET, "/reservations")) shouldBe false
+    }
+
+    @Test
+    fun `GET users-me는 공개 엔드포인트 아님`() {
+        routeValidator.isPublic(exchange(HttpMethod.GET, "/users/me")) shouldBe false
+    }
+
+    @Test
+    fun `POST auth-logout은 공개 엔드포인트 아님`() {
+        routeValidator.isPublic(exchange(HttpMethod.POST, "/auth/logout")) shouldBe false
+    }
+
+    // ─── isAdminOnly: positive ─────────────────────────────────────────
+
+    @Test
+    fun `POST events는 관리자 전용`() {
+        routeValidator.isAdminOnly(exchange(HttpMethod.POST, "/events")) shouldBe true
+    }
+
+    @Test
+    fun `PUT events-id는 관리자 전용`() {
+        routeValidator.isAdminOnly(exchange(HttpMethod.PUT, "/events/123")) shouldBe true
+    }
+
+    @Test
+    fun `DELETE events-id는 관리자 전용`() {
+        routeValidator.isAdminOnly(exchange(HttpMethod.DELETE, "/events/123")) shouldBe true
+    }
+
+    @Test
+    fun `POST venues는 관리자 전용`() {
+        routeValidator.isAdminOnly(exchange(HttpMethod.POST, "/venues")) shouldBe true
+    }
+
+    @Test
+    fun `GET queue-admin-stats는 관리자 전용`() {
+        routeValidator.isAdminOnly(exchange(HttpMethod.GET, "/queue/admin/stats")) shouldBe true
+    }
+
+    // ─── isAdminOnly: negative ─────────────────────────────────────────
+
+    @Test
+    fun `GET events는 관리자 전용 아님`() {
+        routeValidator.isAdminOnly(exchange(HttpMethod.GET, "/events")) shouldBe false
+    }
+
+    @Test
+    fun `GET reservations는 관리자 전용 아님`() {
+        routeValidator.isAdminOnly(exchange(HttpMethod.GET, "/reservations")) shouldBe false
+    }
+
+    @Test
+    fun `POST auth-login은 관리자 전용 아님`() {
+        routeValidator.isAdminOnly(exchange(HttpMethod.POST, "/auth/login")) shouldBe false
+    }
+}

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/security/RouteValidatorTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/security/RouteValidatorTest.kt
@@ -1,10 +1,9 @@
 package com.ticketqueue.gateway.security
 
+import com.ticketqueue.gateway.support.exchange
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
-import org.springframework.mock.http.server.reactive.MockServerHttpRequest
-import org.springframework.mock.web.server.MockServerWebExchange
 
 /**
  * RouteValidator 단위 테스트
@@ -15,18 +14,6 @@ import org.springframework.mock.web.server.MockServerWebExchange
 class RouteValidatorTest {
 
     private val routeValidator = RouteValidator()
-
-    private fun exchange(method: HttpMethod, path: String): MockServerWebExchange {
-        val builder = when (method) {
-            HttpMethod.GET -> MockServerHttpRequest.get(path)
-            HttpMethod.POST -> MockServerHttpRequest.post(path)
-            HttpMethod.PUT -> MockServerHttpRequest.put(path)
-            HttpMethod.DELETE -> MockServerHttpRequest.delete(path)
-            HttpMethod.OPTIONS -> MockServerHttpRequest.options(path)
-            else -> error("Unsupported HTTP method: $method")
-        }
-        return MockServerWebExchange.from(builder.build())
-    }
 
     // ─── isQueueTokenRequired: positive (5개 필수 경로 모두) ────────────
 

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/support/GatewayIntegrationTestSupport.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/support/GatewayIntegrationTestSupport.kt
@@ -1,0 +1,31 @@
+package com.ticketqueue.gateway.support
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import java.util.Base64
+import java.util.Date
+import java.util.UUID
+
+/**
+ * 통합 테스트 공통 헬퍼
+ *
+ * JwtAuthenticationWebFilterTest, QueueTokenWebFilterTest 등에서 공유.
+ */
+fun createValidToken(
+    jwtSecret: String,
+    userId: String,
+    role: String,
+    expirationMs: Long = 3_600_000L, // 1시간
+): String {
+    val decoded = Base64.getDecoder().decode(jwtSecret)
+    val key = Keys.hmacShaKeyFor(decoded)
+
+    return Jwts.builder()
+        .subject(userId)
+        .claim("role", role)
+        .id(UUID.randomUUID().toString())
+        .issuedAt(Date())
+        .expiration(Date(System.currentTimeMillis() + expirationMs))
+        .signWith(key)
+        .compact()
+}

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/support/WebFilterTestSupport.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/support/WebFilterTestSupport.kt
@@ -1,0 +1,30 @@
+package com.ticketqueue.gateway.support
+
+import org.springframework.http.HttpMethod
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+
+/**
+ * WebFilter 단위 테스트 공통 헬퍼
+ *
+ * JwtAuthenticationWebFilterUnitTest, QueueTokenWebFilterUnitTest 등에서 공유.
+ */
+fun exchange(
+    method: HttpMethod,
+    path: String,
+    block: MockServerHttpRequest.BaseBuilder<*>.() -> Unit = {},
+): MockServerWebExchange {
+    val builder = when (method) {
+        HttpMethod.GET -> MockServerHttpRequest.get(path)
+        HttpMethod.POST -> MockServerHttpRequest.post(path)
+        HttpMethod.PUT -> MockServerHttpRequest.put(path)
+        HttpMethod.DELETE -> MockServerHttpRequest.delete(path)
+        HttpMethod.OPTIONS -> MockServerHttpRequest.options(path)
+        else -> error("Unsupported HTTP method: $method")
+    }
+    block(builder)
+    return MockServerWebExchange.from(builder.build())
+}
+
+fun responseBody(exchange: MockServerWebExchange): String =
+    exchange.response.bodyAsString.block() ?: ""

--- a/docs/architecture/06_api_security.md
+++ b/docs/architecture/06_api_security.md
@@ -86,7 +86,7 @@
 - 통과 시: 헤더 그대로 다운스트림 전달 (유효성 미검증)
 
 **적용 경로:**
-- GET /reservations/seats/{id} (qr_ 필수)
+- GET /reservations/seats/{scheduleId} (qr_ 필수)
 - POST /reservations/hold (qr_ 필수)
 - PUT /reservations/hold/{id} (qr_ 필수)
 - POST /payments (qr_ 필수)
@@ -103,7 +103,7 @@
 
 | Method | Endpoint | 설명 | 인증 | Rate Limit |
 |--------|----------|------|------|-----------|
-| GET | `/reservations/seats/{eventId}` | 좌석 상태 조회 | 필수 + Queue Token | 200/분 (사용자) |
+| GET | `/reservations/seats/{scheduleId}` | 좌석 상태 조회 | 필수 + Queue Token | 200/분 (사용자) |
 | POST | `/reservations/hold` | 좌석 선점 | 필수 + Queue Token | 20/분 (사용자) |
 | PUT | `/reservations/hold/{id}` | 좌석 변경 | 필수 + Queue Token | 20/분 (사용자) |
 | GET | `/reservations` | 나의 예매 내역 | 필수 | 200/분 (사용자) |

--- a/docs/architecture/06_api_security.md
+++ b/docs/architecture/06_api_security.md
@@ -82,11 +82,15 @@
 ##### Layer 1: API Gateway (형식 검증)
 - X-Queue-Token 헤더 존재 여부 확인
 - 형식 검증: `qr_` prefix + UUID 형식
-- 없거나 형식 오류 시: 400 Bad Request
+- 없거나 형식 오류 시: 401 Unauthorized
 - 통과 시: 헤더 그대로 다운스트림 전달 (유효성 미검증)
 
 **적용 경로:**
+- GET /reservations/seats/{id} (qr_ 필수)
 - POST /reservations/hold (qr_ 필수)
+- PUT /reservations/hold/{id} (qr_ 필수)
+- POST /payments (qr_ 필수)
+- POST /payments/confirm (qr_ 필수)
 
 ##### Layer 2: Reservation/Payment Service (유효성 검증 - 필수)
 **방식 A (채택): Redis 직접 조회**
@@ -99,9 +103,9 @@
 
 | Method | Endpoint | 설명 | 인증 | Rate Limit |
 |--------|----------|------|------|-----------|
-| GET | `/reservations/seats/{eventId}` | 좌석 상태 조회 | 필수 | 200/분 (사용자) |
+| GET | `/reservations/seats/{eventId}` | 좌석 상태 조회 | 필수 + Queue Token | 200/분 (사용자) |
 | POST | `/reservations/hold` | 좌석 선점 | 필수 + Queue Token | 20/분 (사용자) |
-| PUT | `/reservations/hold/{id}` | 좌석 변경 | 필수 | 20/분 (사용자) |
+| PUT | `/reservations/hold/{id}` | 좌석 변경 | 필수 + Queue Token | 20/분 (사용자) |
 | GET | `/reservations` | 나의 예매 내역 | 필수 | 200/분 (사용자) |
 | DELETE | `/reservations/{id}` | 예매 취소 | 필수 | 20/분 (사용자) |
 
@@ -111,8 +115,8 @@
 
 | Method | Endpoint | 설명 | 인증 | Rate Limit |
 |--------|----------|------|------|-----------|
-| POST | `/payments` | 결제 요청 | 필수 | 20/분 (사용자) |
-| POST | `/payments/confirm` | 결제 확인 | 필수 | 20/분 (사용자) |
+| POST | `/payments` | 결제 요청 | 필수 + Queue Token | 20/분 (사용자) |
+| POST | `/payments/confirm` | 결제 확인 | 필수 + Queue Token | 20/분 (사용자) |
 | GET | `/payments/{id}` | 결제 조회 | 필수 | 200/분 (사용자) |
 | GET | `/payments` | 결제 내역 | 필수 | 200/분 (사용자) |
 

--- a/docs/architecture/06_api_security.md
+++ b/docs/architecture/06_api_security.md
@@ -59,9 +59,9 @@
 | POST | `/events` | 공연 생성 | 관리자 | - |
 | PUT | `/events/{id}` | 공연 수정 | 관리자 | - |
 | POST | `/venues` | 공연장 생성 | 관리자 | - |
-| GET | `/internal/seats/status/{eventId}` | SOLD 좌석 ID 조회 (내부 전용) | 불필요 (내부) | - |
+| GET | `/internal/seats/status/{scheduleId}` | SOLD 좌석 ID 조회 (내부 전용) | X-Service-Api-Key | - |
 
-**참고:** `/internal/**` 경로는 API Gateway를 거치지 않고 서비스 간 직접 호출
+**참고:** `/internal/**` 경로는 API Gateway를 거치지 않고 서비스 간 직접 호출. 내부 API는 `X-Service-Api-Key` 헤더를 통해 인증 (REQ-INT-001 ~ REQ-INT-010)
 
 **관련 요구사항:** REQ-EVT-001 ~ REQ-EVT-006
 


### PR DESCRIPTION
## Summary
- `QueueTokenWebFilter` 구현: `X-Queue-Token` 헤더 형식 검증 (Layer 1) — 누락/형식오류 시 401, 통과 시 downstream 전달
- `WebFilterErrorResponseWriter` 추출: `JwtAuthenticationWebFilter`와 `QueueTokenWebFilter`의 중복 `writeErrorResponse` 로직 DRY 적용
- 테스트 헬퍼 공통화 (`GatewayIntegrationTestSupport`, `WebFilterTestSupport`) 및 커버리지 보강 (154개 테스트 전체 통과)
- `docs/architecture/06_api_security.md` 정합성 수정: 에러코드 400→401, 적용 경로 1개→5개 확장

## Changes
- **신규** `QueueTokenWebFilter.kt` — OPTIONS 통과, 불필요 경로 스킵, `qr_` + 소문자 UUID 형식 검증, 401 에러 처리
- **신규** `WebFilterErrorResponseWriter.kt` — `TIMESTAMP_FORMATTER` + `write()` 공통 유틸리티 object
- **수정** `JwtAuthenticationWebFilter.kt` — `writeErrorResponse()`를 `WebFilterErrorResponseWriter.write()`로 위임, 미사용 import 제거
- **수정** `RouteValidator.kt` — `queueTokenRequiredRoutes` 5개 경로 + `isQueueTokenRequired()` 추가
- **신규** `RouteValidatorTest.kt` — `isQueueTokenRequired()` positive 5개·경계값 2개, `isPublic()`, `isAdminOnly()` 직접 테스트
- **수정** `QueueTokenWebFilterUnitTest.kt` — 유효 토큰 통과 3개 경로 추가, 공백 토큰 에지케이스 추가, `WebFilterTestSupport` 공통 헬퍼 적용
- **수정** `QueueTokenWebFilterTest.kt` — `POST /payments/confirm`, `GET /reservations/seats/{id}`, `PUT /reservations/hold/{id}` 통합 테스트 추가
- **신규** `support/GatewayIntegrationTestSupport.kt` — `createValidToken(jwtSecret, ...)` 공통 함수 (통합 테스트 중복 제거)
- **신규** `support/WebFilterTestSupport.kt` — `exchange()`, `responseBody()` 공통 함수 (단위 테스트 중복 제거)
- **수정** `JwtAuthenticationWebFilterTest.kt`, `JwtAuthenticationWebFilterUnitTest.kt` — 공통 헬퍼로 교체
- **수정** `docs/architecture/06_api_security.md` — Layer 1 에러코드 `400 Bad Request` → `401 Unauthorized`, 적용 경로 5개로 확장, 예매/결제 API 테이블 Queue Token 컬럼 반영

## Test plan
- [x] `./gradlew :api-gateway:test` — 154개 테스트 전체 통과 (실패 0, 오류 0, 스킵 0)
- [x] `RouteValidatorTest` — `isQueueTokenRequired()` 5개 필수 경로 positive, 경계값(path variable 없음, 추가 세그먼트) negative 검증
- [x] `QueueTokenWebFilterUnitTest` — 5개 필수 경로 모두 유효 토큰 통과 확인, 공백 토큰 → `QUEUE_TOKEN_MISSING` 확인
- [x] `QueueTokenWebFilterTest` — `POST /payments/confirm`, `GET /reservations/seats/{id}`, `PUT /reservations/hold/{id}` 통합 시나리오 검증
- [x] 기존 `JwtAuthenticationWebFilter` 테스트 회귀 없음 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced Queue Token (X-Queue-Token) for protected reservations and payments endpoints; tokens must follow qr_<lowercase-uuid>, otherwise 401 with QUEUE_TOKEN_MISSING / QUEUE_TOKEN_INVALID.

* **Refactor**
  * Gateway filters now produce consistent JSON error responses via a centralized writer (uniform fields like code, message, timestamp, traceId).

* **Documentation**
  * Updated API security docs: route coverage, Queue Token requirements, internal endpoint rename (eventId → scheduleId) and internal-key auth notes; some validation errors now return 401.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->