### PR TITLE
refactor: [Event] 공연 CRUD API 품질 개선 - N+1 해결, 에러 처리, 테스트 커버리지 강화 #33

### DIFF
--- a/backend/common/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
@@ -64,5 +64,12 @@ enum class ErrorCode(
     HALL_NAME_DUPLICATE(HttpStatus.CONFLICT, "HALL_NAME_DUPLICATE", "동일 공연장 내 중복된 홀 이름입니다."),
     HALL_HAS_EVENTS(HttpStatus.CONFLICT, "HALL_HAS_EVENTS", "공연이 존재하는 홀은 삭제할 수 없습니다."),
     INVALID_SEAT_TEMPLATE(HttpStatus.INTERNAL_SERVER_ERROR, "SEAT_TEMPLATE_INVALID", "좌석 템플릿 데이터가 손상되었습니다."),
-    INVALID_SEAT_TEMPLATE_MAPPING(HttpStatus.BAD_REQUEST, "SEAT_TEMPLATE_MAPPING_INVALID", "좌석 템플릿의 행-등급 매핑이 올바르지 않습니다.")
+    INVALID_SEAT_TEMPLATE_MAPPING(HttpStatus.BAD_REQUEST, "SEAT_TEMPLATE_MAPPING_INVALID", "좌석 템플릿의 행-등급 매핑이 올바르지 않습니다."),
+    EVENT_HAS_RESERVATIONS(HttpStatus.CONFLICT, "EVENT_HAS_RESERVATIONS", "판매된 좌석이 있는 공연은 삭제할 수 없습니다."),
+    EVENT_ALREADY_DELETED(HttpStatus.CONFLICT, "EVENT_ALREADY_DELETED", "이미 삭제된 공연입니다."),
+    INVALID_EVENT_STATUS(HttpStatus.BAD_REQUEST, "INVALID_EVENT_STATUS", "유효하지 않은 상태 전환입니다."),
+    INVALID_SCHEDULE_TIME(HttpStatus.BAD_REQUEST, "INVALID_SCHEDULE_TIME", "회차 시간이 올바르지 않습니다."),
+    EVENT_NOT_MODIFIABLE(HttpStatus.CONFLICT, "EVENT_NOT_MODIFIABLE", "판매 시작 후에는 아티스트 정보를 수정할 수 없습니다."),
+    DUPLICATE_PLAY_SEQUENCE(HttpStatus.CONFLICT, "DUPLICATE_PLAY_SEQUENCE", "중복된 회차 순번입니다."),
+    HALL_NOT_IN_VENUE(HttpStatus.BAD_REQUEST, "HALL_NOT_IN_VENUE", "해당 홀은 선택한 공연장에 속하지 않습니다.")
 }

--- a/backend/event-service/build.gradle.kts
+++ b/backend/event-service/build.gradle.kts
@@ -22,7 +22,9 @@ dependencies {
     implementation(libs.spring.kafka)
 
     // Test
+    testImplementation(platform(libs.testcontainers.bom))
     testImplementation(libs.bundles.test.base)
     testImplementation(libs.bundles.testcontainers)
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation(libs.spring.security.test)
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/SecurityConfig.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/SecurityConfig.kt
@@ -62,6 +62,12 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.POST, "/venues/**").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.PATCH, "/venues/**").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.DELETE, "/venues/**").hasRole("ADMIN")
+                    // 공연 조회 API - 공개
+                    .requestMatchers(HttpMethod.GET, "/events/**").permitAll()
+                    // 공연 변경 API - ADMIN 전용
+                    .requestMatchers(HttpMethod.POST, "/events/**").hasRole("ADMIN")
+                    .requestMatchers(HttpMethod.PATCH, "/events/**").hasRole("ADMIN")
+                    .requestMatchers(HttpMethod.DELETE, "/events/**").hasRole("ADMIN")
                     // 액추에이터 - 헬스체크/정보만 공개
                     .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                     .anyRequest().authenticated()

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/EventController.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/EventController.kt
@@ -1,0 +1,85 @@
+package com.ticketqueue.event.controller
+
+import com.ticketqueue.common.dto.PageResponse
+import com.ticketqueue.event.dto.EventDto
+import com.ticketqueue.event.entity.EventStatus
+import com.ticketqueue.event.service.EventService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+/**
+ * 공연(Event) 관리 REST API 컨트롤러
+ *
+ * 엔드포인트 목록:
+ * - POST   /events           : 공연 생성 (ADMIN 전용) - REQ-EVT-001
+ * - GET    /events           : 공연 목록 조회 (공개, 페이징/필터/검색) - REQ-EVT-004
+ * - GET    /events/{eventId} : 공연 상세 조회 (공개, 회차 날짜별 그룹핑) - REQ-EVT-005
+ * - PATCH  /events/{eventId} : 공연 수정 (ADMIN 전용, 판매 전/후 차등) - REQ-EVT-002
+ * - DELETE /events/{eventId} : 공연 Soft Delete (ADMIN 전용, SOLD 좌석 있으면 불가) - REQ-EVT-003
+ *
+ * GET 요청은 인증 없이 접근 가능하며, 변경 작업(POST/PATCH/DELETE)은 ADMIN 권한이 필요하다.
+ * 권한 규칙은 SecurityConfig에서 정의된다.
+ */
+@RestController
+@RequestMapping("/events")
+class EventController(
+    private val eventService: EventService
+) {
+
+    /** 공연 생성 (REQ-EVT-001) - ADMIN 권한 필요 */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createEvent(@Valid @RequestBody request: EventDto.CreateRequest): EventDto.CreateResponse {
+        return eventService.createEvent(request)
+    }
+
+    /** 공연 목록 조회 (REQ-EVT-004) - 공개 API, 상태/도시/검색어 필터링 및 페이징 */
+    @GetMapping
+    fun getEvents(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int,
+        @RequestParam(required = false) status: EventStatus?,
+        @RequestParam(required = false) city: String?,
+        @RequestParam(required = false) keyword: String?
+    ): PageResponse<EventDto.ListResponse> {
+        val result = eventService.getEvents(page, size, status, city, keyword)
+        return PageResponse(
+            list = result.content,
+            page = result.number,
+            size = result.size,
+            totalElements = result.totalElements
+        )
+    }
+
+    /** 공연 상세 조회 (REQ-EVT-005) - 공개 API, 회차 날짜별 그룹핑 + isSoldOut */
+    @GetMapping("/{eventId}")
+    fun getEvent(@PathVariable eventId: UUID): EventDto.DetailResponse {
+        return eventService.getEvent(eventId)
+    }
+
+    /** 공연 수정 (REQ-EVT-002) - ADMIN 권한 필요, 판매 후 artist 변경 불가 */
+    @PatchMapping("/{eventId}")
+    fun updateEvent(
+        @PathVariable eventId: UUID,
+        @Valid @RequestBody request: EventDto.UpdateRequest
+    ): EventDto.UpdateResponse {
+        return eventService.updateEvent(eventId, request)
+    }
+
+    /** 공연 삭제 (REQ-EVT-003) - ADMIN 권한 필요, SOLD 좌석 있으면 409 */
+    @DeleteMapping("/{eventId}")
+    fun deleteEvent(@PathVariable eventId: UUID): EventDto.DeleteResponse {
+        return eventService.deleteEvent(eventId)
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/EventDto.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/EventDto.kt
@@ -1,0 +1,190 @@
+package com.ticketqueue.event.dto
+
+import com.ticketqueue.event.entity.Event
+import com.ticketqueue.event.entity.EventSchedule
+import com.ticketqueue.event.entity.EventStatus
+import com.ticketqueue.event.entity.ScheduleStatus
+import com.ticketqueue.event.entity.SeatGrade
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * 공연(Event) API 요청/응답 DTO 모음
+ *
+ * - [CreateRequest]      : POST 요청 - 공연/회차/좌석 일괄 생성
+ * - [ScheduleRequest]    : 회차 생성 정보
+ * - [CreateResponse]     : 생성 응답 - 핵심 메타정보
+ * - [ListResponse]       : 목록 조회 응답 - QueryDSL 프로젝션용 (Venue JOIN + Schedule 집계)
+ * - [ScheduleTimeInfo]   : 회차별 상세 정보 (isSoldOut 포함)
+ * - [ScheduleDateGroup]  : 날짜별 회차 그룹
+ * - [DetailResponse]     : 상세 조회 응답 - 회차 날짜별 그룹핑
+ * - [UpdateRequest]      : PATCH 요청 - nullable 필드 (판매 후 artist 수정 불가)
+ * - [UpdateResponse]     : 수정 응답
+ * - [DeleteResponse]     : 삭제 응답
+ */
+class EventDto {
+
+    /** 공연 생성 요청 - 회차 및 등급별 가격 포함 일괄 생성 */
+    data class CreateRequest(
+        @field:NotBlank(message = "공연 제목은 필수입니다.")
+        val title: String,
+
+        @field:NotBlank(message = "아티스트는 필수입니다.")
+        val artist: String,
+
+        val description: String? = null,
+
+        @field:NotNull(message = "공연장 ID는 필수입니다.")
+        val venueId: UUID,
+
+        @field:NotNull(message = "홀 ID는 필수입니다.")
+        val hallId: UUID,
+
+        @field:NotEmpty(message = "등급별 가격 정보는 필수입니다.")
+        val priceByGrade: Map<SeatGrade, BigDecimal>,
+
+        @field:NotEmpty(message = "회차 정보는 필수입니다.")
+        @field:Valid
+        val schedules: List<ScheduleRequest>
+    )
+
+    /** 회차 생성 요청 */
+    data class ScheduleRequest(
+        @field:Min(value = 1, message = "회차 순번은 1 이상이어야 합니다.")
+        val playSequence: Int,
+
+        @field:NotNull(message = "공연 시작 일시는 필수입니다.")
+        val eventStartAt: LocalDateTime,
+
+        @field:NotNull(message = "공연 종료 일시는 필수입니다.")
+        val eventEndAt: LocalDateTime,
+
+        @field:NotNull(message = "판매 시작 일시는 필수입니다.")
+        val saleStartAt: LocalDateTime,
+
+        @field:NotNull(message = "판매 종료 일시는 필수입니다.")
+        val saleEndAt: LocalDateTime
+    )
+
+    /** 공연 생성 응답 */
+    data class CreateResponse(
+        val id: UUID,
+        val title: String,
+        val artist: String,
+        val status: EventStatus,
+        val createdAt: LocalDateTime
+    ) {
+        companion object {
+            fun from(event: Event): CreateResponse = CreateResponse(
+                id = event.id!!,
+                title = event.title,
+                artist = event.artist,
+                status = event.status,
+                createdAt = event.createdAt!!
+            )
+        }
+    }
+
+    /** 공연 목록 조회 응답 - QueryDSL Tuple 프로젝션으로 구성 */
+    data class ListResponse(
+        val id: UUID,
+        val title: String,
+        val artist: String,
+        val venueName: String,
+        val startDate: LocalDateTime?,
+        val endDate: LocalDateTime?,
+        val status: EventStatus
+    )
+
+    /** 회차별 상세 정보 - 좌석 매진 여부 포함 */
+    data class ScheduleTimeInfo(
+        val id: UUID,
+        val playSequence: Int,
+        val eventStartAt: LocalDateTime,
+        val eventEndAt: LocalDateTime,
+        val saleStartAt: LocalDateTime,
+        val saleEndAt: LocalDateTime,
+        val status: ScheduleStatus,
+        val isSoldOut: Boolean
+    ) {
+        companion object {
+            fun from(schedule: EventSchedule, isSoldOut: Boolean): ScheduleTimeInfo = ScheduleTimeInfo(
+                id = schedule.id!!,
+                playSequence = schedule.playSequence,
+                eventStartAt = schedule.eventStartAt,
+                eventEndAt = schedule.eventEndAt,
+                saleStartAt = schedule.saleStartAt,
+                saleEndAt = schedule.saleEndAt,
+                status = schedule.status,
+                isSoldOut = isSoldOut
+            )
+        }
+    }
+
+    /** 날짜별 회차 그룹 - 상세 조회 시 eventStartAt 기준으로 그룹핑 */
+    data class ScheduleDateGroup(
+        val date: LocalDate,
+        val times: List<ScheduleTimeInfo>
+    )
+
+    /** 공연 상세 조회 응답 - 회차 날짜별 그룹핑 포함 */
+    data class DetailResponse(
+        val id: UUID,
+        val title: String,
+        val artist: String,
+        val description: String?,
+        val venueId: UUID,
+        val venueName: String,
+        val hallId: UUID,
+        val hallName: String,
+        val status: EventStatus,
+        val schedules: List<ScheduleDateGroup>,
+        val createdAt: LocalDateTime,
+        val updatedAt: LocalDateTime
+    )
+
+    /** 공연 수정 요청 - nullable 필드 (판매 시작 후 artist 수정 불가) */
+    data class UpdateRequest(
+        @field:Size(min = 1, message = "공연 제목은 비어있을 수 없습니다.")
+        val title: String? = null,
+
+        @field:Size(min = 1, message = "아티스트는 비어있을 수 없습니다.")
+        val artist: String? = null,
+
+        val description: String? = null
+    )
+
+    /** 공연 수정 응답 */
+    data class UpdateResponse(
+        val id: UUID,
+        val title: String,
+        val artist: String,
+        val description: String?,
+        val status: EventStatus,
+        val updatedAt: LocalDateTime
+    ) {
+        companion object {
+            fun from(event: Event): UpdateResponse = UpdateResponse(
+                id = event.id!!,
+                title = event.title,
+                artist = event.artist,
+                description = event.description,
+                status = event.status,
+                updatedAt = event.updatedAt!!
+            )
+        }
+    }
+
+    /** 공연 삭제 응답 */
+    data class DeleteResponse(
+        val message: String
+    )
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/EventDto.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/EventDto.kt
@@ -6,6 +6,7 @@ import com.ticketqueue.event.entity.EventStatus
 import com.ticketqueue.event.entity.ScheduleStatus
 import com.ticketqueue.event.entity.SeatGrade
 import jakarta.validation.Valid
+import jakarta.validation.constraints.DecimalMin
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
@@ -49,9 +50,10 @@ class EventDto {
         val hallId: UUID,
 
         @field:NotEmpty(message = "등급별 가격 정보는 필수입니다.")
-        val priceByGrade: Map<SeatGrade, BigDecimal>,
+        val priceByGrade: Map<SeatGrade, @DecimalMin(value = "0", message = "가격은 0 이상이어야 합니다.") BigDecimal>,
 
         @field:NotEmpty(message = "회차 정보는 필수입니다.")
+        @field:Size(max = 50, message = "회차는 최대 50개까지 등록 가능합니다.")
         @field:Valid
         val schedules: List<ScheduleRequest>
     )

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Event.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Event.kt
@@ -63,7 +63,8 @@ class Event(
     fun update(title: String?, artist: String?, description: String?) {
         title?.let { this.title = it }
         artist?.let { this.artist = it }
-        description?.let { this.description = it }
+        // 빈 문자열("")은 description을 null로 초기화하는 신호 (스펙 노트 참조)
+        description?.let { this.description = it.ifEmpty { null } }
     }
 
     fun changeStatus(newStatus: EventStatus) {

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Event.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Event.kt
@@ -24,13 +24,13 @@ class Event(
     val id: UUID? = null,
 
     @Column(nullable = false)
-    val title: String,
+    var title: String,
 
     @Column(nullable = false)
-    val artist: String,
+    var artist: String,
 
     @Column(columnDefinition = "TEXT")
-    val description: String? = null,
+    var description: String? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "venue_id", nullable = false)
@@ -42,7 +42,10 @@ class Event(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    val status: EventStatus = EventStatus.PREPARING,
+    var status: EventStatus = EventStatus.PREPARING,
+
+    @Column(name = "deleted_at")
+    var deletedAt: LocalDateTime? = null,
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -52,6 +55,25 @@ class Event(
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime? = null
 ) {
+    /**
+     * PATCH 요청을 위한 부분 업데이트
+     *
+     * null이 아닌 필드만 선택적으로 변경한다.
+     */
+    fun update(title: String?, artist: String?, description: String?) {
+        title?.let { this.title = it }
+        artist?.let { this.artist = it }
+        description?.let { this.description = it }
+    }
+
+    fun changeStatus(newStatus: EventStatus) {
+        this.status = newStatus
+    }
+
+    fun softDelete() {
+        this.deletedAt = LocalDateTime.now()
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Event) return false

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/EventSchedule.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/EventSchedule.kt
@@ -44,7 +44,7 @@ class EventSchedule(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    val status: ScheduleStatus = ScheduleStatus.UPCOMING,
+    var status: ScheduleStatus = ScheduleStatus.UPCOMING,
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -54,6 +54,9 @@ class EventSchedule(
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime? = null
 ) {
+    /** 티켓 판매가 시작된 회차인지 확인 */
+    fun hasSaleStarted(): Boolean = saleStartAt.isBefore(LocalDateTime.now())
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is EventSchedule) return false

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepository.kt
@@ -6,7 +6,8 @@ import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface EventRepository : JpaRepository<Event, UUID> {
+interface EventRepository : JpaRepository<Event, UUID>, EventRepositoryCustom {
     fun existsByVenueId(venueId: UUID): Boolean
     fun existsByHallId(hallId: UUID): Boolean
+    fun findByIdAndDeletedAtIsNull(id: UUID): Event?
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustom.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustom.kt
@@ -36,4 +36,12 @@ interface EventRepositoryCustom {
      * 반환된 Set에 없는 scheduleId는 AVAILABLE 좌석이 없음 (isSoldOut = true).
      */
     fun findScheduleIdsWithAvailableSeats(scheduleIds: List<UUID>): Set<UUID>
+
+    /**
+     * 공연을 비관적 락(FOR UPDATE)으로 조회
+     *
+     * deleteEvent의 race condition 방지: SOLD 좌석 확인과 softDelete 사이의
+     * 동시 좌석 판매를 차단하여 데이터 정합성을 보장한다.
+     */
+    fun findByIdForUpdate(eventId: UUID): Event?
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustom.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustom.kt
@@ -1,0 +1,39 @@
+package com.ticketqueue.event.repository
+
+import com.ticketqueue.event.dto.EventDto
+import com.ticketqueue.event.entity.Event
+import com.ticketqueue.event.entity.EventStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import java.util.UUID
+
+interface EventRepositoryCustom {
+    /**
+     * 공연 목록 조회 (QueryDSL 프로젝션)
+     *
+     * Event + Venue JOIN + EventSchedule 집계(MIN/MAX startDate)를 단일 쿼리로 처리한다.
+     * deleted_at IS NULL 필터를 항상 적용한다.
+     */
+    fun findEventList(
+        pageable: Pageable,
+        status: EventStatus?,
+        city: String?,
+        keyword: String?
+    ): Page<EventDto.ListResponse>
+
+    /**
+     * 공연 상세 조회 (Venue + Hall fetch join)
+     *
+     * N+1 문제 방지를 위해 venue와 hall을 단일 쿼리로 함께 로드한다.
+     * deleted_at IS NULL 필터를 적용한다.
+     */
+    fun findEventWithVenueAndHall(eventId: UUID): Event?
+
+    /**
+     * AVAILABLE 좌석이 하나라도 존재하는 회차 ID Set 반환
+     *
+     * N+1 방지를 위해 회차 ID 목록을 단일 쿼리로 일괄 조회한다.
+     * 반환된 Set에 없는 scheduleId는 AVAILABLE 좌석이 없음 (isSoldOut = true).
+     */
+    fun findScheduleIdsWithAvailableSeats(scheduleIds: List<UUID>): Set<UUID>
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustomImpl.kt
@@ -10,6 +10,7 @@ import com.ticketqueue.event.entity.QEventSchedule
 import com.ticketqueue.event.entity.QSeat
 import com.ticketqueue.event.entity.QVenue
 import com.ticketqueue.event.entity.SeatStatus
+import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -107,6 +108,15 @@ class EventRepositoryCustomImpl(
             .fetch()
             .filterNotNull()
             .toSet()
+    }
+
+    override fun findByIdForUpdate(eventId: UUID): Event? {
+        val event = QEvent.event
+        return queryFactory
+            .selectFrom(event)
+            .where(event.id.eq(eventId))
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+            .fetchOne()
     }
 
     private fun buildPredicate(

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustomImpl.kt
@@ -12,6 +12,7 @@ import com.ticketqueue.event.entity.QVenue
 import com.ticketqueue.event.entity.SeatStatus
 import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Page
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import java.time.LocalDateTime
@@ -27,6 +28,7 @@ import java.util.UUID
  * - GROUP BY로 회차별 MIN/MAX startDate 집계
  * - deleted_at IS NULL 조건 항상 포함
  */
+@Transactional(readOnly = true)
 class EventRepositoryCustomImpl(
     private val queryFactory: JPAQueryFactory
 ) : EventRepositoryCustom {
@@ -110,6 +112,7 @@ class EventRepositoryCustomImpl(
             .toSet()
     }
 
+    @Transactional
     override fun findByIdForUpdate(eventId: UUID): Event? {
         val event = QEvent.event
         return queryFactory

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustomImpl.kt
@@ -1,0 +1,131 @@
+package com.ticketqueue.event.repository
+
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.ticketqueue.event.dto.EventDto
+import com.ticketqueue.event.entity.Event
+import com.ticketqueue.event.entity.EventStatus
+import com.ticketqueue.event.entity.QEvent
+import com.ticketqueue.event.entity.QEventSchedule
+import com.ticketqueue.event.entity.QSeat
+import com.ticketqueue.event.entity.QVenue
+import com.ticketqueue.event.entity.SeatStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Event Custom Repository 구현체
+ *
+ * QueryDSL을 활용하여 집계 쿼리(목록 조회)와 fetch join 쿼리(상세 조회)를 처리한다.
+ *
+ * 목록 조회 전략:
+ * - Event + Venue LEFT JOIN + EventSchedule LEFT JOIN으로 단일 쿼리
+ * - GROUP BY로 회차별 MIN/MAX startDate 집계
+ * - deleted_at IS NULL 조건 항상 포함
+ */
+class EventRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory
+) : EventRepositoryCustom {
+
+    override fun findEventList(
+        pageable: Pageable,
+        status: EventStatus?,
+        city: String?,
+        keyword: String?
+    ): Page<EventDto.ListResponse> {
+        val event = QEvent.event
+        val venue = QVenue.venue
+        val schedule = QEventSchedule.eventSchedule
+
+        // 집계 표현식은 변수로 저장하여 SELECT와 Tuple.get() 양쪽에서 동일 인스턴스 참조
+        val minStartAt = schedule.eventStartAt.min()
+        val maxStartAt = schedule.eventStartAt.max()
+
+        val predicate = buildPredicate(event, venue, status, city, keyword)
+
+        val results = queryFactory
+            .select(event.id, event.title, event.artist, venue.name, minStartAt, maxStartAt, event.status)
+            .from(event)
+            .leftJoin(event.venue, venue)
+            .leftJoin(schedule).on(schedule.event.eq(event))
+            .where(predicate)
+            .groupBy(event.id, event.title, event.artist, event.status, venue.name)
+            .orderBy(minStartAt.asc().nullsLast())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+            .map { tuple ->
+                EventDto.ListResponse(
+                    id = tuple.get(event.id)!!,
+                    title = tuple.get(event.title)!!,
+                    artist = tuple.get(event.artist)!!,
+                    venueName = tuple.get(venue.name) ?: "",
+                    startDate = tuple.get(minStartAt),
+                    endDate = tuple.get(maxStartAt),
+                    status = tuple.get(event.status)!!
+                )
+            }
+
+        val total = queryFactory
+            .select(event.count())
+            .from(event)
+            .leftJoin(event.venue, venue)
+            .where(predicate)
+            .fetchOne() ?: 0L
+
+        return PageImpl(results, pageable, total)
+    }
+
+    override fun findEventWithVenueAndHall(eventId: UUID): Event? {
+        val event = QEvent.event
+
+        return queryFactory
+            .selectFrom(event)
+            .leftJoin(event.venue).fetchJoin()
+            .leftJoin(event.hall).fetchJoin()
+            .where(
+                event.id.eq(eventId),
+                event.deletedAt.isNull
+            )
+            .fetchOne()
+    }
+
+    override fun findScheduleIdsWithAvailableSeats(scheduleIds: List<UUID>): Set<UUID> {
+        if (scheduleIds.isEmpty()) return emptySet()
+        val seat = QSeat.seat
+        return queryFactory
+            .select(seat.eventSchedule.id)
+            .from(seat)
+            .where(
+                seat.eventSchedule.id.`in`(scheduleIds),
+                seat.status.eq(SeatStatus.AVAILABLE)
+            )
+            .groupBy(seat.eventSchedule.id)
+            .fetch()
+            .filterNotNull()
+            .toSet()
+    }
+
+    private fun buildPredicate(
+        event: QEvent,
+        venue: QVenue,
+        status: EventStatus?,
+        city: String?,
+        keyword: String?
+    ): BooleanBuilder {
+        val builder = BooleanBuilder()
+        builder.and(event.deletedAt.isNull)
+        status?.let { builder.and(event.status.eq(it)) }
+        city?.let { builder.and(venue.city.equalsIgnoreCase(it)) }
+        keyword?.let {
+            builder.and(
+                event.title.containsIgnoreCase(it)
+                    .or(event.artist.containsIgnoreCase(it))
+            )
+        }
+        return builder
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustomImpl.kt
@@ -130,6 +130,11 @@ class EventRepositoryCustomImpl(
         builder.and(event.deletedAt.isNull)
         status?.let { builder.and(event.status.eq(it)) }
         city?.let { builder.and(venue.city.equalsIgnoreCase(it)) }
+        // NOTE: QueryDSL-JPA의 booleanTemplate은 JPQL(HQL)을 생성하므로,
+        //       PostgreSQL 전용 @@ 연산자를 사용할 수 없음 (HQL 파서가 거부).
+        //       진짜 GIN 인덱스 활용 FTS는 EntityManager.createNativeQuery() 또는
+        //       JPASQLQuery(SQLTemplates) 방식으로 별도 구현 필요.
+        //       현재는 대소문자 무관 LIKE 검색으로 동작하며 정확성 보장.
         keyword?.let {
             builder.and(
                 event.title.containsIgnoreCase(it)

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepository.kt
@@ -3,9 +3,16 @@ package com.ticketqueue.event.repository
 import com.ticketqueue.event.entity.EventSchedule
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Repository
 interface EventScheduleRepository : JpaRepository<EventSchedule, UUID> {
     fun findByEventIdOrderByPlaySequence(eventId: UUID): List<EventSchedule>
+
+    /**
+     * 주어진 공연의 회차 중 판매가 이미 시작된 회차가 존재하는지 확인한다.
+     * updateEvent의 hasSaleStarted 체크를 위해 전체 목록 로드 대신 EXISTS 쿼리 1개로 처리한다.
+     */
+    fun existsByEventIdAndSaleStartAtBefore(eventId: UUID, dateTime: LocalDateTime): Boolean
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepository.kt
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface EventScheduleRepository : JpaRepository<EventSchedule, UUID>
+interface EventScheduleRepository : JpaRepository<EventSchedule, UUID> {
+    fun findByEventIdOrderByPlaySequence(eventId: UUID): List<EventSchedule>
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepository.kt
@@ -3,16 +3,10 @@ package com.ticketqueue.event.repository
 import com.ticketqueue.event.entity.Seat
 import com.ticketqueue.event.entity.SeatStatus
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface SeatRepository : JpaRepository<Seat, UUID> {
+interface SeatRepository : JpaRepository<Seat, UUID>, SeatRepositoryCustom {
     fun existsByEventScheduleIdAndStatus(eventScheduleId: UUID, status: SeatStatus): Boolean
-
-    /** 공연 전체(모든 회차)에 특정 상태의 좌석 존재 여부 확인 — exists 최적화 (COUNT 대비 조기 종료) */
-    @Query("SELECT CASE WHEN COUNT(s) > 0 THEN true ELSE false END FROM Seat s WHERE s.eventSchedule.event.id = :eventId AND s.status = :status")
-    fun existsByEventIdAndStatus(@Param("eventId") eventId: UUID, @Param("status") status: SeatStatus): Boolean
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepository.kt
@@ -1,9 +1,18 @@
 package com.ticketqueue.event.repository
 
 import com.ticketqueue.event.entity.Seat
+import com.ticketqueue.event.entity.SeatStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface SeatRepository : JpaRepository<Seat, UUID>
+interface SeatRepository : JpaRepository<Seat, UUID> {
+    fun existsByEventScheduleIdAndStatus(eventScheduleId: UUID, status: SeatStatus): Boolean
+
+    /** 공연 전체(모든 회차)에 특정 상태의 좌석 존재 여부 확인 — exists 최적화 (COUNT 대비 조기 종료) */
+    @Query("SELECT CASE WHEN COUNT(s) > 0 THEN true ELSE false END FROM Seat s WHERE s.eventSchedule.event.id = :eventId AND s.status = :status")
+    fun existsByEventIdAndStatus(@Param("eventId") eventId: UUID, @Param("status") status: SeatStatus): Boolean
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustom.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustom.kt
@@ -1,0 +1,8 @@
+package com.ticketqueue.event.repository
+
+import com.ticketqueue.event.entity.SeatStatus
+import java.util.UUID
+
+interface SeatRepositoryCustom {
+    fun existsByEventIdAndStatus(eventId: UUID, status: SeatStatus): Boolean
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustomImpl.kt
@@ -1,0 +1,23 @@
+package com.ticketqueue.event.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.ticketqueue.event.entity.QSeat
+import com.ticketqueue.event.entity.SeatStatus
+import java.util.UUID
+
+class SeatRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory
+) : SeatRepositoryCustom {
+
+    override fun existsByEventIdAndStatus(eventId: UUID, status: SeatStatus): Boolean {
+        val seat = QSeat.seat
+        return queryFactory
+            .selectOne()
+            .from(seat)
+            .where(
+                seat.eventSchedule.event.id.eq(eventId),
+                seat.status.eq(status)
+            )
+            .fetchFirst() != null   // EXISTS 시맨틱: 첫 행 발견 시 즉시 반환
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
@@ -22,6 +22,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
+import java.time.LocalDateTime
 import java.util.UUID
 
 /**
@@ -73,6 +74,14 @@ class EventService(
         // 회차 시간 유효성 검증
         request.schedules.forEach { s ->
             if (!s.eventStartAt.isBefore(s.eventEndAt) || !s.saleStartAt.isBefore(s.saleEndAt)) {
+                throw EventException(ErrorCode.INVALID_SCHEDULE_TIME)
+            }
+            // 판매 종료 시각은 공연 시작 이전이어야 함 (티켓 판매는 공연 전에 마감)
+            if (!s.saleEndAt.isBefore(s.eventStartAt)) {
+                throw EventException(ErrorCode.INVALID_SCHEDULE_TIME)
+            }
+            // 공연 시작 시각은 현재 시각 이후여야 함 (과거 날짜 공연 등록 방지)
+            if (!s.eventStartAt.isAfter(LocalDateTime.now())) {
                 throw EventException(ErrorCode.INVALID_SCHEDULE_TIME)
             }
         }
@@ -203,8 +212,8 @@ class EventService(
     @Transactional
     fun updateEvent(eventId: UUID, request: EventDto.UpdateRequest): EventDto.UpdateResponse {
         val event = findActiveEvent(eventId)
-        val hasSaleStarted = eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId)
-            .any { it.hasSaleStarted() }
+        // 전체 스케줄 로드 대신 EXISTS 쿼리 1개로 판매 시작 여부 확인 (N → 1 쿼리)
+        val hasSaleStarted = eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(eventId, LocalDateTime.now())
 
         if (hasSaleStarted && request.artist != null) {
             throw EventException(ErrorCode.EVENT_NOT_MODIFIABLE)
@@ -238,7 +247,7 @@ class EventService(
         }
 
         event.softDelete()
-        return EventDto.DeleteResponse(message = "공연이 삭제되었습니다.")
+        return EventDto.DeleteResponse(message = "Event deleted successfully")
     }
 
     private fun findActiveEvent(eventId: UUID): Event {

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
@@ -226,8 +226,8 @@ class EventService(
      */
     @Transactional
     fun deleteEvent(eventId: UUID): EventDto.DeleteResponse {
-        val event = eventRepository.findById(eventId)
-            .orElseThrow { EventException(ErrorCode.EVENT_NOT_FOUND) }
+        val event = eventRepository.findByIdForUpdate(eventId)
+            ?: throw EventException(ErrorCode.EVENT_NOT_FOUND)
 
         if (event.deletedAt != null) {
             throw EventException(ErrorCode.EVENT_ALREADY_DELETED)

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
@@ -1,0 +1,248 @@
+package com.ticketqueue.event.service
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.dto.EventDto
+import com.ticketqueue.event.dto.SeatTemplateDto
+import com.ticketqueue.event.entity.Event
+import com.ticketqueue.event.entity.EventSchedule
+import com.ticketqueue.event.entity.EventStatus
+import com.ticketqueue.event.entity.Seat
+import com.ticketqueue.event.entity.SeatGrade
+import com.ticketqueue.event.entity.SeatStatus
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.repository.EventRepository
+import com.ticketqueue.event.repository.EventScheduleRepository
+import com.ticketqueue.event.repository.HallRepository
+import com.ticketqueue.event.repository.SeatRepository
+import com.ticketqueue.event.repository.VenueRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * 공연(Event) 관리 서비스
+ *
+ * 공연의 CRUD 기능과 회차/좌석 일괄 생성을 처리한다.
+ * - 공연 생성 시 Hall의 seatTemplate을 기반으로 회차별 좌석 자동 초기화
+ * - Soft Delete: deleted_at 컬럼으로 논리 삭제, SOLD 좌석이 있으면 삭제 불가
+ * - 수정 범위 차등: 판매 시작 후에는 artist 변경 불가 (REQ-EVT-002)
+ */
+@Service
+@Transactional(readOnly = true)
+class EventService(
+    private val eventRepository: EventRepository,
+    private val eventScheduleRepository: EventScheduleRepository,
+    private val seatRepository: SeatRepository,
+    private val venueRepository: VenueRepository,
+    private val hallRepository: HallRepository,
+    private val objectMapper: ObjectMapper
+) {
+
+    /**
+     * 공연 생성 - 회차 및 좌석 일괄 생성 (REQ-EVT-001)
+     *
+     * 1. Venue/Hall 존재 및 귀속 검증
+     * 2. 회차 순번 중복 및 시간 유효성 검증
+     * 3. Hall seatTemplate 파싱
+     * 4. Event → EventSchedule → Seat 순서로 저장
+     */
+    @Transactional
+    fun createEvent(request: EventDto.CreateRequest): EventDto.CreateResponse {
+        val venue = venueRepository.findById(request.venueId)
+            .orElseThrow { EventException(ErrorCode.VENUE_NOT_FOUND) }
+
+        val hall = hallRepository.findById(request.hallId)
+            .orElseThrow { EventException(ErrorCode.HALL_NOT_FOUND) }
+
+        // 홀이 해당 공연장에 속하는지 검증
+        if (hall.venue.id != venue.id) {
+            throw EventException(ErrorCode.HALL_NOT_IN_VENUE)
+        }
+
+        // 회차 순번 중복 검증
+        val sequences = request.schedules.map { it.playSequence }
+        if (sequences.size != sequences.toSet().size) {
+            throw EventException(ErrorCode.DUPLICATE_PLAY_SEQUENCE)
+        }
+
+        // 회차 시간 유효성 검증
+        request.schedules.forEach { s ->
+            if (!s.eventStartAt.isBefore(s.eventEndAt) || !s.saleStartAt.isBefore(s.saleEndAt)) {
+                throw EventException(ErrorCode.INVALID_SCHEDULE_TIME)
+            }
+        }
+
+        // 좌석 템플릿 파싱 (공연 저장 전 검증하여 fail-fast)
+        val seatTemplate = try {
+            objectMapper.readValue(hall.seatTemplate, SeatTemplateDto::class.java)
+        } catch (e: JsonProcessingException) {
+            throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE, cause = e)
+        }
+
+        val event = eventRepository.save(
+            Event(title = request.title, artist = request.artist, description = request.description, venue = venue, hall = hall)
+        )
+
+        request.schedules.forEach { scheduleRequest ->
+            val schedule = eventScheduleRepository.save(
+                EventSchedule(
+                    event = event,
+                    playSequence = scheduleRequest.playSequence,
+                    eventStartAt = scheduleRequest.eventStartAt,
+                    eventEndAt = scheduleRequest.eventEndAt,
+                    saleStartAt = scheduleRequest.saleStartAt,
+                    saleEndAt = scheduleRequest.saleEndAt
+                )
+            )
+            val seats = initializeSeats(schedule, seatTemplate, request.priceByGrade)
+            seatRepository.saveAll(seats)
+        }
+
+        return EventDto.CreateResponse.from(event)
+    }
+
+    /**
+     * 회차에 속하는 좌석 목록을 생성한다.
+     *
+     * Hall의 seatTemplate(rows × seatsPerRow)과 priceByGrade를 조합하여
+     * 회차별 Seat 엔티티를 초기화한다.
+     *
+     * @param schedule    좌석이 속할 회차 엔티티
+     * @param seatTemplate Hall에 저장된 좌석 배치 정보
+     * @param priceByGrade 등급별 가격 (CreateRequest에서 전달)
+     * @return 생성된 Seat 엔티티 목록 (아직 DB 미저장 상태)
+     */
+    private fun initializeSeats(
+        schedule: EventSchedule,
+        seatTemplate: SeatTemplateDto,
+        priceByGrade: Map<SeatGrade, BigDecimal>
+    ): List<Seat> {
+        return seatTemplate.rows.flatMap { row ->
+            val gradeStr = seatTemplate.gradeMapping[row]
+                ?: throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING)
+            val grade = try {
+                SeatGrade.valueOf(gradeStr)
+            } catch (e: IllegalArgumentException) {
+                throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING)
+            }
+            val price = priceByGrade[grade]
+                ?: throw EventException(ErrorCode.INVALID_INPUT)
+            (1..seatTemplate.seatsPerRow).map { seatIndex ->
+                Seat(eventSchedule = schedule, seatNumber = "${row}-${seatIndex}", grade = grade, price = price)
+            }
+        }
+    }
+
+    /**
+     * 공연 목록 조회 (페이징, 필터링, 검색) - REQ-EVT-004, P95 < 200ms
+     */
+    fun getEvents(
+        page: Int,
+        size: Int,
+        status: EventStatus?,
+        city: String?,
+        keyword: String?
+    ): Page<EventDto.ListResponse> {
+        val pageable = PageRequest.of(page.coerceAtLeast(0), size.coerceIn(1, 100))
+        return eventRepository.findEventList(pageable, status, city, keyword)
+    }
+
+    /**
+     * 공연 상세 조회 - REQ-EVT-005, P95 < 100ms
+     *
+     * 회차를 날짜별로 그룹핑하고, 회차별 매진 여부(isSoldOut)를 계산한다.
+     * isSoldOut: AVAILABLE 좌석이 하나도 없으면 true
+     */
+    fun getEvent(eventId: UUID): EventDto.DetailResponse {
+        val event = eventRepository.findEventWithVenueAndHall(eventId)
+            ?: throw EventException(ErrorCode.EVENT_NOT_FOUND)
+
+        val schedules = eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId)
+
+        val scheduleIds = schedules.map { it.id!! }
+        val availableScheduleIds = eventRepository.findScheduleIdsWithAvailableSeats(scheduleIds)
+
+        val scheduleDateGroups = schedules
+            .map { schedule ->
+                EventDto.ScheduleTimeInfo.from(schedule, isSoldOut = schedule.id!! !in availableScheduleIds)
+            }
+            .groupBy { it.eventStartAt.toLocalDate() }
+            .map { (date, times) ->
+                EventDto.ScheduleDateGroup(date = date, times = times.sortedBy { it.eventStartAt })
+            }
+            .sortedBy { it.date }
+
+        return EventDto.DetailResponse(
+            id = event.id!!,
+            title = event.title,
+            artist = event.artist,
+            description = event.description,
+            venueId = event.venue.id!!,
+            venueName = event.venue.name,
+            hallId = event.hall.id!!,
+            hallName = event.hall.name,
+            status = event.status,
+            schedules = scheduleDateGroups,
+            createdAt = event.createdAt!!,
+            updatedAt = event.updatedAt!!
+        )
+    }
+
+    /**
+     * 공연 수정 (PATCH) - REQ-EVT-002
+     *
+     * 판매 시작 여부: 해당 공연의 어느 회차든 saleStartAt이 현재 시각 이전이면 "판매 시작됨"
+     * - 판매 전: title, artist, description 모두 수정 가능
+     * - 판매 후: title, description만 수정 가능 (artist 변경 시 409 반환)
+     */
+    @Transactional
+    fun updateEvent(eventId: UUID, request: EventDto.UpdateRequest): EventDto.UpdateResponse {
+        val event = findActiveEvent(eventId)
+        val hasSaleStarted = eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId)
+            .any { it.hasSaleStarted() }
+
+        if (hasSaleStarted && request.artist != null) {
+            throw EventException(ErrorCode.EVENT_NOT_MODIFIABLE)
+        }
+
+        event.update(
+            title = request.title,
+            artist = request.artist,
+            description = request.description
+        )
+
+        return EventDto.UpdateResponse.from(event)
+    }
+
+    /**
+     * 공연 Soft Delete - REQ-EVT-003
+     *
+     * SOLD 좌석이 하나라도 있으면 삭제 불가 (데이터 정합성 보장)
+     */
+    @Transactional
+    fun deleteEvent(eventId: UUID): EventDto.DeleteResponse {
+        val event = eventRepository.findById(eventId)
+            .orElseThrow { EventException(ErrorCode.EVENT_NOT_FOUND) }
+
+        if (event.deletedAt != null) {
+            throw EventException(ErrorCode.EVENT_ALREADY_DELETED)
+        }
+
+        if (seatRepository.existsByEventIdAndStatus(eventId, SeatStatus.SOLD)) {
+            throw EventException(ErrorCode.EVENT_HAS_RESERVATIONS)
+        }
+
+        event.softDelete()
+        return EventDto.DeleteResponse(message = "공연이 삭제되었습니다.")
+    }
+
+    private fun findActiveEvent(eventId: UUID): Event {
+        return eventRepository.findByIdAndDeletedAtIsNull(eventId)
+            ?: throw EventException(ErrorCode.EVENT_NOT_FOUND)
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
@@ -1,0 +1,306 @@
+package com.ticketqueue.event.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.exception.GlobalExceptionHandler
+import com.ticketqueue.event.dto.EventDto
+import com.ticketqueue.event.entity.EventStatus
+import com.ticketqueue.event.entity.SeatGrade
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.service.EventService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.http.MediaType
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+class EventControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var eventService: EventService
+    private val objectMapper: ObjectMapper = jacksonObjectMapper().apply {
+        registerModule(JavaTimeModule())
+    }
+
+    private val eventId = UUID.randomUUID()
+    private val now = LocalDateTime.now()
+
+    private fun createResponse() = EventDto.CreateResponse(
+        id = eventId,
+        title = "BTS World Tour",
+        artist = "BTS",
+        status = EventStatus.PREPARING,
+        createdAt = now
+    )
+
+    private fun listResponse() = EventDto.ListResponse(
+        id = eventId,
+        title = "BTS World Tour",
+        artist = "BTS",
+        venueName = "올림픽공원",
+        startDate = now.plusDays(30),
+        endDate = now.plusDays(31),
+        status = EventStatus.PREPARING
+    )
+
+    private fun detailResponse() = EventDto.DetailResponse(
+        id = eventId,
+        title = "BTS World Tour",
+        artist = "BTS",
+        description = null,
+        venueId = UUID.randomUUID(),
+        venueName = "올림픽공원",
+        hallId = UUID.randomUUID(),
+        hallName = "KSPO DOME",
+        status = EventStatus.PREPARING,
+        schedules = emptyList(),
+        createdAt = now,
+        updatedAt = now
+    )
+
+    private fun updateResponse() = EventDto.UpdateResponse(
+        id = eventId,
+        title = "BTS World Tour 2026",
+        artist = "BTS",
+        description = null,
+        status = EventStatus.PREPARING,
+        updatedAt = now
+    )
+
+    private fun validCreateRequest() = EventDto.CreateRequest(
+        title = "BTS World Tour",
+        artist = "BTS",
+        venueId = UUID.randomUUID(),
+        hallId = UUID.randomUUID(),
+        priceByGrade = mapOf(SeatGrade.VIP to BigDecimal("100000")),
+        schedules = listOf(
+            EventDto.ScheduleRequest(
+                playSequence = 1,
+                eventStartAt = now.plusDays(30),
+                eventEndAt = now.plusDays(30).plusHours(2),
+                saleStartAt = now.plusDays(1),
+                saleEndAt = now.plusDays(29)
+            )
+        )
+    )
+
+    @BeforeEach
+    fun setUp() {
+        eventService = mockk()
+        val controller = EventController(eventService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(GlobalExceptionHandler())
+            .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
+            .build()
+    }
+
+    @Nested
+    @DisplayName("POST /events")
+    inner class CreateEvent {
+
+        @Test
+        @DisplayName("201 Created - 공연을 생성한다")
+        fun created() {
+            every { eventService.createEvent(any()) } returns createResponse()
+
+            mockMvc.perform(
+                post("/events")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(validCreateRequest()))
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.title").value("BTS World Tour"))
+                .andExpect(jsonPath("$.artist").value("BTS"))
+                .andExpect(jsonPath("$.status").value("PREPARING"))
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - 유효성 검사 실패 (title 누락)")
+        fun badRequest() {
+            val invalidRequest = mapOf("artist" to "BTS") // title, venueId, hallId 등 누락
+
+            mockMvc.perform(
+                post("/events")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(invalidRequest))
+            )
+                .andExpect(status().isBadRequest)
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /events")
+    inner class GetEvents {
+
+        @Test
+        @DisplayName("200 OK - 공연 목록을 조회한다")
+        fun list() {
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(listOf(listResponse()), pageable, 1)
+            every { eventService.getEvents(0, 20, null, null, null) } returns page
+
+            mockMvc.perform(get("/events"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.list[0].title").value("BTS World Tour"))
+                .andExpect(jsonPath("$.totalElements").value(1))
+        }
+
+        @Test
+        @DisplayName("200 OK - 검색어와 도시 필터로 공연 목록을 조회한다")
+        fun listWithFilters() {
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(listOf(listResponse()), pageable, 1)
+            every { eventService.getEvents(0, 20, null, "서울", "BTS") } returns page
+
+            mockMvc.perform(get("/events").param("city", "서울").param("keyword", "BTS"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.list[0].artist").value("BTS"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /events/{eventId}")
+    inner class GetEvent {
+
+        @Test
+        @DisplayName("200 OK - 공연 상세를 조회한다 (회차 날짜별 그룹핑)")
+        fun detail() {
+            every { eventService.getEvent(eventId) } returns detailResponse()
+
+            mockMvc.perform(get("/events/{eventId}", eventId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.title").value("BTS World Tour"))
+                .andExpect(jsonPath("$.venueName").value("올림픽공원"))
+                .andExpect(jsonPath("$.schedules").isArray)
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 공연")
+        fun notFound() {
+            every { eventService.getEvent(eventId) } throws EventException(ErrorCode.EVENT_NOT_FOUND)
+
+            mockMvc.perform(get("/events/{eventId}", eventId))
+                .andExpect(status().isNotFound)
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /events/{eventId}")
+    inner class UpdateEvent {
+
+        @Test
+        @DisplayName("200 OK - 공연을 수정한다")
+        fun success() {
+            every { eventService.updateEvent(eventId, any()) } returns updateResponse()
+
+            mockMvc.perform(
+                patch("/events/{eventId}", eventId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(EventDto.UpdateRequest(title = "BTS World Tour 2026")))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.title").value("BTS World Tour 2026"))
+        }
+
+        @Test
+        @DisplayName("409 Conflict - 판매 시작 후 artist 수정 불가")
+        fun artistNotModifiable() {
+            every { eventService.updateEvent(eventId, any()) } throws EventException(ErrorCode.EVENT_NOT_MODIFIABLE)
+
+            mockMvc.perform(
+                patch("/events/{eventId}", eventId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(EventDto.UpdateRequest(artist = "변경된 아티스트")))
+            )
+                .andExpect(status().isConflict)
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 공연 수정")
+        fun notFound() {
+            every { eventService.updateEvent(eventId, any()) } throws EventException(ErrorCode.EVENT_NOT_FOUND)
+
+            mockMvc.perform(
+                patch("/events/{eventId}", eventId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(EventDto.UpdateRequest(title = "새 제목")))
+            )
+                .andExpect(status().isNotFound)
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - title 빈 문자열 전달 시 @Size(min=1) 검증 실패")
+        fun titleEmpty() {
+            mockMvc.perform(
+                patch("/events/{eventId}", eventId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(EventDto.UpdateRequest(title = "")))
+            )
+                .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        @DisplayName("200 OK - 빈 body 전달 시 nullable 필드 모두 null이므로 유효성 검사 통과")
+        fun emptyBody() {
+            every { eventService.updateEvent(eventId, any()) } returns updateResponse()
+
+            mockMvc.perform(
+                patch("/events/{eventId}", eventId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}")
+            )
+                .andExpect(status().isOk)
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /events/{eventId}")
+    inner class DeleteEvent {
+
+        @Test
+        @DisplayName("200 OK - 공연을 Soft Delete한다")
+        fun success() {
+            every { eventService.deleteEvent(eventId) } returns EventDto.DeleteResponse("공연이 삭제되었습니다.")
+
+            mockMvc.perform(delete("/events/{eventId}", eventId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.message").value("공연이 삭제되었습니다."))
+        }
+
+        @Test
+        @DisplayName("409 Conflict - 판매된 좌석이 있는 공연 삭제 시")
+        fun conflict() {
+            every { eventService.deleteEvent(eventId) } throws EventException(ErrorCode.EVENT_HAS_RESERVATIONS)
+
+            mockMvc.perform(delete("/events/{eventId}", eventId))
+                .andExpect(status().isConflict)
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 공연 삭제")
+        fun notFound() {
+            every { eventService.deleteEvent(eventId) } throws EventException(ErrorCode.EVENT_NOT_FOUND)
+
+            mockMvc.perform(delete("/events/{eventId}", eventId))
+                .andExpect(status().isNotFound)
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/entity/EventTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/entity/EventTest.kt
@@ -1,0 +1,232 @@
+package com.ticketqueue.event.entity
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+class EventTest {
+
+    private val now = LocalDateTime.now()
+
+    private fun createVenue() = Venue(
+        id = UUID.randomUUID(), name = "올림픽공원",
+        address = "서울시 송파구", city = "서울",
+        createdAt = now, updatedAt = now
+    )
+
+    private fun createHall(venue: Venue) = Hall(
+        id = UUID.randomUUID(), venue = venue,
+        name = "KSPO DOME", capacity = 15000,
+        seatTemplate = """{"rows":["A"],"seatsPerRow":2,"gradeMapping":{"A":"VIP"}}""",
+        createdAt = now, updatedAt = now
+    )
+
+    private fun createEvent(venue: Venue, hall: Hall) = Event(
+        id = UUID.randomUUID(), title = "BTS World Tour", artist = "BTS",
+        venue = venue, hall = hall, createdAt = now, updatedAt = now
+    )
+
+    @Nested
+    @DisplayName("Event.update()")
+    inner class Update {
+
+        @Test
+        @DisplayName("null이 아닌 필드만 선택적으로 변경된다")
+        fun partialUpdate() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall).apply { update(null, null, "기존 설명") }
+
+            event.update(title = "새 제목", artist = null, description = null)
+
+            assertEquals("새 제목", event.title)
+            assertEquals("BTS", event.artist)         // 변경 없음
+            assertEquals("기존 설명", event.description) // 변경 없음
+        }
+
+        @Test
+        @DisplayName("description에 빈 문자열을 전달하면 null로 초기화된다")
+        fun descriptionClearedByEmptyString() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall).apply { update(null, null, "기존 설명") }
+
+            event.update(title = null, artist = null, description = "")
+
+            assertNull(event.description)
+        }
+
+        @Test
+        @DisplayName("description에 새 값을 전달하면 해당 값으로 변경된다")
+        fun descriptionUpdated() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            event.update(title = null, artist = null, description = "새로운 설명")
+
+            assertEquals("새로운 설명", event.description)
+        }
+
+        @Test
+        @DisplayName("모든 필드를 동시에 변경할 수 있다")
+        fun allFieldsUpdated() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            event.update(title = "수정 제목", artist = "수정 아티스트", description = "수정 설명")
+
+            assertEquals("수정 제목", event.title)
+            assertEquals("수정 아티스트", event.artist)
+            assertEquals("수정 설명", event.description)
+        }
+    }
+
+    @Nested
+    @DisplayName("Event.softDelete()")
+    inner class SoftDelete {
+
+        @Test
+        @DisplayName("softDelete 후 deletedAt이 현재 시각에 근사하게 채워진다")
+        fun setsDeletedAt() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            assertNull(event.deletedAt)
+
+            val before = LocalDateTime.now()
+            event.softDelete()
+            val after = LocalDateTime.now()
+
+            assertNotNull(event.deletedAt)
+            assertTrue(!event.deletedAt!!.isBefore(before) && !event.deletedAt!!.isAfter(after))
+        }
+
+        @Test
+        @DisplayName("softDelete를 두 번 호출해도 deletedAt이 덮어씌워진다")
+        fun canBeCalledTwice() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            event.softDelete()
+            val firstDeletedAt = event.deletedAt!!
+
+            event.softDelete()
+
+            // 두 번째 호출로 덮어씌워짐 (서비스 레이어에서 중복 호출 방지)
+            assertNotNull(event.deletedAt)
+            assertTrue(!event.deletedAt!!.isBefore(firstDeletedAt))
+        }
+    }
+
+    @Nested
+    @DisplayName("Event.changeStatus()")
+    inner class ChangeStatus {
+
+        @Test
+        @DisplayName("PREPARING → OPEN으로 상태 전이가 된다")
+        fun preparingToOpen() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            assertEquals(EventStatus.PREPARING, event.status)
+            event.changeStatus(EventStatus.OPEN)
+            assertEquals(EventStatus.OPEN, event.status)
+        }
+
+        @Test
+        @DisplayName("OPEN → ENDED로 상태 전이가 된다")
+        fun openToEnded() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall).apply { changeStatus(EventStatus.OPEN) }
+
+            event.changeStatus(EventStatus.ENDED)
+
+            assertEquals(EventStatus.ENDED, event.status)
+        }
+
+        @Test
+        @DisplayName("OPEN → CANCELLED로 상태 전이가 된다")
+        fun openToCancelled() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall).apply { changeStatus(EventStatus.OPEN) }
+
+            event.changeStatus(EventStatus.CANCELLED)
+
+            assertEquals(EventStatus.CANCELLED, event.status)
+        }
+    }
+
+    @Nested
+    @DisplayName("EventSchedule.hasSaleStarted()")
+    inner class HasSaleStarted {
+
+        private fun createEventSchedule(saleStartAt: LocalDateTime): EventSchedule {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            return EventSchedule(
+                id = UUID.randomUUID(), event = event, playSequence = 1,
+                eventStartAt = saleStartAt.plusDays(30),
+                eventEndAt = saleStartAt.plusDays(30).plusHours(2),
+                saleStartAt = saleStartAt,
+                saleEndAt = saleStartAt.plusDays(29),
+                createdAt = now, updatedAt = now
+            )
+        }
+
+        @Test
+        @DisplayName("saleStartAt이 현재보다 과거이면 true를 반환한다")
+        fun saleAlreadyStarted() {
+            val schedule = createEventSchedule(saleStartAt = now.minusHours(1))
+            assertTrue(schedule.hasSaleStarted())
+        }
+
+        @Test
+        @DisplayName("saleStartAt이 현재보다 미래이면 false를 반환한다")
+        fun saleNotStartedYet() {
+            val schedule = createEventSchedule(saleStartAt = now.plusHours(1))
+            assertFalse(schedule.hasSaleStarted())
+        }
+    }
+
+    @Nested
+    @DisplayName("Seat 생성")
+    inner class SeatCreation {
+
+        @Test
+        @DisplayName("초기 생성 시 status는 AVAILABLE이다")
+        fun defaultStatusIsAvailable() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = EventSchedule(
+                event = event, playSequence = 1,
+                eventStartAt = now.plusDays(30), eventEndAt = now.plusDays(30).plusHours(2),
+                saleStartAt = now.plusDays(1), saleEndAt = now.plusDays(29)
+            )
+            val seat = Seat(
+                eventSchedule = schedule,
+                seatNumber = "A-1",
+                grade = SeatGrade.VIP,
+                price = BigDecimal("150000")
+            )
+
+            assertEquals(SeatStatus.AVAILABLE, seat.status)
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/repository/EventRepositoryIntegrationTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/repository/EventRepositoryIntegrationTest.kt
@@ -16,9 +16,11 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import javax.sql.DataSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
@@ -82,6 +84,7 @@ class EventRepositoryIntegrationTest {
             JPAQueryFactory(SharedEntityManagerCreator.createSharedEntityManager(emf))
     }
 
+    @Autowired private lateinit var dataSource: DataSource
     @Autowired private lateinit var eventRepository: EventRepository
     @Autowired private lateinit var venueRepository: VenueRepository
     @Autowired private lateinit var hallRepository: HallRepository
@@ -89,6 +92,26 @@ class EventRepositoryIntegrationTest {
     @Autowired private lateinit var seatRepository: SeatRepository
 
     private val now: LocalDateTime = LocalDateTime.now()
+
+    /**
+     * 각 테스트 메서드 실행 전 모든 테이블을 정리한다.
+     *
+     * @Nested 클래스에서 Spring TestContext의 @Transactional 롤백이 올바르게 동작하지 않을 수 있으므로,
+     * JUnit 5의 @BeforeEach 상속 + raw JDBC 자동 커밋으로 데이터 격리를 보장한다.
+     * dataSource.connection은 Spring의 트랜잭션 관리 외부에서 별도 연결을 획득하므로 즉시 커밋된다.
+     */
+    @BeforeEach
+    fun cleanAll() {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("DELETE FROM event_service.seats")
+                stmt.execute("DELETE FROM event_service.event_schedules")
+                stmt.execute("DELETE FROM event_service.events")
+                stmt.execute("DELETE FROM event_service.halls")
+                stmt.execute("DELETE FROM event_service.venues")
+            }
+        }
+    }
 
     // ──────── 테스트 데이터 헬퍼 ────────
 
@@ -147,6 +170,7 @@ class EventRepositoryIntegrationTest {
 
     @Nested
     @DisplayName("findEventList")
+    @Transactional
     inner class FindEventList {
 
         @Test
@@ -246,6 +270,7 @@ class EventRepositoryIntegrationTest {
 
     @Nested
     @DisplayName("findEventWithVenueAndHall")
+    @Transactional
     inner class FindEventWithVenueAndHall {
 
         @Test
@@ -287,6 +312,7 @@ class EventRepositoryIntegrationTest {
 
     @Nested
     @DisplayName("findScheduleIdsWithAvailableSeats")
+    @Transactional
     inner class FindScheduleIdsWithAvailableSeats {
 
         @Test
@@ -335,6 +361,7 @@ class EventRepositoryIntegrationTest {
 
     @Nested
     @DisplayName("findByIdForUpdate")
+    @Transactional
     inner class FindByIdForUpdate {
 
         @Test
@@ -376,6 +403,7 @@ class EventRepositoryIntegrationTest {
 
     @Nested
     @DisplayName("existsByEventIdAndSaleStartAtBefore")
+    @Transactional
     inner class ExistsByEventIdAndSaleStartAtBefore {
 
         @Test

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/repository/EventRepositoryIntegrationTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/repository/EventRepositoryIntegrationTest.kt
@@ -1,0 +1,420 @@
+package com.ticketqueue.event.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.ticketqueue.event.entity.Event
+import jakarta.persistence.EntityManagerFactory
+import com.ticketqueue.event.entity.EventSchedule
+import com.ticketqueue.event.entity.EventStatus
+import com.ticketqueue.event.entity.Hall
+import com.ticketqueue.event.entity.Seat
+import com.ticketqueue.event.entity.SeatGrade
+import com.ticketqueue.event.entity.SeatStatus
+import com.ticketqueue.event.entity.Venue
+import jakarta.persistence.EntityManager
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageRequest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.orm.jpa.SharedEntityManagerCreator
+import org.springframework.test.context.TestPropertySource
+import org.springframework.transaction.annotation.Transactional
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Event Repository QueryDSL 통합 테스트
+ *
+ * - @DataJpaTest + @AutoConfigureTestDatabase(replace=NONE): H2 대신 실제 PostgreSQL 사용
+ * - @Testcontainers + @ServiceConnection: 컨테이너 ↔ Spring Datasource 자동 연결
+ * - withInitScript: 스키마 먼저 생성 → Hibernate create-drop으로 테이블 관리
+ * - 각 테스트는 독립 트랜잭션 + 자동 롤백으로 격리됨
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Import(EventRepositoryIntegrationTest.RepositoryTestConfig::class)
+@TestPropertySource(properties = ["spring.jpa.hibernate.ddl-auto=create-drop"])
+@Transactional // 각 테스트 메서드가 독립 트랜잭션 + 롤백으로 실행되어 데이터 격리 보장
+class EventRepositoryIntegrationTest {
+
+    companion object {
+        @Container
+        @ServiceConnection
+        val postgres = PostgreSQLContainer<Nothing>(DockerImageName.parse("postgres:18-alpine"))
+            .apply {
+                withDatabaseName("testdb")
+                withUsername("test")
+                withPassword("test")
+                withInitScript("db_init/init.sql") // CREATE SCHEMA event_service 선행 실행
+            }
+    }
+
+    /**
+     * @DataJpaTest는 JPAQueryFactory를 자동 등록하지 않으므로 수동 제공 필요.
+     *
+     * SharedEntityManagerCreator를 사용하는 이유:
+     * - 일반 EntityManager 직접 주입 시, JPAQueryFactory는 트랜잭션 외부의 EM을 사용하게 됨
+     * - 이 경우 @DataJpaTest의 @Transactional 롤백이 제대로 동작하지 않아 테스트 간 데이터가 누적됨
+     * - SharedEntityManagerCreator는 현재 스레드에 바인딩된 트랜잭션 EM을 사용하는 프록시를 생성
+     * - → QueryDSL 쿼리가 테스트의 @Transactional 컨텍스트 안에서 실행되어 데이터 격리 보장
+     */
+    @TestConfiguration
+    class RepositoryTestConfig {
+        @Bean
+        fun jpaQueryFactory(emf: EntityManagerFactory): JPAQueryFactory =
+            JPAQueryFactory(SharedEntityManagerCreator.createSharedEntityManager(emf))
+    }
+
+    @Autowired private lateinit var eventRepository: EventRepository
+    @Autowired private lateinit var venueRepository: VenueRepository
+    @Autowired private lateinit var hallRepository: HallRepository
+    @Autowired private lateinit var eventScheduleRepository: EventScheduleRepository
+    @Autowired private lateinit var seatRepository: SeatRepository
+
+    private val now: LocalDateTime = LocalDateTime.now()
+
+    // ──────── 테스트 데이터 헬퍼 ────────
+
+    private fun saveVenue(name: String = "올림픽공원", city: String = "서울"): Venue =
+        venueRepository.save(Venue(name = name, address = "서울시 송파구 올림픽로 25", city = city))
+
+    private fun saveHall(venue: Venue, name: String = "메인 홀"): Hall =
+        hallRepository.save(
+            Hall(
+                venue = venue, name = name, capacity = 15000,
+                seatTemplate = """{"rows":["A"],"seatsPerRow":2,"gradeMapping":{"A":"VIP"}}"""
+            )
+        )
+
+    private fun saveEvent(
+        venue: Venue,
+        hall: Hall,
+        title: String = "BTS World Tour",
+        artist: String = "BTS",
+        status: EventStatus = EventStatus.PREPARING,
+        deleted: Boolean = false
+    ): Event {
+        val event = eventRepository.save(Event(title = title, artist = artist, venue = venue, hall = hall))
+        if (status != EventStatus.PREPARING) event.changeStatus(status)
+        if (deleted) event.softDelete()
+        return if (status != EventStatus.PREPARING || deleted) eventRepository.save(event) else event
+    }
+
+    private fun saveSchedule(
+        event: Event,
+        playSequence: Int = 1,
+        eventStartAt: LocalDateTime = now.plusDays(30),
+        saleStartAt: LocalDateTime = now.plusDays(1)
+    ): EventSchedule = eventScheduleRepository.save(
+        EventSchedule(
+            event = event, playSequence = playSequence,
+            eventStartAt = eventStartAt,
+            eventEndAt = eventStartAt.plusHours(2),
+            saleStartAt = saleStartAt,
+            saleEndAt = saleStartAt.plusDays(28)
+        )
+    )
+
+    private fun saveSeat(
+        schedule: EventSchedule,
+        seatNumber: String = "A-1",
+        status: SeatStatus = SeatStatus.AVAILABLE
+    ): Seat = seatRepository.save(
+        Seat(
+            eventSchedule = schedule, seatNumber = seatNumber,
+            grade = SeatGrade.VIP, price = BigDecimal("150000"), status = status
+        )
+    )
+
+    // ──────── findEventList ────────
+
+    @Nested
+    @DisplayName("findEventList")
+    inner class FindEventList {
+
+        @Test
+        @DisplayName("삭제된 공연은 목록에 포함되지 않는다")
+        fun deletedEventExcluded() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            saveEvent(venue, hall, title = "삭제된 공연", deleted = true)
+            saveEvent(venue, hall, title = "활성 공연")
+
+            val result = eventRepository.findEventList(PageRequest.of(0, 20), null, null, null)
+
+            assertTrue(result.content.none { it.title == "삭제된 공연" })
+            assertTrue(result.content.any { it.title == "활성 공연" })
+        }
+
+        @Test
+        @DisplayName("status 필터가 동작한다")
+        fun statusFilter() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            saveEvent(venue, hall, title = "PREPARING 공연", status = EventStatus.PREPARING)
+            saveEvent(venue, hall, title = "OPEN 공연", status = EventStatus.OPEN)
+
+            val result = eventRepository.findEventList(PageRequest.of(0, 20), EventStatus.OPEN, null, null)
+
+            assertEquals(1, result.totalElements)
+            assertEquals(EventStatus.OPEN, result.content[0].status)
+        }
+
+        @Test
+        @DisplayName("city 필터가 동작한다")
+        fun cityFilter() {
+            val seoulVenue = saveVenue(name = "서울공연장", city = "서울")
+            val busanVenue = saveVenue(name = "부산공연장", city = "부산")
+            val hall1 = saveHall(seoulVenue)
+            val hall2 = saveHall(busanVenue)
+            saveEvent(seoulVenue, hall1, title = "서울 공연")
+            saveEvent(busanVenue, hall2, title = "부산 공연")
+
+            val result = eventRepository.findEventList(PageRequest.of(0, 20), null, "서울", null)
+
+            assertEquals(1, result.totalElements)
+            assertEquals("서울 공연", result.content[0].title)
+        }
+
+        @Test
+        @DisplayName("keyword 검색이 동작한다 (LIKE 기반, FTS 동작 방식 동일)")
+        fun keywordFtsSearch() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            saveEvent(venue, hall, title = "BTS World Tour", artist = "BTS")
+            saveEvent(venue, hall, title = "블랙핑크 콘서트", artist = "BLACKPINK")
+
+            val result = eventRepository.findEventList(PageRequest.of(0, 20), null, null, "BTS")
+
+            assertEquals(1, result.totalElements)
+            assertEquals("BTS World Tour", result.content[0].title)
+        }
+
+        @Test
+        @DisplayName("회차의 MIN/MAX startDate가 집계된다")
+        fun scheduleAggregation() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+            saveSchedule(event, 1, eventStartAt = now.plusDays(30))
+            saveSchedule(event, 2, eventStartAt = now.plusDays(60))
+
+            val result = eventRepository.findEventList(PageRequest.of(0, 20), null, null, null)
+
+            assertEquals(1, result.totalElements)
+            val item = result.content[0]
+            assertNotNull(item.startDate)
+            assertNotNull(item.endDate)
+            // MIN = plusDays(30), MAX = plusDays(60) → startDate < endDate
+            assertTrue(item.startDate!!.isBefore(item.endDate!!))
+        }
+
+        @Test
+        @DisplayName("페이지네이션이 동작한다")
+        fun pagination() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            repeat(5) { i -> saveEvent(venue, hall, title = "공연$i") }
+
+            val page0 = eventRepository.findEventList(PageRequest.of(0, 3), null, null, null)
+            val page1 = eventRepository.findEventList(PageRequest.of(1, 3), null, null, null)
+
+            assertEquals(5, page0.totalElements)
+            assertEquals(3, page0.content.size)
+            assertEquals(2, page1.content.size)
+        }
+    }
+
+    // ──────── findEventWithVenueAndHall ────────
+
+    @Nested
+    @DisplayName("findEventWithVenueAndHall")
+    inner class FindEventWithVenueAndHall {
+
+        @Test
+        @DisplayName("venue와 hall을 페치 조인으로 함께 조회한다")
+        fun fetchJoin() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+
+            val result = eventRepository.findEventWithVenueAndHall(event.id!!)
+
+            assertNotNull(result)
+            assertEquals(event.id, result!!.id)
+            assertEquals(venue.id, result.venue.id)
+            assertEquals(hall.id, result.hall.id)
+        }
+
+        @Test
+        @DisplayName("deletedAt이 설정된 공연은 null을 반환한다")
+        fun deletedReturnsNull() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall, deleted = true)
+
+            val result = eventRepository.findEventWithVenueAndHall(event.id!!)
+
+            assertNull(result)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID는 null을 반환한다")
+        fun notFoundReturnsNull() {
+            val result = eventRepository.findEventWithVenueAndHall(UUID.randomUUID())
+            assertNull(result)
+        }
+    }
+
+    // ──────── findScheduleIdsWithAvailableSeats ────────
+
+    @Nested
+    @DisplayName("findScheduleIdsWithAvailableSeats")
+    inner class FindScheduleIdsWithAvailableSeats {
+
+        @Test
+        @DisplayName("AVAILABLE 좌석이 있는 회차 ID만 반환된다")
+        fun onlyAvailableScheduleIds() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+            val schedule1 = saveSchedule(event, 1)
+            val schedule2 = saveSchedule(event, 2)
+            saveSeat(schedule1, "A-1", SeatStatus.AVAILABLE)
+            saveSeat(schedule2, "A-1", SeatStatus.SOLD) // schedule2는 SOLD 좌석만
+
+            val result = eventRepository.findScheduleIdsWithAvailableSeats(
+                listOf(schedule1.id!!, schedule2.id!!)
+            )
+
+            assertTrue(schedule1.id!! in result)
+            assertFalse(schedule2.id!! in result)
+        }
+
+        @Test
+        @DisplayName("모든 좌석이 SOLD이면 빈 Set을 반환한다")
+        fun allSoldReturnsEmpty() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+            val schedule = saveSchedule(event)
+            saveSeat(schedule, "A-1", SeatStatus.SOLD)
+            saveSeat(schedule, "A-2", SeatStatus.SOLD)
+
+            val result = eventRepository.findScheduleIdsWithAvailableSeats(listOf(schedule.id!!))
+
+            assertTrue(result.isEmpty())
+        }
+
+        @Test
+        @DisplayName("빈 scheduleIds 입력 시 빈 Set을 반환한다")
+        fun emptyInputReturnsEmpty() {
+            val result = eventRepository.findScheduleIdsWithAvailableSeats(emptyList())
+            assertTrue(result.isEmpty())
+        }
+    }
+
+    // ──────── findByIdForUpdate ────────
+
+    @Nested
+    @DisplayName("findByIdForUpdate")
+    inner class FindByIdForUpdate {
+
+        @Test
+        @DisplayName("비관적 락으로 공연 엔티티를 반환한다")
+        fun returnsEventWithLock() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+
+            val result = eventRepository.findByIdForUpdate(event.id!!)
+
+            assertNotNull(result)
+            assertEquals(event.id, result!!.id)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID는 null을 반환한다")
+        fun notFoundReturnsNull() {
+            val result = eventRepository.findByIdForUpdate(UUID.randomUUID())
+            assertNull(result)
+        }
+
+        @Test
+        @DisplayName("소프트 삭제된 공연도 잠금 조회 대상에 포함된다 (deleteEvent 내부 검증용)")
+        fun deletedEventIsStillReturned() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall, deleted = true)
+
+            // findByIdForUpdate는 deletedAt 필터 없이 단순 ID 조회 (서비스에서 직접 검증)
+            val result = eventRepository.findByIdForUpdate(event.id!!)
+
+            assertNotNull(result)
+            assertNotNull(result!!.deletedAt)
+        }
+    }
+
+    // ──────── existsByEventIdAndSaleStartAtBefore ────────
+
+    @Nested
+    @DisplayName("existsByEventIdAndSaleStartAtBefore")
+    inner class ExistsByEventIdAndSaleStartAtBefore {
+
+        @Test
+        @DisplayName("판매가 이미 시작된 회차가 있으면 true를 반환한다")
+        fun saleAlreadyStarted() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+            saveSchedule(event, saleStartAt = now.minusHours(1)) // 1시간 전 판매 시작
+
+            val result = eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(event.id!!, now)
+
+            assertTrue(result)
+        }
+
+        @Test
+        @DisplayName("모든 회차가 판매 시작 전이면 false를 반환한다")
+        fun saleNotYetStarted() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+            saveSchedule(event, saleStartAt = now.plusDays(1)) // 내일 판매 시작
+
+            val result = eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(event.id!!, now)
+
+            assertFalse(result)
+        }
+
+        @Test
+        @DisplayName("회차가 없는 공연은 false를 반환한다")
+        fun noSchedulesReturnsFalse() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+            // 회차 없음
+
+            val result = eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(event.id!!, now)
+
+            assertFalse(result)
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
@@ -589,7 +589,7 @@ class EventServiceTest {
             val hall = createHall(venue)
             val event = createEvent(venue, hall)
 
-            every { eventRepository.findById(eventId) } returns Optional.of(event)
+            every { eventRepository.findByIdForUpdate(eventId) } returns event
             every { seatRepository.existsByEventIdAndStatus(eventId, SeatStatus.SOLD) } returns false
 
             val result = eventService.deleteEvent(eventId)
@@ -605,7 +605,7 @@ class EventServiceTest {
             val hall = createHall(venue)
             val event = createEvent(venue, hall)
 
-            every { eventRepository.findById(eventId) } returns Optional.of(event)
+            every { eventRepository.findByIdForUpdate(eventId) } returns event
             every { seatRepository.existsByEventIdAndStatus(eventId, SeatStatus.SOLD) } returns true
 
             val exception = assertThrows<EventException> { eventService.deleteEvent(eventId) }
@@ -615,7 +615,7 @@ class EventServiceTest {
         @Test
         @DisplayName("존재하지 않는 공연 삭제 시 예외가 발생한다")
         fun notFound() {
-            every { eventRepository.findById(eventId) } returns Optional.empty()
+            every { eventRepository.findByIdForUpdate(eventId) } returns null
 
             val exception = assertThrows<EventException> { eventService.deleteEvent(eventId) }
             assertEquals(ErrorCode.EVENT_NOT_FOUND, exception.errorCode)
@@ -628,7 +628,7 @@ class EventServiceTest {
             val hall = createHall(venue)
             val deletedEvent = createEvent(venue, hall).apply { softDelete() }
 
-            every { eventRepository.findById(eventId) } returns Optional.of(deletedEvent)
+            every { eventRepository.findByIdForUpdate(eventId) } returns deletedEvent
 
             val exception = assertThrows<EventException> { eventService.deleteEvent(eventId) }
             assertEquals(ErrorCode.EVENT_ALREADY_DELETED, exception.errorCode)

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
@@ -1,0 +1,637 @@
+package com.ticketqueue.event.service
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.dto.EventDto
+import com.ticketqueue.event.dto.SeatTemplateDto
+import com.ticketqueue.event.entity.Event
+import com.ticketqueue.event.entity.EventSchedule
+import com.ticketqueue.event.entity.EventStatus
+import com.ticketqueue.event.entity.Hall
+import com.ticketqueue.event.entity.Seat
+import com.ticketqueue.event.entity.SeatGrade
+import com.ticketqueue.event.entity.SeatStatus
+import com.ticketqueue.event.entity.Venue
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.repository.EventRepository
+import com.ticketqueue.event.repository.EventScheduleRepository
+import com.ticketqueue.event.repository.HallRepository
+import com.ticketqueue.event.repository.SeatRepository
+import com.ticketqueue.event.repository.VenueRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.Optional
+import java.util.UUID
+
+class EventServiceTest {
+
+    private lateinit var eventRepository: EventRepository
+    private lateinit var eventScheduleRepository: EventScheduleRepository
+    private lateinit var seatRepository: SeatRepository
+    private lateinit var venueRepository: VenueRepository
+    private lateinit var hallRepository: HallRepository
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var eventService: EventService
+
+    private val venueId = UUID.randomUUID()
+    private val hallId = UUID.randomUUID()
+    private val eventId = UUID.randomUUID()
+    private val scheduleId = UUID.randomUUID()
+    private val now = LocalDateTime.now()
+
+    private fun createVenue() = Venue(
+        id = venueId,
+        name = "올림픽공원",
+        address = "서울시 송파구",
+        city = "서울",
+        createdAt = now,
+        updatedAt = now
+    )
+
+    private fun createHall(venue: Venue) = Hall(
+        id = hallId,
+        venue = venue,
+        name = "KSPO DOME",
+        capacity = 15000,
+        seatTemplate = """{"rows":["A"],"seatsPerRow":2,"gradeMapping":{"A":"VIP"}}""",
+        createdAt = now,
+        updatedAt = now
+    )
+
+    private fun createEvent(venue: Venue, hall: Hall) = Event(
+        id = eventId,
+        title = "BTS World Tour",
+        artist = "BTS",
+        venue = venue,
+        hall = hall,
+        createdAt = now,
+        updatedAt = now
+    )
+
+    private fun createSchedule(
+        event: Event,
+        saleStartAt: LocalDateTime = now.plusDays(1)
+    ) = EventSchedule(
+        id = scheduleId,
+        event = event,
+        playSequence = 1,
+        eventStartAt = now.plusDays(30),
+        eventEndAt = now.plusDays(30).plusHours(2),
+        saleStartAt = saleStartAt,
+        saleEndAt = now.plusDays(29),
+        createdAt = now,
+        updatedAt = now
+    )
+
+    @BeforeEach
+    fun setUp() {
+        eventRepository = mockk()
+        eventScheduleRepository = mockk()
+        seatRepository = mockk()
+        venueRepository = mockk()
+        hallRepository = mockk()
+        objectMapper = mockk()
+        eventService = EventService(
+            eventRepository, eventScheduleRepository, seatRepository,
+            venueRepository, hallRepository, objectMapper
+        )
+    }
+
+    @Nested
+    @DisplayName("createEvent")
+    inner class CreateEvent {
+
+        private val seatTemplate = SeatTemplateDto(
+            rows = listOf("A"),
+            seatsPerRow = 2,
+            gradeMapping = mapOf("A" to "VIP")
+        )
+        private val priceByGrade = mapOf(SeatGrade.VIP to BigDecimal("100000"))
+        private val scheduleRequest = EventDto.ScheduleRequest(
+            playSequence = 1,
+            eventStartAt = now.plusDays(30),
+            eventEndAt = now.plusDays(30).plusHours(2),
+            saleStartAt = now.plusDays(1),
+            saleEndAt = now.plusDays(29)
+        )
+
+        @Test
+        @DisplayName("성공적으로 공연과 회차, 좌석을 생성한다")
+        fun success() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+            val request = EventDto.CreateRequest(
+                title = "BTS World Tour",
+                artist = "BTS",
+                venueId = venueId,
+                hallId = hallId,
+                priceByGrade = priceByGrade,
+                schedules = listOf(scheduleRequest)
+            )
+
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.findById(hallId) } returns Optional.of(hall)
+            every { objectMapper.readValue(any<String>(), SeatTemplateDto::class.java) } returns seatTemplate
+            every { eventRepository.save(any()) } returns event
+            every { eventScheduleRepository.save(any()) } returns schedule
+            every { seatRepository.saveAll(any<List<Seat>>()) } returns emptyList()
+
+            val result = eventService.createEvent(request)
+
+            assertEquals(eventId, result.id)
+            assertEquals("BTS World Tour", result.title)
+            verify { seatRepository.saveAll(any<List<Seat>>()) }
+        }
+
+        @Test
+        @DisplayName("홀이 공연장에 속하지 않으면 예외가 발생한다")
+        fun hallNotInVenue() {
+            val venue = createVenue()
+            val differentVenue = Venue(
+                id = UUID.randomUUID(), name = "다른 공연장",
+                address = "부산시 해운대구", city = "부산", createdAt = now, updatedAt = now
+            )
+            val hall = createHall(differentVenue)
+            val request = EventDto.CreateRequest(
+                title = "BTS World Tour", artist = "BTS",
+                venueId = venueId, hallId = hallId,
+                priceByGrade = priceByGrade, schedules = listOf(scheduleRequest)
+            )
+
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.findById(hallId) } returns Optional.of(hall)
+
+            val exception = assertThrows<EventException> { eventService.createEvent(request) }
+            assertEquals(ErrorCode.HALL_NOT_IN_VENUE, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("회차 순번이 중복되면 예외가 발생한다")
+        fun duplicatePlaySequence() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val request = EventDto.CreateRequest(
+                title = "BTS World Tour", artist = "BTS",
+                venueId = venueId, hallId = hallId,
+                priceByGrade = priceByGrade,
+                schedules = listOf(
+                    scheduleRequest,
+                    scheduleRequest.copy(eventStartAt = now.plusDays(60)) // playSequence 중복
+                )
+            )
+
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.findById(hallId) } returns Optional.of(hall)
+
+            val exception = assertThrows<EventException> { eventService.createEvent(request) }
+            assertEquals(ErrorCode.DUPLICATE_PLAY_SEQUENCE, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("회차 종료 시각이 시작 시각보다 빠르면 예외가 발생한다")
+        fun invalidScheduleTime() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val invalidSchedule = scheduleRequest.copy(
+                eventStartAt = now.plusDays(30).plusHours(3),
+                eventEndAt = now.plusDays(30) // 종료가 시작보다 앞섬
+            )
+            val request = EventDto.CreateRequest(
+                title = "BTS World Tour", artist = "BTS",
+                venueId = venueId, hallId = hallId,
+                priceByGrade = priceByGrade, schedules = listOf(invalidSchedule)
+            )
+
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.findById(hallId) } returns Optional.of(hall)
+
+            val exception = assertThrows<EventException> { eventService.createEvent(request) }
+            assertEquals(ErrorCode.INVALID_SCHEDULE_TIME, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("공연장이 존재하지 않으면 VENUE_NOT_FOUND 예외가 발생한다")
+        fun venueNotFound() {
+            val request = EventDto.CreateRequest(
+                title = "BTS World Tour", artist = "BTS",
+                venueId = venueId, hallId = hallId,
+                priceByGrade = priceByGrade, schedules = listOf(scheduleRequest)
+            )
+            every { venueRepository.findById(venueId) } returns Optional.empty()
+
+            val exception = assertThrows<EventException> { eventService.createEvent(request) }
+            assertEquals(ErrorCode.VENUE_NOT_FOUND, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("홀이 존재하지 않으면 HALL_NOT_FOUND 예외가 발생한다")
+        fun hallNotFound() {
+            val venue = createVenue()
+            val request = EventDto.CreateRequest(
+                title = "BTS World Tour", artist = "BTS",
+                venueId = venueId, hallId = hallId,
+                priceByGrade = priceByGrade, schedules = listOf(scheduleRequest)
+            )
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.findById(hallId) } returns Optional.empty()
+
+            val exception = assertThrows<EventException> { eventService.createEvent(request) }
+            assertEquals(ErrorCode.HALL_NOT_FOUND, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("좌석 템플릿 JSON 파싱 실패 시 INVALID_SEAT_TEMPLATE 예외가 발생한다")
+        fun invalidSeatTemplate() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val request = EventDto.CreateRequest(
+                title = "BTS World Tour", artist = "BTS",
+                venueId = venueId, hallId = hallId,
+                priceByGrade = priceByGrade, schedules = listOf(scheduleRequest)
+            )
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.findById(hallId) } returns Optional.of(hall)
+            every { objectMapper.readValue(any<String>(), SeatTemplateDto::class.java) } throws
+                object : JsonProcessingException("invalid template") {}
+
+            val exception = assertThrows<EventException> { eventService.createEvent(request) }
+            assertEquals(ErrorCode.INVALID_SEAT_TEMPLATE, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("행-등급 매핑이 누락되면 INVALID_SEAT_TEMPLATE_MAPPING 예외가 발생한다")
+        fun invalidSeatTemplateMapping() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+            val templateWithMissingGrade = SeatTemplateDto(
+                rows = listOf("A", "B"),
+                seatsPerRow = 1,
+                gradeMapping = mapOf("A" to "VIP") // B 행 매핑 없음
+            )
+            val request = EventDto.CreateRequest(
+                title = "BTS World Tour", artist = "BTS",
+                venueId = venueId, hallId = hallId,
+                priceByGrade = priceByGrade, schedules = listOf(scheduleRequest)
+            )
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.findById(hallId) } returns Optional.of(hall)
+            every { objectMapper.readValue(any<String>(), SeatTemplateDto::class.java) } returns templateWithMissingGrade
+            every { eventRepository.save(any()) } returns event
+            every { eventScheduleRepository.save(any()) } returns schedule
+
+            val exception = assertThrows<EventException> { eventService.createEvent(request) }
+            assertEquals(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("등급별 가격이 누락되면 INVALID_INPUT 예외가 발생한다")
+        fun missingGradePrice() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+            val templateWithSGrade = SeatTemplateDto(
+                rows = listOf("A"),
+                seatsPerRow = 1,
+                gradeMapping = mapOf("A" to "S") // S 등급인데 가격 없음
+            )
+            val request = EventDto.CreateRequest(
+                title = "BTS World Tour", artist = "BTS",
+                venueId = venueId, hallId = hallId,
+                priceByGrade = mapOf(SeatGrade.VIP to BigDecimal("100000")), // S 가격 없음
+                schedules = listOf(scheduleRequest)
+            )
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.findById(hallId) } returns Optional.of(hall)
+            every { objectMapper.readValue(any<String>(), SeatTemplateDto::class.java) } returns templateWithSGrade
+            every { eventRepository.save(any()) } returns event
+            every { eventScheduleRepository.save(any()) } returns schedule
+
+            val exception = assertThrows<EventException> { eventService.createEvent(request) }
+            assertEquals(ErrorCode.INVALID_INPUT, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("판매 종료 시각이 판매 시작 시각보다 빠르면 INVALID_SCHEDULE_TIME 예외가 발생한다")
+        fun invalidSaleTime() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val invalidSchedule = scheduleRequest.copy(
+                saleStartAt = now.plusDays(29),
+                saleEndAt = now.plusDays(1) // saleEnd < saleStart
+            )
+            val request = EventDto.CreateRequest(
+                title = "BTS World Tour", artist = "BTS",
+                venueId = venueId, hallId = hallId,
+                priceByGrade = priceByGrade, schedules = listOf(invalidSchedule)
+            )
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.findById(hallId) } returns Optional.of(hall)
+
+            val exception = assertThrows<EventException> { eventService.createEvent(request) }
+            assertEquals(ErrorCode.INVALID_SCHEDULE_TIME, exception.errorCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("getEvents")
+    inner class GetEvents {
+
+        @Test
+        @DisplayName("공연 목록을 페이징으로 조회한다")
+        fun success() {
+            val listItem = EventDto.ListResponse(
+                id = eventId,
+                title = "BTS World Tour",
+                artist = "BTS",
+                venueName = "올림픽공원",
+                startDate = now.plusDays(30),
+                endDate = now.plusDays(31),
+                status = EventStatus.PREPARING
+            )
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(listOf(listItem), pageable, 1)
+            every { eventRepository.findEventList(any(), null, null, null) } returns page
+
+            val result = eventService.getEvents(0, 20, null, null, null)
+
+            assertEquals(1, result.totalElements)
+            assertEquals("BTS World Tour", result.content[0].title)
+        }
+
+        @Test
+        @DisplayName("status 필터 전달 시 findEventList에 status 파라미터가 전달된다")
+        fun withStatusFilter() {
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(emptyList<EventDto.ListResponse>(), pageable, 0)
+            every { eventRepository.findEventList(any(), EventStatus.OPEN, null, null) } returns page
+
+            val result = eventService.getEvents(0, 20, EventStatus.OPEN, null, null)
+
+            assertEquals(0, result.totalElements)
+            verify { eventRepository.findEventList(any(), EventStatus.OPEN, null, null) }
+        }
+
+        @Test
+        @DisplayName("음수 page는 0으로, 최대 초과 size는 100으로 보정된다")
+        fun pageSizeCoerce() {
+            val pageable = PageRequest.of(0, 100)
+            val page = PageImpl(emptyList<EventDto.ListResponse>(), pageable, 0)
+            every { eventRepository.findEventList(any(), null, null, null) } returns page
+
+            eventService.getEvents(-1, 200, null, null, null)
+
+            verify { eventRepository.findEventList(match { it.pageNumber == 0 && it.pageSize == 100 }, null, null, null) }
+        }
+    }
+
+    @Nested
+    @DisplayName("getEvent")
+    inner class GetEvent {
+
+        @Test
+        @DisplayName("공연 상세를 조회한다 (회차 날짜별 그룹핑)")
+        fun success() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+
+            every { eventRepository.findEventWithVenueAndHall(eventId) } returns event
+            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns listOf(schedule)
+            every { eventRepository.findScheduleIdsWithAvailableSeats(any()) } returns setOf(scheduleId)
+
+            val result = eventService.getEvent(eventId)
+
+            assertEquals(eventId, result.id)
+            assertEquals("BTS World Tour", result.title)
+            assertEquals(1, result.schedules.size)
+            assertEquals(1, result.schedules[0].times.size)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 공연 조회 시 예외가 발생한다")
+        fun notFound() {
+            every { eventRepository.findEventWithVenueAndHall(eventId) } returns null
+
+            val exception = assertThrows<EventException> { eventService.getEvent(eventId) }
+            assertEquals(ErrorCode.EVENT_NOT_FOUND, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("복수 날짜의 회차가 날짜별로 그룹핑된다")
+        fun multipleDateGroups() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val scheduleId2 = UUID.randomUUID()
+            val schedule1 = createSchedule(event)
+            val schedule2 = EventSchedule(
+                id = scheduleId2, event = event, playSequence = 2,
+                eventStartAt = now.plusDays(31), eventEndAt = now.plusDays(31).plusHours(2),
+                saleStartAt = now.plusDays(1), saleEndAt = now.plusDays(29),
+                createdAt = now, updatedAt = now
+            )
+
+            every { eventRepository.findEventWithVenueAndHall(eventId) } returns event
+            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns listOf(schedule1, schedule2)
+            every { eventRepository.findScheduleIdsWithAvailableSeats(any()) } returns setOf(scheduleId, scheduleId2)
+
+            val result = eventService.getEvent(eventId)
+
+            assertEquals(2, result.schedules.size)
+            assertEquals(1, result.schedules[0].times.size)
+            assertEquals(1, result.schedules[1].times.size)
+        }
+
+        @Test
+        @DisplayName("동일 날짜의 복수 회차는 시작 시각 오름차순으로 정렬된다")
+        fun sameDateMultipleTimesOrdered() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val scheduleId2 = UUID.randomUUID()
+            val scheduleEarly = createSchedule(event) // now.plusDays(30) 이른 시각
+            val scheduleLate = EventSchedule(
+                id = scheduleId2, event = event, playSequence = 2,
+                eventStartAt = now.plusDays(30).plusHours(3), // 같은 날, 늦은 시각
+                eventEndAt = now.plusDays(30).plusHours(5),
+                saleStartAt = now.plusDays(1), saleEndAt = now.plusDays(29),
+                createdAt = now, updatedAt = now
+            )
+
+            every { eventRepository.findEventWithVenueAndHall(eventId) } returns event
+            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns listOf(scheduleLate, scheduleEarly)
+            every { eventRepository.findScheduleIdsWithAvailableSeats(any()) } returns setOf(scheduleId, scheduleId2)
+
+            val result = eventService.getEvent(eventId)
+
+            assertEquals(1, result.schedules.size)
+            assertEquals(2, result.schedules[0].times.size)
+            assertTrue(
+                result.schedules[0].times[0].eventStartAt.isBefore(result.schedules[0].times[1].eventStartAt)
+            )
+        }
+
+        @Test
+        @DisplayName("AVAILABLE 좌석이 없는 회차는 isSoldOut이 true이다")
+        fun soldOut() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+
+            every { eventRepository.findEventWithVenueAndHall(eventId) } returns event
+            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns listOf(schedule)
+            every { eventRepository.findScheduleIdsWithAvailableSeats(any()) } returns emptySet()
+
+            val result = eventService.getEvent(eventId)
+
+            assertTrue(result.schedules[0].times[0].isSoldOut)
+        }
+    }
+
+    @Nested
+    @DisplayName("updateEvent")
+    inner class UpdateEvent {
+
+        @Test
+        @DisplayName("판매 전에는 모든 필드를 수정할 수 있다")
+        fun successBeforeSale() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event, saleStartAt = now.plusDays(1)) // 판매 시작 전
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns listOf(schedule)
+
+            val result = eventService.updateEvent(eventId, EventDto.UpdateRequest(title = "BTS 투어 2026", artist = "BTS 팀"))
+
+            assertEquals("BTS 투어 2026", result.title)
+            assertEquals("BTS 팀", result.artist)
+        }
+
+        @Test
+        @DisplayName("판매 시작 후 artist 수정 시 409 예외가 발생한다")
+        fun artistNotModifiableAfterSale() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event, saleStartAt = now.minusDays(1)) // 판매 이미 시작됨
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns listOf(schedule)
+
+            val exception = assertThrows<EventException> {
+                eventService.updateEvent(eventId, EventDto.UpdateRequest(artist = "변경된 아티스트"))
+            }
+            assertEquals(ErrorCode.EVENT_NOT_MODIFIABLE, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("판매 시작 후에도 title과 description은 수정 가능하다")
+        fun titleModifiableAfterSale() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event, saleStartAt = now.minusDays(1))
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns listOf(schedule)
+
+            val result = eventService.updateEvent(
+                eventId,
+                EventDto.UpdateRequest(title = "BTS 투어 업데이트", description = "공연 설명 변경")
+            )
+
+            assertEquals("BTS 투어 업데이트", result.title)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 공연 수정 시 예외가 발생한다")
+        fun notFound() {
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns null
+
+            val exception = assertThrows<EventException> {
+                eventService.updateEvent(eventId, EventDto.UpdateRequest(title = "새 제목"))
+            }
+            assertEquals(ErrorCode.EVENT_NOT_FOUND, exception.errorCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteEvent")
+    inner class DeleteEvent {
+
+        @Test
+        @DisplayName("성공적으로 공연을 Soft Delete한다")
+        fun success() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            every { eventRepository.findById(eventId) } returns Optional.of(event)
+            every { seatRepository.existsByEventIdAndStatus(eventId, SeatStatus.SOLD) } returns false
+
+            val result = eventService.deleteEvent(eventId)
+
+            assertNotNull(result.message)
+            assertNotNull(event.deletedAt) // soft delete로 deletedAt이 채워졌는지 확인
+        }
+
+        @Test
+        @DisplayName("판매된 좌석이 있으면 삭제할 수 없다")
+        fun hasSoldSeats() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            every { eventRepository.findById(eventId) } returns Optional.of(event)
+            every { seatRepository.existsByEventIdAndStatus(eventId, SeatStatus.SOLD) } returns true
+
+            val exception = assertThrows<EventException> { eventService.deleteEvent(eventId) }
+            assertEquals(ErrorCode.EVENT_HAS_RESERVATIONS, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 공연 삭제 시 예외가 발생한다")
+        fun notFound() {
+            every { eventRepository.findById(eventId) } returns Optional.empty()
+
+            val exception = assertThrows<EventException> { eventService.deleteEvent(eventId) }
+            assertEquals(ErrorCode.EVENT_NOT_FOUND, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 공연은 EVENT_ALREADY_DELETED 예외가 발생한다")
+        fun alreadyDeleted() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val deletedEvent = createEvent(venue, hall).apply { softDelete() }
+
+            every { eventRepository.findById(eventId) } returns Optional.of(deletedEvent)
+
+            val exception = assertThrows<EventException> { eventService.deleteEvent(eventId) }
+            assertEquals(ErrorCode.EVENT_ALREADY_DELETED, exception.errorCode)
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
@@ -21,9 +21,11 @@ import com.ticketqueue.event.repository.SeatRepository
 import com.ticketqueue.event.repository.VenueRepository
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -349,6 +351,121 @@ class EventServiceTest {
             val exception = assertThrows<EventException> { eventService.createEvent(request) }
             assertEquals(ErrorCode.INVALID_SCHEDULE_TIME, exception.errorCode)
         }
+
+        @Test
+        @DisplayName("판매 종료 시각이 공연 시작 시각 이후이면 INVALID_SCHEDULE_TIME 예외가 발생한다")
+        fun saleEndAfterEventStart() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val invalidSchedule = scheduleRequest.copy(
+                saleEndAt = now.plusDays(31) // eventStartAt(+30일) 이후라 판매 마감 불가
+            )
+            val request = EventDto.CreateRequest(
+                title = "BTS World Tour", artist = "BTS",
+                venueId = venueId, hallId = hallId,
+                priceByGrade = priceByGrade, schedules = listOf(invalidSchedule)
+            )
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.findById(hallId) } returns Optional.of(hall)
+
+            val exception = assertThrows<EventException> { eventService.createEvent(request) }
+            assertEquals(ErrorCode.INVALID_SCHEDULE_TIME, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("공연 시작 시각이 현재보다 과거이면 INVALID_SCHEDULE_TIME 예외가 발생한다")
+        fun eventStartInPast() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val invalidSchedule = scheduleRequest.copy(
+                eventStartAt = now.minusDays(1),
+                eventEndAt = now.minusDays(1).plusHours(2),
+                saleStartAt = now.minusDays(30),
+                saleEndAt = now.minusDays(2) // saleEndAt < eventStartAt 조건 충족
+            )
+            val request = EventDto.CreateRequest(
+                title = "BTS World Tour", artist = "BTS",
+                venueId = venueId, hallId = hallId,
+                priceByGrade = priceByGrade, schedules = listOf(invalidSchedule)
+            )
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.findById(hallId) } returns Optional.of(hall)
+
+            val exception = assertThrows<EventException> { eventService.createEvent(request) }
+            assertEquals(ErrorCode.INVALID_SCHEDULE_TIME, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("다중 회차 생성 시 회차 수만큼 스케줄과 좌석이 저장된다")
+        fun multipleSchedules() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule1 = createSchedule(event)
+            val schedule2 = EventSchedule(
+                id = UUID.randomUUID(), event = event, playSequence = 2,
+                eventStartAt = now.plusDays(60), eventEndAt = now.plusDays(60).plusHours(2),
+                saleStartAt = now.plusDays(1), saleEndAt = now.plusDays(59),
+                createdAt = now, updatedAt = now
+            )
+            val request = EventDto.CreateRequest(
+                title = "BTS World Tour", artist = "BTS",
+                venueId = venueId, hallId = hallId,
+                priceByGrade = priceByGrade,
+                schedules = listOf(
+                    scheduleRequest,
+                    scheduleRequest.copy(
+                        playSequence = 2,
+                        eventStartAt = now.plusDays(60),
+                        eventEndAt = now.plusDays(60).plusHours(2),
+                        saleStartAt = now.plusDays(1),
+                        saleEndAt = now.plusDays(59)
+                    )
+                )
+            )
+
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.findById(hallId) } returns Optional.of(hall)
+            every { objectMapper.readValue(any<String>(), SeatTemplateDto::class.java) } returns seatTemplate
+            every { eventRepository.save(any()) } returns event
+            every { eventScheduleRepository.save(any()) } returnsMany listOf(schedule1, schedule2)
+            every { seatRepository.saveAll(any<List<Seat>>()) } returns emptyList()
+
+            eventService.createEvent(request)
+
+            verify(exactly = 2) { eventScheduleRepository.save(any()) }
+            verify(exactly = 2) { seatRepository.saveAll(any<List<Seat>>()) }
+        }
+
+        @Test
+        @DisplayName("생성된 좌석의 번호는 '행-순번' 형식이고 좌석 수는 템플릿과 일치한다")
+        fun seatCountAndNumberFormat() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+            val request = EventDto.CreateRequest(
+                title = "BTS World Tour", artist = "BTS",
+                venueId = venueId, hallId = hallId,
+                priceByGrade = priceByGrade, schedules = listOf(scheduleRequest)
+            )
+
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.findById(hallId) } returns Optional.of(hall)
+            every { objectMapper.readValue(any<String>(), SeatTemplateDto::class.java) } returns seatTemplate
+            every { eventRepository.save(any()) } returns event
+            every { eventScheduleRepository.save(any()) } returns schedule
+            val seatsSlot = slot<List<Seat>>()
+            every { seatRepository.saveAll(capture(seatsSlot)) } returns emptyList()
+
+            eventService.createEvent(request)
+
+            val savedSeats = seatsSlot.captured
+            assertEquals(2, savedSeats.size) // rows=["A"], seatsPerRow=2 → 2개
+            assertEquals("A-1", savedSeats[0].seatNumber)
+            assertEquals("A-2", savedSeats[1].seatNumber)
+            assertTrue(savedSeats.all { it.grade == SeatGrade.VIP })
+        }
     }
 
     @Nested
@@ -507,6 +624,22 @@ class EventServiceTest {
 
             assertTrue(result.schedules[0].times[0].isSoldOut)
         }
+
+        @Test
+        @DisplayName("회차가 없는 공연 상세 조회 시 빈 schedules 목록을 반환한다")
+        fun noSchedules() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            every { eventRepository.findEventWithVenueAndHall(eventId) } returns event
+            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns emptyList()
+            every { eventRepository.findScheduleIdsWithAvailableSeats(emptyList()) } returns emptySet()
+
+            val result = eventService.getEvent(eventId)
+
+            assertTrue(result.schedules.isEmpty())
+        }
     }
 
     @Nested
@@ -519,10 +652,9 @@ class EventServiceTest {
             val venue = createVenue()
             val hall = createHall(venue)
             val event = createEvent(venue, hall)
-            val schedule = createSchedule(event, saleStartAt = now.plusDays(1)) // 판매 시작 전
 
             every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
-            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns listOf(schedule)
+            every { eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(eventId, any()) } returns false
 
             val result = eventService.updateEvent(eventId, EventDto.UpdateRequest(title = "BTS 투어 2026", artist = "BTS 팀"))
 
@@ -536,10 +668,9 @@ class EventServiceTest {
             val venue = createVenue()
             val hall = createHall(venue)
             val event = createEvent(venue, hall)
-            val schedule = createSchedule(event, saleStartAt = now.minusDays(1)) // 판매 이미 시작됨
 
             every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
-            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns listOf(schedule)
+            every { eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(eventId, any()) } returns true
 
             val exception = assertThrows<EventException> {
                 eventService.updateEvent(eventId, EventDto.UpdateRequest(artist = "변경된 아티스트"))
@@ -553,10 +684,9 @@ class EventServiceTest {
             val venue = createVenue()
             val hall = createHall(venue)
             val event = createEvent(venue, hall)
-            val schedule = createSchedule(event, saleStartAt = now.minusDays(1))
 
             every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
-            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns listOf(schedule)
+            every { eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(eventId, any()) } returns true
 
             val result = eventService.updateEvent(
                 eventId,
@@ -575,6 +705,38 @@ class EventServiceTest {
                 eventService.updateEvent(eventId, EventDto.UpdateRequest(title = "새 제목"))
             }
             assertEquals(ErrorCode.EVENT_NOT_FOUND, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("description만 수정해도 다른 필드는 변경되지 않는다")
+        fun descriptionOnly() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(eventId, any()) } returns false
+
+            val result = eventService.updateEvent(eventId, EventDto.UpdateRequest(description = "새 설명"))
+
+            assertEquals("새 설명", result.description)
+            assertEquals("BTS World Tour", result.title) // 변경 없음
+            assertEquals("BTS", result.artist)           // 변경 없음
+        }
+
+        @Test
+        @DisplayName("description에 빈 문자열 전달 시 null로 초기화된다")
+        fun descriptionClearedWithEmptyString() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall).apply { update(null, null, "기존 설명") }
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(eventId, any()) } returns false
+
+            val result = eventService.updateEvent(eventId, EventDto.UpdateRequest(description = ""))
+
+            assertNull(result.description)
         }
     }
 
@@ -632,6 +794,24 @@ class EventServiceTest {
 
             val exception = assertThrows<EventException> { eventService.deleteEvent(eventId) }
             assertEquals(ErrorCode.EVENT_ALREADY_DELETED, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("Soft Delete 후 deletedAt 타임스탬프가 호출 시각에 근사하다")
+        fun softDeleteTimestamp() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            every { eventRepository.findByIdForUpdate(eventId) } returns event
+            every { seatRepository.existsByEventIdAndStatus(eventId, SeatStatus.SOLD) } returns false
+
+            val before = LocalDateTime.now()
+            eventService.deleteEvent(eventId)
+            val after = LocalDateTime.now()
+
+            val deletedAt = event.deletedAt!!
+            assertTrue(!deletedAt.isBefore(before) && !deletedAt.isAfter(after))
         }
     }
 }

--- a/backend/event-service/src/test/resources/db_init/init.sql
+++ b/backend/event-service/src/test/resources/db_init/init.sql
@@ -1,0 +1,3 @@
+-- Event Service 통합 테스트용 스키마 생성
+-- Hibernate ddl-auto=create-drop이 테이블을 생성하기 전에 스키마가 존재해야 함
+CREATE SCHEMA IF NOT EXISTS event_service;

--- a/docker/db_init/3_event_service_ddl.sql
+++ b/docker/db_init/3_event_service_ddl.sql
@@ -70,6 +70,7 @@ CREATE TABLE event_service.events (
     venue_id UUID NOT NULL REFERENCES event_service.venues(id) ON DELETE RESTRICT,
     hall_id UUID NOT NULL REFERENCES event_service.halls(id) ON DELETE RESTRICT,
     status VARCHAR(20) NOT NULL DEFAULT 'PREPARING',
+    deleted_at TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT now(),
     updated_at TIMESTAMP NOT NULL DEFAULT now(),
 
@@ -78,6 +79,7 @@ CREATE TABLE event_service.events (
 
 -- 인덱스
 CREATE INDEX idx_events_status ON event_service.events(status);
+CREATE INDEX idx_events_not_deleted ON event_service.events(id) WHERE deleted_at IS NULL;
 CREATE INDEX idx_events_artist ON event_service.events(artist);
 CREATE INDEX idx_events_venue ON event_service.events(venue_id);
 

--- a/docs/specification/02_event_service.md
+++ b/docs/specification/02_event_service.md
@@ -17,6 +17,11 @@ Event Service는 공연, 공연장, 좌석 정보를 관리하며 조회 성능�
   "description": "최고의 공연입니다.",
   "venueId": "venue_uuid",
   "hallId": "hall_uuid",
+  "priceByGrade": {
+    "VIP": 150000,
+    "S": 120000,
+    "A": 99000
+  },
   "schedules": [
     {
       "playSequence": 1,
@@ -35,7 +40,7 @@ Event Service는 공연, 공연장, 좌석 정보를 관리하며 조회 성능�
   "id": "event_uuid",
   "title": "2026 월드 투어 서울",
   "artist": "인기 가수",
-  "status": "DRAFT",
+  "status": "PREPARING",
   "createdAt": "2026-01-20T10:00:00"
 }
 ```
@@ -46,8 +51,9 @@ Event Service는 공연, 공연장, 좌석 정보를 관리하며 조회 성능�
 - **Query Parameters:**
   - `page` (int, default: 0): 페이지 번호
   - `size` (int, default: 20): 페이지 크기
-  - `status` (string, optional): 공연 상태 필터 (OPEN, CLOSED, UPCOMING)
+  - `status` (string, optional): 공연 상태 필터 (PREPARING, OPEN, ENDED, CANCELLED)
   - `city` (string, optional): 도시 필터
+  - `keyword` (string, optional): 제목/아티스트 키워드 검색 (PostgreSQL FTS)
 
 **Response (200 OK)**
 ```json
@@ -163,8 +169,11 @@ Event Service는 공연, 공연장, 좌석 정보를 관리하며 조회 성능�
 ```
 
 ### 1.5 공연 수정 (관리자)
-- **URL:** `PUT /events/{id}`
+- **URL:** `PATCH /events/{id}`
 - **Headers:** `Authorization: Bearer {adminToken}`
+
+> **구현 노트**: null 필드는 변경하지 않는다 (PATCH 시맨틱). description을 `null`로 초기화하려면 빈 문자열(`""`)을 전달한다.
+> 판매 시작 후에는 `artist` 수정이 불가하며, 시도 시 409 Conflict를 반환한다.
 
 **Request Body**
 ```json
@@ -179,7 +188,9 @@ Event Service는 공연, 공연장, 좌석 정보를 관리하며 조회 성능�
 {
   "id": "event_uuid",
   "title": "수정된 공연 제목",
+  "artist": "인기 가수",
   "description": "수정된 설명",
+  "status": "OPEN",
   "updatedAt": "2026-01-20T11:00:00"
 }
 ```

--- a/docs/specification/02_event_service.md
+++ b/docs/specification/02_event_service.md
@@ -73,53 +73,66 @@ Event Service는 공연, 공연장, 좌석 정보를 관리하며 조회 성능�
 - **URL:** `GET /events/{id}`
 - **Auth:** None
 
+> **구현 노트**: venue/hall은 평탄화 구조(`venueId`, `venueName`, `hallId`, `hallName`)로 반환한다.
+> `isSoldOut`은 회차(times) 레벨에 위치한다 (날짜 레벨보다 정확도 높음).
+> description을 `null`로 초기화하려면 빈 문자열(`""`)을 전달한다.
+
 **Response (200 OK)**
 ```json
 {
   "id": "event_uuid",
   "title": "2026 월드 투어 서울",
   "artist": "인기 가수",
-  "description": "...",
-  "venue": { "id": "venue_uuid", "name": "잠실 주경기장" },
-  "halls": { "id": "hall_uuid", "name": "메인 홀" },
+  "description": "최고의 공연입니다.",
+  "venueId": "venue_uuid",
+  "venueName": "잠실 주경기장",
+  "hallId": "hall_uuid",
+  "hallName": "메인 홀",
+  "status": "OPEN",
   "schedules": [
     {
       "date": "2026-06-01",
-      "isSoldOut": false,
       "times": [
         {
           "id": "schedule_uuid",
-          "sequence": 1,
-          "time": "19:00:00",
+          "playSequence": 1,
+          "eventStartAt": "2026-06-01T19:00:00",
+          "eventEndAt": "2026-06-01T22:00:00",
           "saleStartAt": "2026-05-01T20:00:00",
           "saleEndAt": "2026-05-31T23:59:59",
-          "status": "UPCOMING"
+          "status": "UPCOMING",
+          "isSoldOut": false
         },
         {
           "id": "schedule_uuid",
-          "sequence": 2,
-          "time": "21:00:00",
+          "playSequence": 2,
+          "eventStartAt": "2026-06-01T21:00:00",
+          "eventEndAt": "2026-06-01T23:00:00",
           "saleStartAt": "2026-05-01T20:00:00",
           "saleEndAt": "2026-05-31T23:59:59",
-          "status": "UPCOMING"
+          "status": "UPCOMING",
+          "isSoldOut": true
         }
       ]
     },
     {
       "date": "2026-06-02",
-      "isSoldOut": false,
       "times": [
         {
           "id": "schedule_uuid",
-          "sequence": 3,
-          "time": "17:00:00",
+          "playSequence": 3,
+          "eventStartAt": "2026-06-02T17:00:00",
+          "eventEndAt": "2026-06-02T20:00:00",
           "saleStartAt": "2026-05-02T20:00:00",
           "saleEndAt": "2026-06-01T23:59:59",
-          "status": "UPCOMING"
+          "status": "UPCOMING",
+          "isSoldOut": false
         }
       ]
     }
-  ]
+  ],
+  "createdAt": "2026-01-20T10:00:00",
+  "updatedAt": "2026-01-20T10:00:00"
 }
 ```
 


### PR DESCRIPTION
## Summary
- Event Service의 공연 CRUD API 전체 구현 (POST/GET/PATCH/DELETE)
- PR #152 CodeRabbit 리뷰 대응: EXISTS 최적화, deleteEvent 비관적 락 적용
- Validation 강화, 테스트 커버리지 확장, API 스펙 현행화

## Changes
- `EventController`: 공연 CRUD 엔드포인트 5개 구현 (REQ-EVT-001 ~ REQ-EVT-007)
- `EventDto`: CreateRequest/UpdateRequest validation 강화 (@DecimalMin, @Size)
- `Event`: description 빈 문자열 → null 초기화 (PATCH 시맨틱)
- `EventService`: 스케줄 시간 검증 강화, updateEvent EXISTS 쿼리 최적화 (N→1)
- `EventScheduleRepository`: existsByEventIdAndSaleStartAtBefore 추가
- `SeatRepository`: QueryDSL EXISTS 시맨틱으로 교체 (조기 종료)
- `EventRepository`: findByIdForUpdate (비관적 락) 추가
- `EventServiceTest`: 12건+ 신규 테스트 (validation, edge case, 동시성)
- `EventTest`: Entity 단위 테스트 추가
- `EventRepositoryIntegrationTest`: TestContainers 통합 테스트 추가
- `02_event_service.md`: API 스펙 현행화 (priceByGrade, PATCH 노트, status enum)

## Test plan
- [x] `./gradlew :event-service:test` 전체 통과
- [x] `./gradlew :event-service:build` 컴파일 성공

Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full event management API: create (priceByGrade), list (paging/filters + keyword/status/city), detail, update (PATCH), and soft-delete; per-schedule isSoldOut flags and automatic seat initialization with grade pricing. Admin-only for write endpoints; public read access for listings.

* **Documentation**
  * API schema updated: flattened venue/hall fields, schedule field renames, added createdAt/updatedAt, example payloads updated, PATCH semantics clarified.

* **Tests**
  * Extensive unit and integration tests for controllers, service, repositories, and entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->