### PR TITLE
feat: [Event] 내부 API - SOLD 좌석 조회 구현 #38

### DIFF
--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClient.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClient.kt
@@ -1,0 +1,18 @@
+package com.ticketqueue.reservation.client
+
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import java.util.UUID
+
+@FeignClient(name = "event-service", url = "\${feign.client.config.event-service.url}")
+interface EventServiceClient {
+
+    @GetMapping("/internal/seats/status/{scheduleId}")
+    fun getSoldSeats(@PathVariable scheduleId: UUID): SoldSeatsResponse
+
+    data class SoldSeatsResponse(
+        val scheduleId: UUID,
+        val soldSeatIds: List<UUID>
+    )
+}

--- a/backend/reservation-service/src/main/resources/application.yml
+++ b/backend/reservation-service/src/main/resources/application.yml
@@ -78,6 +78,8 @@ feign:
         read-timeout: 10000
       event-service:
         url: http://localhost:8082
+        connect-timeout: 2000
+        read-timeout: 3000
 
 internal:
   api:


### PR DESCRIPTION
## Summary
- Event Service에 `GET /internal/seats/status/{scheduleId}` 내부 API 구현
- Reservation Service에서 Feign Client로 SOLD 좌석 목록을 조회할 수 있도록 연결

## Changes
- `SeatRepositoryCustom` / `SeatRepositoryCustomImpl`: `findSeatIdsByScheduleIdAndStatus()` QueryDSL 쿼리 추가 (전체 엔티티 로딩 없이 ID만 projection)
- `InternalSeatDto`: `SoldSeatsResponse` 응답 DTO 추가
- `InternalSeatService`: 스케줄 존재 검증 후 SOLD 좌석 ID 목록 반환 (없으면 빈 리스트)
- `InternalSeatController`: `GET /internal/seats/status/{scheduleId}` 엔드포인트 (API Key 검증은 `InternalApiAuthInterceptor` 자동 처리)
- `EventServiceClient` (reservation-service): Feign Client 인터페이스 추가 (`X-Service-Api-Key` 헤더는 common `FeignConfig` 자동 주입)

Closes #38 

## Test plan
- [x] `InternalSeatServiceTest`: SOLD 좌석 반환 / 빈 리스트 / 스케줄 미존재 404 (3케이스)
- [x] `InternalSeatControllerTest`: 200 정상 / 200 빈 배열 / 404 에러 응답 (3케이스)
- [x] `./gradlew :event-service:test` BUILD SUCCESSFUL
- [x] `./gradlew :reservation-service:compileKotlin` BUILD SUCCESSFUL

관련 이슈: #38
요구사항: REQ-INT-001, REQ-INT-005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added backend integration for real-time seat availability checking between reservation and event services.

* **Chores**
  * Configured connection and response timeouts for improved service reliability and system stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->