### PR TITLE
fix: [Event] 상태 전이 검증, softDelete 멱등성, 쿼리 정확도 보강 #33

### DIFF
--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Event.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Event.kt
@@ -68,10 +68,16 @@ class Event(
     }
 
     fun changeStatus(newStatus: EventStatus) {
+        if (!this.status.canTransitionTo(newStatus)) {
+            throw com.ticketqueue.event.exception.EventException(
+                com.ticketqueue.common.exception.ErrorCode.INVALID_EVENT_STATUS
+            )
+        }
         this.status = newStatus
     }
 
     fun softDelete() {
+        if (this.deletedAt != null) return
         this.deletedAt = LocalDateTime.now()
     }
 

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/enums.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/enums.kt
@@ -1,6 +1,21 @@
 package com.ticketqueue.event.entity
 
-enum class EventStatus { PREPARING, OPEN, ENDED, CANCELLED }
+enum class EventStatus {
+    PREPARING, OPEN, ENDED, CANCELLED;
+
+    private companion object {
+        val allowedTransitions = mapOf(
+            PREPARING to setOf(OPEN, CANCELLED),
+            OPEN to setOf(ENDED, CANCELLED),
+            ENDED to emptySet<EventStatus>(),
+            CANCELLED to emptySet<EventStatus>()
+        )
+    }
+
+    fun canTransitionTo(target: EventStatus): Boolean =
+        allowedTransitions[this]?.contains(target) ?: false
+}
+
 enum class ScheduleStatus { UPCOMING, ONGOING, ENDED, CANCELLED }
 enum class SeatGrade { VIP, S, A, B }
 enum class SeatStatus { AVAILABLE, SOLD }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustomImpl.kt
@@ -56,7 +56,7 @@ class EventRepositoryCustomImpl(
             .leftJoin(schedule).on(schedule.event.eq(event))
             .where(predicate)
             .groupBy(event.id, event.title, event.artist, event.status, venue.name)
-            .orderBy(minStartAt.asc().nullsLast())
+            .orderBy(minStartAt.asc().nullsLast(), event.id.asc())
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .fetch()
@@ -117,7 +117,10 @@ class EventRepositoryCustomImpl(
         val event = QEvent.event
         return queryFactory
             .selectFrom(event)
-            .where(event.id.eq(eventId))
+            .where(
+                event.id.eq(eventId),
+                event.deletedAt.isNull
+            )
             .setLockMode(LockModeType.PESSIMISTIC_WRITE)
             .fetchOne()
     }
@@ -132,13 +135,13 @@ class EventRepositoryCustomImpl(
         val builder = BooleanBuilder()
         builder.and(event.deletedAt.isNull)
         status?.let { builder.and(event.status.eq(it)) }
-        city?.let { builder.and(venue.city.equalsIgnoreCase(it)) }
+        city?.takeIf { it.isNotBlank() }?.let { builder.and(venue.city.equalsIgnoreCase(it)) }
         // NOTE: QueryDSL-JPA의 booleanTemplate은 JPQL(HQL)을 생성하므로,
         //       PostgreSQL 전용 @@ 연산자를 사용할 수 없음 (HQL 파서가 거부).
         //       진짜 GIN 인덱스 활용 FTS는 EntityManager.createNativeQuery() 또는
         //       JPASQLQuery(SQLTemplates) 방식으로 별도 구현 필요.
         //       현재는 대소문자 무관 LIKE 검색으로 동작하며 정확성 보장.
-        keyword?.let {
+        keyword?.takeIf { it.isNotBlank() }?.let {
             builder.and(
                 event.title.containsIgnoreCase(it)
                     .or(event.artist.containsIgnoreCase(it))

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepository.kt
@@ -14,5 +14,5 @@ interface EventScheduleRepository : JpaRepository<EventSchedule, UUID> {
      * 주어진 공연의 회차 중 판매가 이미 시작된 회차가 존재하는지 확인한다.
      * updateEvent의 hasSaleStarted 체크를 위해 전체 목록 로드 대신 EXISTS 쿼리 1개로 처리한다.
      */
-    fun existsByEventIdAndSaleStartAtBefore(eventId: UUID, dateTime: LocalDateTime): Boolean
+    fun existsByEventIdAndSaleStartAtLessThanEqual(eventId: UUID, dateTime: LocalDateTime): Boolean
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
@@ -213,7 +213,7 @@ class EventService(
     fun updateEvent(eventId: UUID, request: EventDto.UpdateRequest): EventDto.UpdateResponse {
         val event = findActiveEvent(eventId)
         // 전체 스케줄 로드 대신 EXISTS 쿼리 1개로 판매 시작 여부 확인 (N → 1 쿼리)
-        val hasSaleStarted = eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(eventId, LocalDateTime.now())
+        val hasSaleStarted = eventScheduleRepository.existsByEventIdAndSaleStartAtLessThanEqual(eventId, LocalDateTime.now())
 
         if (hasSaleStarted && request.artist != null) {
             throw EventException(ErrorCode.EVENT_NOT_MODIFIABLE)

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/entity/EventTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/entity/EventTest.kt
@@ -1,9 +1,11 @@
 package com.ticketqueue.event.entity
 
+import com.ticketqueue.event.exception.EventException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -113,7 +115,7 @@ class EventTest {
         }
 
         @Test
-        @DisplayName("softDelete를 두 번 호출해도 deletedAt이 덮어씌워진다")
+        @DisplayName("softDelete를 두 번 호출해도 원본 삭제 시각이 보존된다")
         fun canBeCalledTwice() {
             val venue = createVenue()
             val hall = createHall(venue)
@@ -124,9 +126,8 @@ class EventTest {
 
             event.softDelete()
 
-            // 두 번째 호출로 덮어씌워짐 (서비스 레이어에서 중복 호출 방지)
-            assertNotNull(event.deletedAt)
-            assertTrue(!event.deletedAt!!.isBefore(firstDeletedAt))
+            // 두 번째 호출은 무시되어 원본 삭제 시각이 보존됨
+            assertEquals(firstDeletedAt, event.deletedAt)
         }
     }
 
@@ -168,6 +169,39 @@ class EventTest {
             event.changeStatus(EventStatus.CANCELLED)
 
             assertEquals(EventStatus.CANCELLED, event.status)
+        }
+
+        @Test
+        @DisplayName("ENDED → OPEN 전이 시 INVALID_EVENT_STATUS 예외가 발생한다")
+        fun endedToOpenThrows() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall).apply {
+                changeStatus(EventStatus.OPEN)
+                changeStatus(EventStatus.ENDED)
+            }
+
+            assertThrows(EventException::class.java) { event.changeStatus(EventStatus.OPEN) }
+        }
+
+        @Test
+        @DisplayName("CANCELLED → OPEN 전이 시 예외가 발생한다")
+        fun cancelledToOpenThrows() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall).apply { changeStatus(EventStatus.CANCELLED) }
+
+            assertThrows(EventException::class.java) { event.changeStatus(EventStatus.OPEN) }
+        }
+
+        @Test
+        @DisplayName("PREPARING → ENDED 전이 시 예외가 발생한다 (OPEN 건너뛰기 불가)")
+        fun preparingToEndedThrows() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            assertThrows(EventException::class.java) { event.changeStatus(EventStatus.ENDED) }
         }
     }
 

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/repository/EventRepositoryIntegrationTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/repository/EventRepositoryIntegrationTest.kt
@@ -385,24 +385,23 @@ class EventRepositoryIntegrationTest {
         }
 
         @Test
-        @DisplayName("소프트 삭제된 공연도 잠금 조회 대상에 포함된다 (deleteEvent 내부 검증용)")
-        fun deletedEventIsStillReturned() {
+        @DisplayName("소프트 삭제된 공연은 findByIdForUpdate에서 null을 반환한다")
+        fun deletedEventIsNotReturned() {
             val venue = saveVenue()
             val hall = saveHall(venue)
             val event = saveEvent(venue, hall, deleted = true)
 
-            // findByIdForUpdate는 deletedAt 필터 없이 단순 ID 조회 (서비스에서 직접 검증)
+            // findByIdForUpdate는 deletedAt IS NULL 필터를 포함하므로 soft-deleted 이벤트는 null 반환
             val result = eventRepository.findByIdForUpdate(event.id!!)
 
-            assertNotNull(result)
-            assertNotNull(result!!.deletedAt)
+            assertNull(result)
         }
     }
 
-    // ──────── existsByEventIdAndSaleStartAtBefore ────────
+    // ──────── existsByEventIdAndSaleStartAtLessThanEqual ────────
 
     @Nested
-    @DisplayName("existsByEventIdAndSaleStartAtBefore")
+    @DisplayName("existsByEventIdAndSaleStartAtLessThanEqual")
     @Transactional
     inner class ExistsByEventIdAndSaleStartAtBefore {
 
@@ -414,7 +413,7 @@ class EventRepositoryIntegrationTest {
             val event = saveEvent(venue, hall)
             saveSchedule(event, saleStartAt = now.minusHours(1)) // 1시간 전 판매 시작
 
-            val result = eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(event.id!!, now)
+            val result = eventScheduleRepository.existsByEventIdAndSaleStartAtLessThanEqual(event.id!!, now)
 
             assertTrue(result)
         }
@@ -427,7 +426,7 @@ class EventRepositoryIntegrationTest {
             val event = saveEvent(venue, hall)
             saveSchedule(event, saleStartAt = now.plusDays(1)) // 내일 판매 시작
 
-            val result = eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(event.id!!, now)
+            val result = eventScheduleRepository.existsByEventIdAndSaleStartAtLessThanEqual(event.id!!, now)
 
             assertFalse(result)
         }
@@ -440,7 +439,7 @@ class EventRepositoryIntegrationTest {
             val event = saveEvent(venue, hall)
             // 회차 없음
 
-            val result = eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(event.id!!, now)
+            val result = eventScheduleRepository.existsByEventIdAndSaleStartAtLessThanEqual(event.id!!, now)
 
             assertFalse(result)
         }

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
@@ -586,11 +586,18 @@ class EventServiceTest {
             val hall = createHall(venue)
             val event = createEvent(venue, hall)
             val scheduleId2 = UUID.randomUUID()
-            val scheduleEarly = createSchedule(event) // now.plusDays(30) 이른 시각
+            // 자정을 넘지 않도록 정오(12:00) 기준으로 고정 — 시간대 flakiness 방지
+            val baseTime = now.toLocalDate().atTime(12, 0).plusDays(30)
+            val scheduleEarly = EventSchedule(
+                id = scheduleId, event = event, playSequence = 1,
+                eventStartAt = baseTime, eventEndAt = baseTime.plusHours(2),
+                saleStartAt = now.plusDays(1), saleEndAt = now.plusDays(29),
+                createdAt = now, updatedAt = now
+            )
             val scheduleLate = EventSchedule(
                 id = scheduleId2, event = event, playSequence = 2,
-                eventStartAt = now.plusDays(30).plusHours(3), // 같은 날, 늦은 시각
-                eventEndAt = now.plusDays(30).plusHours(5),
+                eventStartAt = baseTime.plusHours(3), // 같은 날 15:00 — 자정 경계 없음
+                eventEndAt = baseTime.plusHours(5),
                 saleStartAt = now.plusDays(1), saleEndAt = now.plusDays(29),
                 createdAt = now, updatedAt = now
             )
@@ -654,7 +661,7 @@ class EventServiceTest {
             val event = createEvent(venue, hall)
 
             every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
-            every { eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(eventId, any()) } returns false
+            every { eventScheduleRepository.existsByEventIdAndSaleStartAtLessThanEqual(eventId, any()) } returns false
 
             val result = eventService.updateEvent(eventId, EventDto.UpdateRequest(title = "BTS 투어 2026", artist = "BTS 팀"))
 
@@ -670,7 +677,7 @@ class EventServiceTest {
             val event = createEvent(venue, hall)
 
             every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
-            every { eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(eventId, any()) } returns true
+            every { eventScheduleRepository.existsByEventIdAndSaleStartAtLessThanEqual(eventId, any()) } returns true
 
             val exception = assertThrows<EventException> {
                 eventService.updateEvent(eventId, EventDto.UpdateRequest(artist = "변경된 아티스트"))
@@ -686,7 +693,7 @@ class EventServiceTest {
             val event = createEvent(venue, hall)
 
             every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
-            every { eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(eventId, any()) } returns true
+            every { eventScheduleRepository.existsByEventIdAndSaleStartAtLessThanEqual(eventId, any()) } returns true
 
             val result = eventService.updateEvent(
                 eventId,
@@ -715,7 +722,7 @@ class EventServiceTest {
             val event = createEvent(venue, hall)
 
             every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
-            every { eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(eventId, any()) } returns false
+            every { eventScheduleRepository.existsByEventIdAndSaleStartAtLessThanEqual(eventId, any()) } returns false
 
             val result = eventService.updateEvent(eventId, EventDto.UpdateRequest(description = "새 설명"))
 
@@ -732,7 +739,7 @@ class EventServiceTest {
             val event = createEvent(venue, hall).apply { update(null, null, "기존 설명") }
 
             every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
-            every { eventScheduleRepository.existsByEventIdAndSaleStartAtBefore(eventId, any()) } returns false
+            every { eventScheduleRepository.existsByEventIdAndSaleStartAtLessThanEqual(eventId, any()) } returns false
 
             val result = eventService.updateEvent(eventId, EventDto.UpdateRequest(description = ""))
 

--- a/docker/db_init/3_event_service_ddl.sql
+++ b/docker/db_init/3_event_service_ddl.sql
@@ -79,7 +79,7 @@ CREATE TABLE event_service.events (
 
 -- 인덱스
 CREATE INDEX idx_events_status ON event_service.events(status);
-CREATE INDEX idx_events_not_deleted ON event_service.events(id) WHERE deleted_at IS NULL;
+CREATE INDEX idx_events_not_deleted ON event_service.events(status) WHERE deleted_at IS NULL;
 CREATE INDEX idx_events_artist ON event_service.events(artist);
 CREATE INDEX idx_events_venue ON event_service.events(venue_id);
 

--- a/docs/specification/02_event_service.md
+++ b/docs/specification/02_event_service.md
@@ -53,7 +53,7 @@ Event Service는 공연, 공연장, 좌석 정보를 관리하며 조회 성능�
   - `size` (int, default: 20): 페이지 크기
   - `status` (string, optional): 공연 상태 필터 (PREPARING, OPEN, ENDED, CANCELLED)
   - `city` (string, optional): 도시 필터
-  - `keyword` (string, optional): 제목/아티스트 키워드 검색 (PostgreSQL FTS)
+  - `keyword` (string, optional): 제목/아티스트 키워드 검색 (LIKE, 대소문자 무시)
 
 **Response (200 OK)**
 ```json


### PR DESCRIPTION
## Summary

- **EventStatus 상태 머신 명시화**: `canTransitionTo()` 메서드로 허용 전이 맵 캡슐화, `changeStatus()` 호출 시 유효하지 않은 전이에 `INVALID_EVENT_STATUS` 예외 발생
- **`softDelete()` 멱등성 보장**: 이미 삭제된 이벤트에 재호출 시 `deletedAt` 덮어쓰기 방지 (원본 삭제 시각 보존)
- **`findByIdForUpdate` 소프트 삭제 필터 추가**: 비관적 락 조회 시 `deletedAt IS NULL` 조건 포함 (삭제된 이벤트 수정 방지)
- **메서드명 수정**: `existsByEventIdAndSaleStartAtBefore` → `LessThanEqual` (현재 시각 판매 시작 케이스 포함)
- **공백 필터 무시**: `city`, `keyword` 파라미터에 `takeIf { isNotBlank() }` 적용
- **결정적 페이지네이션**: 목록 정렬에 `event.id.asc()` 보조 정렬 추가
- **DDL 부분 인덱스 최적화**: `idx_events_not_deleted` 컬럼 `id` → `status`로 변경
- **스펙 문서 수정**: keyword 검색 설명 `PostgreSQL FTS` → `LIKE (대소문자 무시)`로 현행화

## Test plan

- [x] 빌드 성공: `./gradlew :event-service:build -x test`
- [x] 단위 테스트 통과: `./gradlew :event-service:test`
- [x] 상태 전이 위반 케이스 3개 추가 (ENDED→OPEN, CANCELLED→OPEN, PREPARING→ENDED)
- [x] `softDelete` 멱등성 테스트 — 두 번째 호출 시 원본 `deletedAt` 보존 검증
- [x] `findByIdForUpdate` — 소프트 삭제 이벤트 `null` 반환 검증
- [x] 플래키 테스트 수정 — 자정 경계 문제 제거 (정오 기준 고정)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event soft deletion now preserves original deletion timestamp when called multiple times.
  * Invalid event status transitions are now properly rejected with appropriate error handling.
  * Sale start detection now correctly treats the exact moment as "already started."

* **Improvements**
  * Event list filtering now conditionally applies city and keyword filters for better accuracy.
  * Keyword search changed from full-text search to case-insensitive pattern matching.
  * Database query optimization for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->