### PR TITLE
feat: [Event] 공연 회차(Schedule) 독립 CRUD 및 상태 전이 API 구현 #34

### DIFF
--- a/backend/common/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
@@ -71,5 +71,6 @@ enum class ErrorCode(
     INVALID_SCHEDULE_TIME(HttpStatus.BAD_REQUEST, "INVALID_SCHEDULE_TIME", "회차 시간이 올바르지 않습니다."),
     EVENT_NOT_MODIFIABLE(HttpStatus.CONFLICT, "EVENT_NOT_MODIFIABLE", "판매 시작 후에는 아티스트 정보를 수정할 수 없습니다."),
     DUPLICATE_PLAY_SEQUENCE(HttpStatus.CONFLICT, "DUPLICATE_PLAY_SEQUENCE", "중복된 회차 순번입니다."),
-    HALL_NOT_IN_VENUE(HttpStatus.BAD_REQUEST, "HALL_NOT_IN_VENUE", "해당 홀은 선택한 공연장에 속하지 않습니다.")
+    HALL_NOT_IN_VENUE(HttpStatus.BAD_REQUEST, "HALL_NOT_IN_VENUE", "해당 홀은 선택한 공연장에 속하지 않습니다."),
+    INVALID_SCHEDULE_STATUS(HttpStatus.BAD_REQUEST, "INVALID_SCHEDULE_STATUS", "유효하지 않은 회차 상태 전환입니다.")
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/ScheduleController.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/ScheduleController.kt
@@ -1,0 +1,64 @@
+package com.ticketqueue.event.controller
+
+import com.ticketqueue.event.dto.ScheduleDto
+import com.ticketqueue.event.service.ScheduleService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+/**
+ * 공연 회차(EventSchedule) 관리 REST API 컨트롤러
+ *
+ * 엔드포인트 목록:
+ * - POST   /events/{eventId}/schedules            : 회차 생성 (ADMIN 전용) - REQ-EVT-001
+ * - GET    /events/{eventId}/schedules            : 회차 목록 조회 (공개) - REQ-EVT-007
+ * - GET    /events/schedules/{scheduleId}         : 회차 상세 조회 (공개) - REQ-EVT-007
+ * - PATCH  /events/schedules/{scheduleId}/status : 회차 상태 변경 (ADMIN 전용) - REQ-EVT-007
+ *
+ * 경로가 /events/{eventId}/schedules 와 /events/schedules/{scheduleId}로 혼합되어 있어
+ * 클래스 레벨 @RequestMapping 대신 메서드별 전체 경로를 정의한다.
+ * 권한 규칙은 SecurityConfig의 /events/ 와일드카드 규칙이 모든 엔드포인트를 커버한다.
+ */
+@RestController
+class ScheduleController(
+    private val scheduleService: ScheduleService
+) {
+
+    /** 회차 생성 (REQ-EVT-001) - ADMIN 권한 필요 */
+    @PostMapping("/events/{eventId}/schedules")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createSchedule(
+        @PathVariable eventId: UUID,
+        @Valid @RequestBody request: ScheduleDto.CreateRequest
+    ): ScheduleDto.CreateResponse {
+        return scheduleService.createSchedule(eventId, request)
+    }
+
+    /** 회차 목록 조회 (REQ-EVT-007) - 공개 API */
+    @GetMapping("/events/{eventId}/schedules")
+    fun getSchedules(@PathVariable eventId: UUID): List<ScheduleDto.ListResponse> {
+        return scheduleService.getSchedules(eventId)
+    }
+
+    /** 회차 상세 조회 (REQ-EVT-007) - 공개 API */
+    @GetMapping("/events/schedules/{scheduleId}")
+    fun getSchedule(@PathVariable scheduleId: UUID): ScheduleDto.DetailResponse {
+        return scheduleService.getSchedule(scheduleId)
+    }
+
+    /** 회차 상태 변경 (REQ-EVT-007) - ADMIN 권한 필요 */
+    @PatchMapping("/events/schedules/{scheduleId}/status")
+    fun changeScheduleStatus(
+        @PathVariable scheduleId: UUID,
+        @Valid @RequestBody request: ScheduleDto.ChangeStatusRequest
+    ): ScheduleDto.ChangeStatusResponse {
+        return scheduleService.changeScheduleStatus(scheduleId, request)
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/ScheduleDto.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/ScheduleDto.kt
@@ -1,0 +1,145 @@
+package com.ticketqueue.event.dto
+
+import com.ticketqueue.event.entity.EventSchedule
+import com.ticketqueue.event.entity.ScheduleStatus
+import com.ticketqueue.event.entity.SeatGrade
+import jakarta.validation.constraints.DecimalMin
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * 공연 회차(EventSchedule) API 요청/응답 DTO 모음
+ *
+ * - [CreateRequest]        : POST 요청 - 회차 생성 및 좌석 초기화
+ * - [CreateResponse]       : 생성 응답
+ * - [ListResponse]         : 목록 조회 응답
+ * - [DetailResponse]       : 상세 조회 응답
+ * - [ChangeStatusRequest]  : PATCH 요청 - 상태 변경
+ * - [ChangeStatusResponse] : 상태 변경 응답
+ */
+class ScheduleDto {
+
+    /** 회차 생성 요청 - 좌석 초기화를 위해 등급별 가격 포함 */
+    data class CreateRequest(
+        @field:Min(value = 1, message = "회차 순번은 1 이상이어야 합니다.")
+        val playSequence: Int,
+
+        @field:NotNull(message = "공연 시작 일시는 필수입니다.")
+        val eventStartAt: LocalDateTime,
+
+        @field:NotNull(message = "공연 종료 일시는 필수입니다.")
+        val eventEndAt: LocalDateTime,
+
+        @field:NotNull(message = "판매 시작 일시는 필수입니다.")
+        val saleStartAt: LocalDateTime,
+
+        @field:NotNull(message = "판매 종료 일시는 필수입니다.")
+        val saleEndAt: LocalDateTime,
+
+        @field:NotEmpty(message = "등급별 가격 정보는 필수입니다.")
+        val priceByGrade: Map<SeatGrade, @DecimalMin(value = "0", message = "가격은 0 이상이어야 합니다.") BigDecimal>
+    )
+
+    /** 회차 생성 응답 */
+    data class CreateResponse(
+        val id: UUID,
+        val eventId: UUID,
+        val playSequence: Int,
+        val eventStartAt: LocalDateTime,
+        val eventEndAt: LocalDateTime,
+        val saleStartAt: LocalDateTime,
+        val saleEndAt: LocalDateTime,
+        val status: ScheduleStatus,
+        val createdAt: LocalDateTime
+    ) {
+        companion object {
+            fun from(schedule: EventSchedule): CreateResponse = CreateResponse(
+                id = schedule.id!!,
+                eventId = schedule.event.id!!,
+                playSequence = schedule.playSequence,
+                eventStartAt = schedule.eventStartAt,
+                eventEndAt = schedule.eventEndAt,
+                saleStartAt = schedule.saleStartAt,
+                saleEndAt = schedule.saleEndAt,
+                status = schedule.status,
+                createdAt = schedule.createdAt!!
+            )
+        }
+    }
+
+    /** 회차 목록 조회 응답 */
+    data class ListResponse(
+        val id: UUID,
+        val playSequence: Int,
+        val eventStartAt: LocalDateTime,
+        val eventEndAt: LocalDateTime,
+        val saleStartAt: LocalDateTime,
+        val saleEndAt: LocalDateTime,
+        val status: ScheduleStatus,
+        val isSoldOut: Boolean
+    ) {
+        companion object {
+            fun from(schedule: EventSchedule, isSoldOut: Boolean): ListResponse = ListResponse(
+                id = schedule.id!!,
+                playSequence = schedule.playSequence,
+                eventStartAt = schedule.eventStartAt,
+                eventEndAt = schedule.eventEndAt,
+                saleStartAt = schedule.saleStartAt,
+                saleEndAt = schedule.saleEndAt,
+                status = schedule.status,
+                isSoldOut = isSoldOut
+            )
+        }
+    }
+
+    /** 회차 상세 조회 응답 */
+    data class DetailResponse(
+        val id: UUID,
+        val eventId: UUID,
+        val eventTitle: String,
+        val playSequence: Int,
+        val eventStartAt: LocalDateTime,
+        val eventEndAt: LocalDateTime,
+        val saleStartAt: LocalDateTime,
+        val saleEndAt: LocalDateTime,
+        val status: ScheduleStatus,
+        val isSoldOut: Boolean,
+        val createdAt: LocalDateTime,
+        val updatedAt: LocalDateTime
+    ) {
+        companion object {
+            fun from(schedule: EventSchedule, isSoldOut: Boolean): DetailResponse = DetailResponse(
+                id = schedule.id!!,
+                eventId = schedule.event.id!!,
+                eventTitle = schedule.event.title,
+                playSequence = schedule.playSequence,
+                eventStartAt = schedule.eventStartAt,
+                eventEndAt = schedule.eventEndAt,
+                saleStartAt = schedule.saleStartAt,
+                saleEndAt = schedule.saleEndAt,
+                status = schedule.status,
+                isSoldOut = isSoldOut,
+                createdAt = schedule.createdAt!!,
+                updatedAt = schedule.updatedAt!!
+            )
+        }
+    }
+
+    /** 회차 상태 변경 요청 */
+    data class ChangeStatusRequest(
+        @field:NotNull(message = "변경할 상태는 필수입니다.")
+        val status: ScheduleStatus
+    )
+
+    /** 회차 상태 변경 응답 */
+    data class ChangeStatusResponse(
+        val id: UUID,
+        val previousStatus: ScheduleStatus,
+        val currentStatus: ScheduleStatus,
+        val updatedAt: LocalDateTime
+    )
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/EventSchedule.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/EventSchedule.kt
@@ -57,6 +57,15 @@ class EventSchedule(
     /** 티켓 판매가 시작된 회차인지 확인 */
     fun hasSaleStarted(): Boolean = saleStartAt.isBefore(LocalDateTime.now())
 
+    fun changeStatus(newStatus: ScheduleStatus) {
+        if (!this.status.canTransitionTo(newStatus)) {
+            throw com.ticketqueue.event.exception.EventException(
+                com.ticketqueue.common.exception.ErrorCode.INVALID_SCHEDULE_STATUS
+            )
+        }
+        this.status = newStatus
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is EventSchedule) return false

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/enums.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/enums.kt
@@ -16,6 +16,20 @@ enum class EventStatus {
         allowedTransitions[this]?.contains(target) ?: false
 }
 
-enum class ScheduleStatus { UPCOMING, ONGOING, ENDED, CANCELLED }
+enum class ScheduleStatus {
+    UPCOMING, ONGOING, ENDED, CANCELLED;
+
+    private companion object {
+        val allowedTransitions = mapOf(
+            UPCOMING to setOf(ONGOING, CANCELLED),
+            ONGOING to setOf(ENDED, CANCELLED),
+            ENDED to emptySet<ScheduleStatus>(),
+            CANCELLED to emptySet<ScheduleStatus>()
+        )
+    }
+
+    fun canTransitionTo(target: ScheduleStatus): Boolean =
+        allowedTransitions[this]?.contains(target) ?: false
+}
 enum class SeatGrade { VIP, S, A, B }
 enum class SeatStatus { AVAILABLE, SOLD }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepository.kt
@@ -15,4 +15,10 @@ interface EventScheduleRepository : JpaRepository<EventSchedule, UUID> {
      * updateEvent의 hasSaleStarted 체크를 위해 전체 목록 로드 대신 EXISTS 쿼리 1개로 처리한다.
      */
     fun existsByEventIdAndSaleStartAtLessThanEqual(eventId: UUID, dateTime: LocalDateTime): Boolean
+
+    /**
+     * 동일 공연에 동일 회차 순번이 이미 존재하는지 확인한다.
+     * createSchedule의 중복 순번 방지를 위해 사용한다.
+     */
+    fun existsByEventIdAndPlaySequence(eventId: UUID, playSequence: Int): Boolean
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
@@ -3,6 +3,7 @@ package com.ticketqueue.event.service
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.util.DateTimeUtils
 import com.ticketqueue.event.dto.ScheduleDto
 import com.ticketqueue.event.dto.SeatTemplateDto
 import com.ticketqueue.event.entity.EventSchedule
@@ -12,6 +13,7 @@ import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.repository.EventRepository
 import com.ticketqueue.event.repository.EventScheduleRepository
 import com.ticketqueue.event.repository.SeatRepository
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -61,16 +63,20 @@ class ScheduleService(
             throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE, cause = e)
         }
 
-        val schedule = eventScheduleRepository.save(
-            EventSchedule(
-                event = event,
-                playSequence = request.playSequence,
-                eventStartAt = request.eventStartAt,
-                eventEndAt = request.eventEndAt,
-                saleStartAt = request.saleStartAt,
-                saleEndAt = request.saleEndAt
+        val schedule = try {
+            eventScheduleRepository.save(
+                EventSchedule(
+                    event = event,
+                    playSequence = request.playSequence,
+                    eventStartAt = request.eventStartAt,
+                    eventEndAt = request.eventEndAt,
+                    saleStartAt = request.saleStartAt,
+                    saleEndAt = request.saleEndAt
+                )
             )
-        )
+        } catch (e: DataIntegrityViolationException) {
+            throw EventException(ErrorCode.DUPLICATE_PLAY_SEQUENCE, cause = e)
+        }
 
         val seats = initializeSeats(schedule, seatTemplate, request.priceByGrade)
         seatRepository.saveAll(seats)
@@ -146,7 +152,7 @@ class ScheduleService(
         if (!saleEndAt.isBefore(eventStartAt)) {
             throw EventException(ErrorCode.INVALID_SCHEDULE_TIME)
         }
-        if (!eventStartAt.isAfter(LocalDateTime.now())) {
+        if (!eventStartAt.isAfter(DateTimeUtils.now())) {
             throw EventException(ErrorCode.INVALID_SCHEDULE_TIME)
         }
     }
@@ -162,7 +168,7 @@ class ScheduleService(
             val grade = try {
                 SeatGrade.valueOf(gradeStr)
             } catch (e: IllegalArgumentException) {
-                throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING)
+                throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING, cause = e)
             }
             val price = priceByGrade[grade]
                 ?: throw EventException(ErrorCode.INVALID_INPUT)

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
@@ -1,0 +1,174 @@
+package com.ticketqueue.event.service
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.dto.ScheduleDto
+import com.ticketqueue.event.dto.SeatTemplateDto
+import com.ticketqueue.event.entity.EventSchedule
+import com.ticketqueue.event.entity.Seat
+import com.ticketqueue.event.entity.SeatGrade
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.repository.EventRepository
+import com.ticketqueue.event.repository.EventScheduleRepository
+import com.ticketqueue.event.repository.SeatRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * 공연 회차(EventSchedule) 관리 서비스
+ *
+ * 공연에 회차를 추가하거나 개별 회차를 조회/상태 관리한다.
+ * - 회차 생성 시 Hall seatTemplate 기반 좌석 자동 초기화 (EventService와 동일 로직)
+ * - 상태 전이: UPCOMING → ONGOING/CANCELLED, ONGOING → ENDED/CANCELLED (도메인 메서드 위임)
+ * - REQ-EVT-001, REQ-EVT-007
+ */
+@Service
+@Transactional(readOnly = true)
+class ScheduleService(
+    private val eventRepository: EventRepository,
+    private val eventScheduleRepository: EventScheduleRepository,
+    private val seatRepository: SeatRepository,
+    private val objectMapper: ObjectMapper
+) {
+
+    /**
+     * 특정 공연에 회차를 추가한다 (좌석 자동 초기화 포함)
+     *
+     * 1. Event 존재 및 softDelete 여부 확인
+     * 2. playSequence 중복 검증
+     * 3. 시간 유효성 검증 (4가지 규칙)
+     * 4. seatTemplate 파싱 (fail-fast)
+     * 5. EventSchedule 저장 → 좌석 일괄 초기화
+     */
+    @Transactional
+    fun createSchedule(eventId: UUID, request: ScheduleDto.CreateRequest): ScheduleDto.CreateResponse {
+        val event = eventRepository.findByIdAndDeletedAtIsNull(eventId)
+            ?: throw EventException(ErrorCode.EVENT_NOT_FOUND)
+
+        if (eventScheduleRepository.existsByEventIdAndPlaySequence(eventId, request.playSequence)) {
+            throw EventException(ErrorCode.DUPLICATE_PLAY_SEQUENCE)
+        }
+
+        validateScheduleTime(request.eventStartAt, request.eventEndAt, request.saleStartAt, request.saleEndAt)
+
+        val seatTemplate = try {
+            objectMapper.readValue(event.hall.seatTemplate, SeatTemplateDto::class.java)
+        } catch (e: JsonProcessingException) {
+            throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE, cause = e)
+        }
+
+        val schedule = eventScheduleRepository.save(
+            EventSchedule(
+                event = event,
+                playSequence = request.playSequence,
+                eventStartAt = request.eventStartAt,
+                eventEndAt = request.eventEndAt,
+                saleStartAt = request.saleStartAt,
+                saleEndAt = request.saleEndAt
+            )
+        )
+
+        val seats = initializeSeats(schedule, seatTemplate, request.priceByGrade)
+        seatRepository.saveAll(seats)
+
+        return ScheduleDto.CreateResponse.from(schedule)
+    }
+
+    /**
+     * 특정 공연의 회차 목록을 조회한다
+     *
+     * isSoldOut: AVAILABLE 좌석이 하나도 없으면 true
+     */
+    fun getSchedules(eventId: UUID): List<ScheduleDto.ListResponse> {
+        eventRepository.findByIdAndDeletedAtIsNull(eventId)
+            ?: throw EventException(ErrorCode.EVENT_NOT_FOUND)
+
+        val schedules = eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId)
+        if (schedules.isEmpty()) return emptyList()
+
+        val scheduleIds = schedules.map { it.id!! }
+        val availableScheduleIds = eventRepository.findScheduleIdsWithAvailableSeats(scheduleIds)
+
+        return schedules.map { schedule ->
+            ScheduleDto.ListResponse.from(schedule, isSoldOut = schedule.id!! !in availableScheduleIds)
+        }
+    }
+
+    /**
+     * 회차 상세를 조회한다
+     *
+     * LAZY event 접근으로 추가 쿼리 1회 발생 (단건 조회라 허용)
+     */
+    fun getSchedule(scheduleId: UUID): ScheduleDto.DetailResponse {
+        val schedule = eventScheduleRepository.findById(scheduleId)
+            .orElseThrow { EventException(ErrorCode.SCHEDULE_NOT_FOUND) }
+
+        val availableScheduleIds = eventRepository.findScheduleIdsWithAvailableSeats(listOf(scheduleId))
+        val isSoldOut = scheduleId !in availableScheduleIds
+
+        return ScheduleDto.DetailResponse.from(schedule, isSoldOut)
+    }
+
+    /**
+     * 회차 상태를 변경한다
+     *
+     * 유효하지 않은 전이 시 EventSchedule.changeStatus()에서 INVALID_SCHEDULE_STATUS 예외 발생
+     */
+    @Transactional
+    fun changeScheduleStatus(scheduleId: UUID, request: ScheduleDto.ChangeStatusRequest): ScheduleDto.ChangeStatusResponse {
+        val schedule = eventScheduleRepository.findById(scheduleId)
+            .orElseThrow { EventException(ErrorCode.SCHEDULE_NOT_FOUND) }
+
+        val previousStatus = schedule.status
+        schedule.changeStatus(request.status)
+
+        return ScheduleDto.ChangeStatusResponse(
+            id = schedule.id!!,
+            previousStatus = previousStatus,
+            currentStatus = schedule.status,
+            updatedAt = schedule.updatedAt!!
+        )
+    }
+
+    private fun validateScheduleTime(
+        eventStartAt: LocalDateTime,
+        eventEndAt: LocalDateTime,
+        saleStartAt: LocalDateTime,
+        saleEndAt: LocalDateTime
+    ) {
+        if (!eventStartAt.isBefore(eventEndAt) || !saleStartAt.isBefore(saleEndAt)) {
+            throw EventException(ErrorCode.INVALID_SCHEDULE_TIME)
+        }
+        if (!saleEndAt.isBefore(eventStartAt)) {
+            throw EventException(ErrorCode.INVALID_SCHEDULE_TIME)
+        }
+        if (!eventStartAt.isAfter(LocalDateTime.now())) {
+            throw EventException(ErrorCode.INVALID_SCHEDULE_TIME)
+        }
+    }
+
+    private fun initializeSeats(
+        schedule: EventSchedule,
+        seatTemplate: SeatTemplateDto,
+        priceByGrade: Map<SeatGrade, BigDecimal>
+    ): List<Seat> {
+        return seatTemplate.rows.flatMap { row ->
+            val gradeStr = seatTemplate.gradeMapping[row]
+                ?: throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING)
+            val grade = try {
+                SeatGrade.valueOf(gradeStr)
+            } catch (e: IllegalArgumentException) {
+                throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING)
+            }
+            val price = priceByGrade[grade]
+                ?: throw EventException(ErrorCode.INVALID_INPUT)
+            (1..seatTemplate.seatsPerRow).map { seatIndex ->
+                Seat(eventSchedule = schedule, seatNumber = "${row}-${seatIndex}", grade = grade, price = price)
+            }
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/ScheduleControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/ScheduleControllerTest.kt
@@ -1,0 +1,320 @@
+package com.ticketqueue.event.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.exception.GlobalExceptionHandler
+import com.ticketqueue.event.dto.ScheduleDto
+import com.ticketqueue.event.entity.ScheduleStatus
+import com.ticketqueue.event.entity.SeatGrade
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.service.ScheduleService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+class ScheduleControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var scheduleService: ScheduleService
+    private val objectMapper: ObjectMapper = jacksonObjectMapper().apply {
+        registerModule(JavaTimeModule())
+    }
+
+    private val eventId = UUID.randomUUID()
+    private val scheduleId = UUID.randomUUID()
+    private val now = LocalDateTime.now()
+
+    private fun createResponse() = ScheduleDto.CreateResponse(
+        id = scheduleId,
+        eventId = eventId,
+        playSequence = 1,
+        eventStartAt = now.plusDays(30),
+        eventEndAt = now.plusDays(30).plusHours(2),
+        saleStartAt = now.plusDays(1),
+        saleEndAt = now.plusDays(29),
+        status = ScheduleStatus.UPCOMING,
+        createdAt = now
+    )
+
+    private fun listResponse(playSequence: Int = 1, isSoldOut: Boolean = false) = ScheduleDto.ListResponse(
+        id = scheduleId,
+        playSequence = playSequence,
+        eventStartAt = now.plusDays(30),
+        eventEndAt = now.plusDays(30).plusHours(2),
+        saleStartAt = now.plusDays(1),
+        saleEndAt = now.plusDays(29),
+        status = ScheduleStatus.UPCOMING,
+        isSoldOut = isSoldOut
+    )
+
+    private fun detailResponse() = ScheduleDto.DetailResponse(
+        id = scheduleId,
+        eventId = eventId,
+        eventTitle = "BTS World Tour",
+        playSequence = 1,
+        eventStartAt = now.plusDays(30),
+        eventEndAt = now.plusDays(30).plusHours(2),
+        saleStartAt = now.plusDays(1),
+        saleEndAt = now.plusDays(29),
+        status = ScheduleStatus.UPCOMING,
+        isSoldOut = false,
+        createdAt = now,
+        updatedAt = now
+    )
+
+    private fun changeStatusResponse() = ScheduleDto.ChangeStatusResponse(
+        id = scheduleId,
+        previousStatus = ScheduleStatus.UPCOMING,
+        currentStatus = ScheduleStatus.ONGOING,
+        updatedAt = now
+    )
+
+    private fun validCreateRequest() = ScheduleDto.CreateRequest(
+        playSequence = 1,
+        eventStartAt = now.plusDays(30),
+        eventEndAt = now.plusDays(30).plusHours(2),
+        saleStartAt = now.plusDays(1),
+        saleEndAt = now.plusDays(29),
+        priceByGrade = mapOf(SeatGrade.VIP to BigDecimal("100000"))
+    )
+
+    @BeforeEach
+    fun setUp() {
+        scheduleService = mockk()
+        val controller = ScheduleController(scheduleService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(GlobalExceptionHandler())
+            .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
+            .build()
+    }
+
+    @Nested
+    @DisplayName("POST /events/{eventId}/schedules")
+    inner class CreateSchedule {
+
+        @Test
+        @DisplayName("201 Created - 회차를 생성한다")
+        fun created() {
+            every { scheduleService.createSchedule(eventId, any()) } returns createResponse()
+
+            mockMvc.perform(
+                post("/events/{eventId}/schedules", eventId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(validCreateRequest()))
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.id").value(scheduleId.toString()))
+                .andExpect(jsonPath("$.playSequence").value(1))
+                .andExpect(jsonPath("$.status").value("UPCOMING"))
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - Bean Validation 실패 (playSequence < 1)")
+        fun badRequestValidation() {
+            val invalidRequest = mapOf(
+                "playSequence" to 0, // Min(1) 위반
+                "priceByGrade" to mapOf("VIP" to "100000")
+            )
+
+            mockMvc.perform(
+                post("/events/{eventId}/schedules", eventId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(invalidRequest))
+            )
+                .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - priceByGrade 누락")
+        fun badRequestMissingPriceByGrade() {
+            val invalidRequest = mapOf(
+                "playSequence" to 1
+                // priceByGrade 누락
+            )
+
+            mockMvc.perform(
+                post("/events/{eventId}/schedules", eventId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(invalidRequest))
+            )
+                .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 공연")
+        fun eventNotFound() {
+            every { scheduleService.createSchedule(eventId, any()) } throws EventException(ErrorCode.EVENT_NOT_FOUND)
+
+            mockMvc.perform(
+                post("/events/{eventId}/schedules", eventId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(validCreateRequest()))
+            )
+                .andExpect(status().isNotFound)
+        }
+
+        @Test
+        @DisplayName("409 Conflict - 회차 순번 중복")
+        fun duplicatePlaySequence() {
+            every { scheduleService.createSchedule(eventId, any()) } throws EventException(ErrorCode.DUPLICATE_PLAY_SEQUENCE)
+
+            mockMvc.perform(
+                post("/events/{eventId}/schedules", eventId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(validCreateRequest()))
+            )
+                .andExpect(status().isConflict)
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - 회차 시간 유효성 검사 실패")
+        fun invalidScheduleTime() {
+            every { scheduleService.createSchedule(eventId, any()) } throws EventException(ErrorCode.INVALID_SCHEDULE_TIME)
+
+            mockMvc.perform(
+                post("/events/{eventId}/schedules", eventId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(validCreateRequest()))
+            )
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_SCHEDULE_TIME"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /events/{eventId}/schedules")
+    inner class GetSchedules {
+
+        @Test
+        @DisplayName("200 OK - 회차 목록을 반환한다")
+        fun list() {
+            every { scheduleService.getSchedules(eventId) } returns listOf(listResponse())
+
+            mockMvc.perform(get("/events/{eventId}/schedules", eventId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$[0].playSequence").value(1))
+                .andExpect(jsonPath("$[0].isSoldOut").value(false))
+        }
+
+        @Test
+        @DisplayName("200 OK - 빈 목록을 반환한다")
+        fun emptyList() {
+            every { scheduleService.getSchedules(eventId) } returns emptyList<ScheduleDto.ListResponse>()
+
+            mockMvc.perform(get("/events/{eventId}/schedules", eventId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$").isArray)
+                .andExpect(jsonPath("$").isEmpty)
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 공연")
+        fun eventNotFound() {
+            every { scheduleService.getSchedules(eventId) } throws EventException(ErrorCode.EVENT_NOT_FOUND)
+
+            mockMvc.perform(get("/events/{eventId}/schedules", eventId))
+                .andExpect(status().isNotFound)
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /events/schedules/{scheduleId}")
+    inner class GetSchedule {
+
+        @Test
+        @DisplayName("200 OK - 회차 상세를 반환한다")
+        fun detail() {
+            every { scheduleService.getSchedule(scheduleId) } returns detailResponse()
+
+            mockMvc.perform(get("/events/schedules/{scheduleId}", scheduleId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.id").value(scheduleId.toString()))
+                .andExpect(jsonPath("$.eventTitle").value("BTS World Tour"))
+                .andExpect(jsonPath("$.isSoldOut").value(false))
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 회차")
+        fun notFound() {
+            every { scheduleService.getSchedule(scheduleId) } throws EventException(ErrorCode.SCHEDULE_NOT_FOUND)
+
+            mockMvc.perform(get("/events/schedules/{scheduleId}", scheduleId))
+                .andExpect(status().isNotFound)
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /events/schedules/{scheduleId}/status")
+    inner class ChangeScheduleStatus {
+
+        @Test
+        @DisplayName("200 OK - 회차 상태를 변경한다")
+        fun success() {
+            every { scheduleService.changeScheduleStatus(scheduleId, any()) } returns changeStatusResponse()
+
+            mockMvc.perform(
+                patch("/events/schedules/{scheduleId}/status", scheduleId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(ScheduleDto.ChangeStatusRequest(ScheduleStatus.ONGOING)))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.previousStatus").value("UPCOMING"))
+                .andExpect(jsonPath("$.currentStatus").value("ONGOING"))
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - status 누락")
+        fun badRequestMissingStatus() {
+            mockMvc.perform(
+                patch("/events/schedules/{scheduleId}/status", scheduleId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}")
+            )
+                .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - 유효하지 않은 상태 전이")
+        fun invalidTransition() {
+            every { scheduleService.changeScheduleStatus(scheduleId, any()) } throws EventException(ErrorCode.INVALID_SCHEDULE_STATUS)
+
+            mockMvc.perform(
+                patch("/events/schedules/{scheduleId}/status", scheduleId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(ScheduleDto.ChangeStatusRequest(ScheduleStatus.UPCOMING)))
+            )
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_SCHEDULE_STATUS"))
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 회차")
+        fun notFound() {
+            every { scheduleService.changeScheduleStatus(scheduleId, any()) } throws EventException(ErrorCode.SCHEDULE_NOT_FOUND)
+
+            mockMvc.perform(
+                patch("/events/schedules/{scheduleId}/status", scheduleId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(ScheduleDto.ChangeStatusRequest(ScheduleStatus.ONGOING)))
+            )
+                .andExpect(status().isNotFound)
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/entity/ScheduleStatusTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/entity/ScheduleStatusTest.kt
@@ -1,0 +1,218 @@
+package com.ticketqueue.event.entity
+
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.exception.EventException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.UUID
+
+class ScheduleStatusTest {
+
+    private val now = LocalDateTime.now()
+
+    private fun createVenue() = Venue(
+        id = UUID.randomUUID(), name = "올림픽공원",
+        address = "서울시 송파구", city = "서울",
+        createdAt = now, updatedAt = now
+    )
+
+    private fun createHall(venue: Venue) = Hall(
+        id = UUID.randomUUID(), venue = venue,
+        name = "KSPO DOME", capacity = 15000,
+        seatTemplate = """{"rows":["A"],"seatsPerRow":2,"gradeMapping":{"A":"VIP"}}""",
+        createdAt = now, updatedAt = now
+    )
+
+    private fun createEvent(venue: Venue, hall: Hall) = Event(
+        id = UUID.randomUUID(), title = "BTS World Tour", artist = "BTS",
+        venue = venue, hall = hall, createdAt = now, updatedAt = now
+    )
+
+    private fun createSchedule(event: Event, status: ScheduleStatus = ScheduleStatus.UPCOMING) = EventSchedule(
+        id = UUID.randomUUID(), event = event, playSequence = 1,
+        eventStartAt = now.plusDays(30), eventEndAt = now.plusDays(30).plusHours(2),
+        saleStartAt = now.plusDays(1), saleEndAt = now.plusDays(29),
+        status = status, createdAt = now, updatedAt = now
+    )
+
+    @Nested
+    @DisplayName("ScheduleStatus.canTransitionTo()")
+    inner class CanTransitionTo {
+
+        @Test
+        @DisplayName("UPCOMING → ONGOING 전이가 허용된다")
+        fun upcomingToOngoing() {
+            assertTrue(ScheduleStatus.UPCOMING.canTransitionTo(ScheduleStatus.ONGOING))
+        }
+
+        @Test
+        @DisplayName("UPCOMING → CANCELLED 전이가 허용된다")
+        fun upcomingToCancelled() {
+            assertTrue(ScheduleStatus.UPCOMING.canTransitionTo(ScheduleStatus.CANCELLED))
+        }
+
+        @Test
+        @DisplayName("ONGOING → ENDED 전이가 허용된다")
+        fun ongoingToEnded() {
+            assertTrue(ScheduleStatus.ONGOING.canTransitionTo(ScheduleStatus.ENDED))
+        }
+
+        @Test
+        @DisplayName("ONGOING → CANCELLED 전이가 허용된다")
+        fun ongoingToCancelled() {
+            assertTrue(ScheduleStatus.ONGOING.canTransitionTo(ScheduleStatus.CANCELLED))
+        }
+
+        @Test
+        @DisplayName("UPCOMING → ENDED 전이는 허용되지 않는다")
+        fun upcomingToEndedDenied() {
+            assertFalse(ScheduleStatus.UPCOMING.canTransitionTo(ScheduleStatus.ENDED))
+        }
+
+        @Test
+        @DisplayName("ENDED → UPCOMING 전이는 허용되지 않는다 (terminal)")
+        fun endedToUpcomingDenied() {
+            assertFalse(ScheduleStatus.ENDED.canTransitionTo(ScheduleStatus.UPCOMING))
+        }
+
+        @Test
+        @DisplayName("ENDED → ONGOING 전이는 허용되지 않는다 (terminal)")
+        fun endedToOngoingDenied() {
+            assertFalse(ScheduleStatus.ENDED.canTransitionTo(ScheduleStatus.ONGOING))
+        }
+
+        @Test
+        @DisplayName("ENDED → CANCELLED 전이는 허용되지 않는다 (terminal)")
+        fun endedToCancelledDenied() {
+            assertFalse(ScheduleStatus.ENDED.canTransitionTo(ScheduleStatus.CANCELLED))
+        }
+
+        @Test
+        @DisplayName("CANCELLED → UPCOMING 전이는 허용되지 않는다 (terminal)")
+        fun cancelledToUpcomingDenied() {
+            assertFalse(ScheduleStatus.CANCELLED.canTransitionTo(ScheduleStatus.UPCOMING))
+        }
+
+        @Test
+        @DisplayName("CANCELLED → ONGOING 전이는 허용되지 않는다 (terminal)")
+        fun cancelledToOngoingDenied() {
+            assertFalse(ScheduleStatus.CANCELLED.canTransitionTo(ScheduleStatus.ONGOING))
+        }
+
+        @Test
+        @DisplayName("CANCELLED → ENDED 전이는 허용되지 않는다 (terminal)")
+        fun cancelledToEndedDenied() {
+            assertFalse(ScheduleStatus.CANCELLED.canTransitionTo(ScheduleStatus.ENDED))
+        }
+
+        @Test
+        @DisplayName("ONGOING → UPCOMING 전이는 허용되지 않는다")
+        fun ongoingToUpcomingDenied() {
+            assertFalse(ScheduleStatus.ONGOING.canTransitionTo(ScheduleStatus.UPCOMING))
+        }
+    }
+
+    @Nested
+    @DisplayName("EventSchedule.changeStatus()")
+    inner class ChangeStatus {
+
+        @Test
+        @DisplayName("UPCOMING → ONGOING으로 상태 전이가 성공한다")
+        fun upcomingToOngoing() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event, ScheduleStatus.UPCOMING)
+
+            schedule.changeStatus(ScheduleStatus.ONGOING)
+
+            assertEquals(ScheduleStatus.ONGOING, schedule.status)
+        }
+
+        @Test
+        @DisplayName("UPCOMING → CANCELLED로 상태 전이가 성공한다")
+        fun upcomingToCancelled() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event, ScheduleStatus.UPCOMING)
+
+            schedule.changeStatus(ScheduleStatus.CANCELLED)
+
+            assertEquals(ScheduleStatus.CANCELLED, schedule.status)
+        }
+
+        @Test
+        @DisplayName("ONGOING → ENDED로 상태 전이가 성공한다")
+        fun ongoingToEnded() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event, ScheduleStatus.ONGOING)
+
+            schedule.changeStatus(ScheduleStatus.ENDED)
+
+            assertEquals(ScheduleStatus.ENDED, schedule.status)
+        }
+
+        @Test
+        @DisplayName("ONGOING → CANCELLED로 상태 전이가 성공한다")
+        fun ongoingToCancelled() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event, ScheduleStatus.ONGOING)
+
+            schedule.changeStatus(ScheduleStatus.CANCELLED)
+
+            assertEquals(ScheduleStatus.CANCELLED, schedule.status)
+        }
+
+        @Test
+        @DisplayName("ENDED → UPCOMING 전이 시 INVALID_SCHEDULE_STATUS 예외가 발생한다")
+        fun endedToUpcomingThrows() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event, ScheduleStatus.ENDED)
+
+            val ex = assertThrows(EventException::class.java) {
+                schedule.changeStatus(ScheduleStatus.UPCOMING)
+            }
+            assertEquals(ErrorCode.INVALID_SCHEDULE_STATUS, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("CANCELLED → ONGOING 전이 시 INVALID_SCHEDULE_STATUS 예외가 발생한다")
+        fun cancelledToOngoingThrows() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event, ScheduleStatus.CANCELLED)
+
+            val ex = assertThrows(EventException::class.java) {
+                schedule.changeStatus(ScheduleStatus.ONGOING)
+            }
+            assertEquals(ErrorCode.INVALID_SCHEDULE_STATUS, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("UPCOMING → ENDED 전이 시 예외가 발생한다 (ONGOING 건너뛰기 불가)")
+        fun upcomingToEndedThrows() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event, ScheduleStatus.UPCOMING)
+
+            assertThrows(EventException::class.java) {
+                schedule.changeStatus(ScheduleStatus.ENDED)
+            }
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/entity/ScheduleStatusTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/entity/ScheduleStatusTest.kt
@@ -210,9 +210,10 @@ class ScheduleStatusTest {
             val event = createEvent(venue, hall)
             val schedule = createSchedule(event, ScheduleStatus.UPCOMING)
 
-            assertThrows(EventException::class.java) {
+            val ex = assertThrows(EventException::class.java) {
                 schedule.changeStatus(ScheduleStatus.ENDED)
             }
+            assertEquals(ErrorCode.INVALID_SCHEDULE_STATUS, ex.errorCode)
         }
     }
 }

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/repository/ScheduleRepositoryIntegrationTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/repository/ScheduleRepositoryIntegrationTest.kt
@@ -1,0 +1,167 @@
+package com.ticketqueue.event.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.ticketqueue.event.entity.Event
+import com.ticketqueue.event.entity.EventSchedule
+import com.ticketqueue.event.entity.Hall
+import com.ticketqueue.event.entity.Venue
+import jakarta.persistence.EntityManagerFactory
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import javax.sql.DataSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.orm.jpa.SharedEntityManagerCreator
+import org.springframework.test.context.TestPropertySource
+import org.springframework.transaction.annotation.Transactional
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import java.time.LocalDateTime
+
+/**
+ * EventScheduleRepository 통합 테스트
+ *
+ * existsByEventIdAndPlaySequence 메서드를 PostgreSQL 18 환경에서 검증한다.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Import(ScheduleRepositoryIntegrationTest.RepositoryTestConfig::class)
+@TestPropertySource(properties = ["spring.jpa.hibernate.ddl-auto=create-drop"])
+@Transactional
+class ScheduleRepositoryIntegrationTest {
+
+    companion object {
+        @Container
+        @ServiceConnection
+        val postgres = PostgreSQLContainer<Nothing>(DockerImageName.parse("postgres:18-alpine"))
+            .apply {
+                withDatabaseName("testdb")
+                withUsername("test")
+                withPassword("test")
+                withInitScript("db_init/init.sql")
+            }
+    }
+
+    @TestConfiguration
+    class RepositoryTestConfig {
+        @Bean
+        fun jpaQueryFactory(emf: EntityManagerFactory): JPAQueryFactory =
+            JPAQueryFactory(SharedEntityManagerCreator.createSharedEntityManager(emf))
+    }
+
+    @Autowired private lateinit var dataSource: DataSource
+    @Autowired private lateinit var eventRepository: EventRepository
+    @Autowired private lateinit var venueRepository: VenueRepository
+    @Autowired private lateinit var hallRepository: HallRepository
+    @Autowired private lateinit var eventScheduleRepository: EventScheduleRepository
+
+    private val now: LocalDateTime = LocalDateTime.now()
+
+    @BeforeEach
+    fun cleanAll() {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("DELETE FROM event_service.seats")
+                stmt.execute("DELETE FROM event_service.event_schedules")
+                stmt.execute("DELETE FROM event_service.events")
+                stmt.execute("DELETE FROM event_service.halls")
+                stmt.execute("DELETE FROM event_service.venues")
+            }
+        }
+    }
+
+    private fun saveVenue(): Venue =
+        venueRepository.save(Venue(name = "올림픽공원", address = "서울시 송파구 올림픽로 25", city = "서울"))
+
+    private fun saveHall(venue: Venue): Hall =
+        hallRepository.save(
+            Hall(
+                venue = venue, name = "메인 홀", capacity = 15000,
+                seatTemplate = """{"rows":["A"],"seatsPerRow":2,"gradeMapping":{"A":"VIP"}}"""
+            )
+        )
+
+    private fun saveEvent(venue: Venue, hall: Hall): Event =
+        eventRepository.save(Event(title = "BTS World Tour", artist = "BTS", venue = venue, hall = hall))
+
+    private fun saveSchedule(event: Event, playSequence: Int): EventSchedule =
+        eventScheduleRepository.save(
+            EventSchedule(
+                event = event, playSequence = playSequence,
+                eventStartAt = now.plusDays(30),
+                eventEndAt = now.plusDays(30).plusHours(2),
+                saleStartAt = now.plusDays(1),
+                saleEndAt = now.plusDays(29)
+            )
+        )
+
+    @Nested
+    @DisplayName("existsByEventIdAndPlaySequence")
+    @Transactional
+    inner class ExistsByEventIdAndPlaySequence {
+
+        @Test
+        @DisplayName("동일 공연에 동일 순번의 회차가 존재하면 true를 반환한다")
+        fun existsReturnsTrue() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+            saveSchedule(event, playSequence = 1)
+
+            val result = eventScheduleRepository.existsByEventIdAndPlaySequence(event.id!!, 1)
+
+            assertTrue(result)
+        }
+
+        @Test
+        @DisplayName("동일 공연에 해당 순번의 회차가 없으면 false를 반환한다")
+        fun notExistsReturnsFalse() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+            saveSchedule(event, playSequence = 1)
+
+            val result = eventScheduleRepository.existsByEventIdAndPlaySequence(event.id!!, 2)
+
+            assertFalse(result)
+        }
+
+        @Test
+        @DisplayName("다른 공연의 동일 순번은 false를 반환한다")
+        fun differentEventReturnsFalse() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event1 = saveEvent(venue, hall)
+            val event2 = saveEvent(venue, hall)
+            saveSchedule(event1, playSequence = 1)
+
+            val result = eventScheduleRepository.existsByEventIdAndPlaySequence(event2.id!!, 1)
+
+            assertFalse(result)
+        }
+
+        @Test
+        @DisplayName("회차가 없는 공연은 false를 반환한다")
+        fun noSchedulesReturnsFalse() {
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+
+            val result = eventScheduleRepository.existsByEventIdAndPlaySequence(event.id!!, 1)
+
+            assertFalse(result)
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
@@ -1,0 +1,441 @@
+package com.ticketqueue.event.service
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.dto.ScheduleDto
+import com.ticketqueue.event.dto.SeatTemplateDto
+import com.ticketqueue.event.entity.Event
+import com.ticketqueue.event.entity.EventSchedule
+import com.ticketqueue.event.entity.Hall
+import com.ticketqueue.event.entity.Seat
+import com.ticketqueue.event.entity.ScheduleStatus
+import com.ticketqueue.event.entity.SeatGrade
+import com.ticketqueue.event.entity.Venue
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.repository.EventRepository
+import com.ticketqueue.event.repository.EventScheduleRepository
+import com.ticketqueue.event.repository.SeatRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.Optional
+import java.util.UUID
+
+class ScheduleServiceTest {
+
+    private lateinit var eventRepository: EventRepository
+    private lateinit var eventScheduleRepository: EventScheduleRepository
+    private lateinit var seatRepository: SeatRepository
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var scheduleService: ScheduleService
+
+    private val venueId = UUID.randomUUID()
+    private val hallId = UUID.randomUUID()
+    private val eventId = UUID.randomUUID()
+    private val scheduleId = UUID.randomUUID()
+    private val now = LocalDateTime.now()
+
+    private fun createVenue() = Venue(
+        id = venueId, name = "올림픽공원",
+        address = "서울시 송파구", city = "서울",
+        createdAt = now, updatedAt = now
+    )
+
+    private fun createHall(venue: Venue) = Hall(
+        id = hallId, venue = venue,
+        name = "KSPO DOME", capacity = 15000,
+        seatTemplate = """{"rows":["A"],"seatsPerRow":2,"gradeMapping":{"A":"VIP"}}""",
+        createdAt = now, updatedAt = now
+    )
+
+    private fun createEvent(venue: Venue, hall: Hall) = Event(
+        id = eventId, title = "BTS World Tour", artist = "BTS",
+        venue = venue, hall = hall, createdAt = now, updatedAt = now
+    )
+
+    private fun createSchedule(
+        event: Event,
+        status: ScheduleStatus = ScheduleStatus.UPCOMING
+    ) = EventSchedule(
+        id = scheduleId, event = event, playSequence = 1,
+        eventStartAt = now.plusDays(30), eventEndAt = now.plusDays(30).plusHours(2),
+        saleStartAt = now.plusDays(1), saleEndAt = now.plusDays(29),
+        status = status, createdAt = now, updatedAt = now
+    )
+
+    private val seatTemplate = SeatTemplateDto(
+        rows = listOf("A"),
+        seatsPerRow = 2,
+        gradeMapping = mapOf("A" to "VIP")
+    )
+
+    private val priceByGrade = mapOf(SeatGrade.VIP to BigDecimal("100000"))
+
+    private fun validCreateRequest(playSequence: Int = 1) = ScheduleDto.CreateRequest(
+        playSequence = playSequence,
+        eventStartAt = now.plusDays(30),
+        eventEndAt = now.plusDays(30).plusHours(2),
+        saleStartAt = now.plusDays(1),
+        saleEndAt = now.plusDays(29),
+        priceByGrade = priceByGrade
+    )
+
+    @BeforeEach
+    fun setUp() {
+        eventRepository = mockk()
+        eventScheduleRepository = mockk()
+        seatRepository = mockk()
+        objectMapper = mockk()
+        scheduleService = ScheduleService(eventRepository, eventScheduleRepository, seatRepository, objectMapper)
+    }
+
+    @Nested
+    @DisplayName("createSchedule")
+    inner class CreateSchedule {
+
+        @Test
+        @DisplayName("성공적으로 회차와 좌석을 생성한다")
+        fun success() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.existsByEventIdAndPlaySequence(eventId, 1) } returns false
+            every { objectMapper.readValue(any<String>(), SeatTemplateDto::class.java) } returns seatTemplate
+            every { eventScheduleRepository.save(any()) } returns schedule
+            every { seatRepository.saveAll(any<List<Seat>>()) } returns emptyList()
+
+            val result = scheduleService.createSchedule(eventId, validCreateRequest())
+
+            assertEquals(scheduleId, result.id)
+            assertEquals(eventId, result.eventId)
+            assertEquals(1, result.playSequence)
+            verify { seatRepository.saveAll(any<List<Seat>>()) }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 공연에 회차를 생성하면 EVENT_NOT_FOUND 예외가 발생한다")
+        fun eventNotFound() {
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns null
+
+            val ex = assertThrows<EventException> { scheduleService.createSchedule(eventId, validCreateRequest()) }
+            assertEquals(ErrorCode.EVENT_NOT_FOUND, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("회차 순번이 중복되면 DUPLICATE_PLAY_SEQUENCE 예외가 발생한다")
+        fun duplicatePlaySequence() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.existsByEventIdAndPlaySequence(eventId, 1) } returns true
+
+            val ex = assertThrows<EventException> { scheduleService.createSchedule(eventId, validCreateRequest()) }
+            assertEquals(ErrorCode.DUPLICATE_PLAY_SEQUENCE, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("공연 종료 시각이 시작 시각보다 빠르면 INVALID_SCHEDULE_TIME 예외가 발생한다")
+        fun invalidEventTime() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val request = validCreateRequest().copy(
+                eventStartAt = now.plusDays(30).plusHours(3),
+                eventEndAt = now.plusDays(30) // 종료 < 시작
+            )
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.existsByEventIdAndPlaySequence(eventId, 1) } returns false
+
+            val ex = assertThrows<EventException> { scheduleService.createSchedule(eventId, request) }
+            assertEquals(ErrorCode.INVALID_SCHEDULE_TIME, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("판매 종료 시각이 판매 시작 시각보다 빠르면 INVALID_SCHEDULE_TIME 예외가 발생한다")
+        fun invalidSaleTime() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val request = validCreateRequest().copy(
+                saleStartAt = now.plusDays(29),
+                saleEndAt = now.plusDays(1) // saleEnd < saleStart
+            )
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.existsByEventIdAndPlaySequence(eventId, 1) } returns false
+
+            val ex = assertThrows<EventException> { scheduleService.createSchedule(eventId, request) }
+            assertEquals(ErrorCode.INVALID_SCHEDULE_TIME, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("판매 종료 시각이 공연 시작 시각 이후이면 INVALID_SCHEDULE_TIME 예외가 발생한다")
+        fun saleEndAfterEventStart() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val request = validCreateRequest().copy(
+                saleEndAt = now.plusDays(31) // eventStartAt(+30일) 이후
+            )
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.existsByEventIdAndPlaySequence(eventId, 1) } returns false
+
+            val ex = assertThrows<EventException> { scheduleService.createSchedule(eventId, request) }
+            assertEquals(ErrorCode.INVALID_SCHEDULE_TIME, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("공연 시작 시각이 현재보다 과거이면 INVALID_SCHEDULE_TIME 예외가 발생한다")
+        fun eventStartInPast() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val request = validCreateRequest().copy(
+                eventStartAt = now.minusDays(1),
+                eventEndAt = now.minusDays(1).plusHours(2),
+                saleStartAt = now.minusDays(30),
+                saleEndAt = now.minusDays(2)
+            )
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.existsByEventIdAndPlaySequence(eventId, 1) } returns false
+
+            val ex = assertThrows<EventException> { scheduleService.createSchedule(eventId, request) }
+            assertEquals(ErrorCode.INVALID_SCHEDULE_TIME, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("좌석 템플릿 JSON 파싱 실패 시 INVALID_SEAT_TEMPLATE 예외가 발생한다")
+        fun invalidSeatTemplate() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.existsByEventIdAndPlaySequence(eventId, 1) } returns false
+            every { objectMapper.readValue(any<String>(), SeatTemplateDto::class.java) } throws
+                object : JsonProcessingException("invalid") {}
+
+            val ex = assertThrows<EventException> { scheduleService.createSchedule(eventId, validCreateRequest()) }
+            assertEquals(ErrorCode.INVALID_SEAT_TEMPLATE, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("행-등급 매핑이 누락되면 INVALID_SEAT_TEMPLATE_MAPPING 예외가 발생한다")
+        fun invalidSeatTemplateMapping() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+            val templateWithMissingGrade = SeatTemplateDto(
+                rows = listOf("A", "B"),
+                seatsPerRow = 1,
+                gradeMapping = mapOf("A" to "VIP") // B 행 매핑 없음
+            )
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.existsByEventIdAndPlaySequence(eventId, 1) } returns false
+            every { objectMapper.readValue(any<String>(), SeatTemplateDto::class.java) } returns templateWithMissingGrade
+            every { eventScheduleRepository.save(any()) } returns schedule
+
+            val ex = assertThrows<EventException> { scheduleService.createSchedule(eventId, validCreateRequest()) }
+            assertEquals(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("등급별 가격이 누락되면 INVALID_INPUT 예외가 발생한다")
+        fun missingGradePrice() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+            val templateWithSGrade = SeatTemplateDto(
+                rows = listOf("A"),
+                seatsPerRow = 1,
+                gradeMapping = mapOf("A" to "S") // S 등급인데 VIP 가격만 있음
+            )
+            val requestWithoutSPrice = validCreateRequest().copy(
+                priceByGrade = mapOf(SeatGrade.VIP to BigDecimal("100000"))
+            )
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.existsByEventIdAndPlaySequence(eventId, 1) } returns false
+            every { objectMapper.readValue(any<String>(), SeatTemplateDto::class.java) } returns templateWithSGrade
+            every { eventScheduleRepository.save(any()) } returns schedule
+
+            val ex = assertThrows<EventException> { scheduleService.createSchedule(eventId, requestWithoutSPrice) }
+            assertEquals(ErrorCode.INVALID_INPUT, ex.errorCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("getSchedules")
+    inner class GetSchedules {
+
+        @Test
+        @DisplayName("회차 목록을 isSoldOut 혼합으로 반환한다")
+        fun success() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val scheduleId2 = UUID.randomUUID()
+            val schedule1 = createSchedule(event)
+            val schedule2 = EventSchedule(
+                id = scheduleId2, event = event, playSequence = 2,
+                eventStartAt = now.plusDays(60), eventEndAt = now.plusDays(60).plusHours(2),
+                saleStartAt = now.plusDays(1), saleEndAt = now.plusDays(59),
+                createdAt = now, updatedAt = now
+            )
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns listOf(schedule1, schedule2)
+            every { eventRepository.findScheduleIdsWithAvailableSeats(any()) } returns setOf(scheduleId) // schedule1만 AVAILABLE
+
+            val result = scheduleService.getSchedules(eventId)
+
+            assertEquals(2, result.size)
+            assertFalse(result[0].isSoldOut) // schedule1: AVAILABLE 있음
+            assertTrue(result[1].isSoldOut)  // schedule2: AVAILABLE 없음
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 공연의 회차 목록 조회 시 EVENT_NOT_FOUND 예외가 발생한다")
+        fun eventNotFound() {
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns null
+
+            val ex = assertThrows<EventException> { scheduleService.getSchedules(eventId) }
+            assertEquals(ErrorCode.EVENT_NOT_FOUND, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("회차가 없는 공연은 빈 목록을 반환한다")
+        fun emptySchedules() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns emptyList()
+
+            val result = scheduleService.getSchedules(eventId)
+
+            assertTrue(result.isEmpty())
+        }
+    }
+
+    @Nested
+    @DisplayName("getSchedule")
+    inner class GetSchedule {
+
+        @Test
+        @DisplayName("회차 상세를 조회한다")
+        fun success() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+
+            every { eventScheduleRepository.findById(scheduleId) } returns Optional.of(schedule)
+            every { eventRepository.findScheduleIdsWithAvailableSeats(listOf(scheduleId)) } returns setOf(scheduleId)
+
+            val result = scheduleService.getSchedule(scheduleId)
+
+            assertEquals(scheduleId, result.id)
+            assertEquals(eventId, result.eventId)
+            assertEquals("BTS World Tour", result.eventTitle)
+            assertFalse(result.isSoldOut)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회차 조회 시 SCHEDULE_NOT_FOUND 예외가 발생한다")
+        fun notFound() {
+            every { eventScheduleRepository.findById(scheduleId) } returns Optional.empty()
+
+            val ex = assertThrows<EventException> { scheduleService.getSchedule(scheduleId) }
+            assertEquals(ErrorCode.SCHEDULE_NOT_FOUND, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("AVAILABLE 좌석이 없으면 isSoldOut이 true이다")
+        fun soldOut() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+
+            every { eventScheduleRepository.findById(scheduleId) } returns Optional.of(schedule)
+            every { eventRepository.findScheduleIdsWithAvailableSeats(listOf(scheduleId)) } returns emptySet()
+
+            val result = scheduleService.getSchedule(scheduleId)
+
+            assertTrue(result.isSoldOut)
+        }
+    }
+
+    @Nested
+    @DisplayName("changeScheduleStatus")
+    inner class ChangeScheduleStatus {
+
+        @Test
+        @DisplayName("유효한 상태 전이가 성공한다 (UPCOMING → ONGOING)")
+        fun validTransition() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event, ScheduleStatus.UPCOMING)
+            val request = ScheduleDto.ChangeStatusRequest(status = ScheduleStatus.ONGOING)
+
+            every { eventScheduleRepository.findById(scheduleId) } returns Optional.of(schedule)
+
+            val result = scheduleService.changeScheduleStatus(scheduleId, request)
+
+            assertEquals(ScheduleStatus.UPCOMING, result.previousStatus)
+            assertEquals(ScheduleStatus.ONGOING, result.currentStatus)
+            assertEquals(scheduleId, result.id)
+        }
+
+        @Test
+        @DisplayName("무효한 상태 전이 시 INVALID_SCHEDULE_STATUS 예외가 발생한다 (ENDED → UPCOMING)")
+        fun invalidTransition() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event, ScheduleStatus.ENDED)
+            val request = ScheduleDto.ChangeStatusRequest(status = ScheduleStatus.UPCOMING)
+
+            every { eventScheduleRepository.findById(scheduleId) } returns Optional.of(schedule)
+
+            val ex = assertThrows<EventException> { scheduleService.changeScheduleStatus(scheduleId, request) }
+            assertEquals(ErrorCode.INVALID_SCHEDULE_STATUS, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회차 상태 변경 시 SCHEDULE_NOT_FOUND 예외가 발생한다")
+        fun notFound() {
+            every { eventScheduleRepository.findById(scheduleId) } returns Optional.empty()
+
+            val ex = assertThrows<EventException> {
+                scheduleService.changeScheduleStatus(scheduleId, ScheduleDto.ChangeStatusRequest(ScheduleStatus.ONGOING))
+            }
+            assertEquals(ErrorCode.SCHEDULE_NOT_FOUND, ex.errorCode)
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
@@ -3,6 +3,7 @@ package com.ticketqueue.event.service
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.exception.ErrorCode
+import org.springframework.dao.DataIntegrityViolationException
 import com.ticketqueue.event.dto.ScheduleDto
 import com.ticketqueue.event.dto.SeatTemplateDto
 import com.ticketqueue.event.entity.Event
@@ -144,6 +145,22 @@ class ScheduleServiceTest {
 
             every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
             every { eventScheduleRepository.existsByEventIdAndPlaySequence(eventId, 1) } returns true
+
+            val ex = assertThrows<EventException> { scheduleService.createSchedule(eventId, validCreateRequest()) }
+            assertEquals(ErrorCode.DUPLICATE_PLAY_SEQUENCE, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("save() 시 DataIntegrityViolationException 발생하면 DUPLICATE_PLAY_SEQUENCE 예외로 변환된다 (race condition 방어)")
+        fun duplicatePlaySequenceOnSave() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.existsByEventIdAndPlaySequence(eventId, 1) } returns false
+            every { objectMapper.readValue(any<String>(), SeatTemplateDto::class.java) } returns seatTemplate
+            every { eventScheduleRepository.save(any()) } throws DataIntegrityViolationException("duplicate key")
 
             val ex = assertThrows<EventException> { scheduleService.createSchedule(eventId, validCreateRequest()) }
             assertEquals(ErrorCode.DUPLICATE_PLAY_SEQUENCE, ex.errorCode)


### PR DESCRIPTION
## Summary
- 기존 공연 생성 시 일괄 생성되던 회차(EventSchedule)에 대한 독립 CRUD API 구현
- 회차 상태 전이 검증 로직(`ScheduleStatus.canTransitionTo()`) 추가
- REQ-EVT-001, REQ-EVT-007 요구사항 충족

## Changes
- `ErrorCode`: `INVALID_SCHEDULE_STATUS` 에러 코드 추가
- `ScheduleStatus`: `canTransitionTo()` 메서드 추가 — `UPCOMING→ONGOING/CANCELLED`, `ONGOING→ENDED/CANCELLED`, `ENDED/CANCELLED`는 terminal
- `EventSchedule`: `changeStatus()` 도메인 메서드 추가 — 유효하지 않은 전이 시 `INVALID_SCHEDULE_STATUS` 예외
- `EventScheduleRepository`: `existsByEventIdAndPlaySequence()` 메서드 추가 (중복 순번 방지)
- `ScheduleDto`: CreateRequest/Response, ListResponse, DetailResponse, ChangeStatusRequest/Response
- `ScheduleService`: createSchedule(Hall seatTemplate 기반 좌석 자동 초기화), getSchedules, getSchedule, changeScheduleStatus
- `ScheduleController`: 4개 엔드포인트 구현
  - `POST /events/{eventId}/schedules` — 회차 생성 (ADMIN)
  - `GET /events/{eventId}/schedules` — 회차 목록 조회 (공개)
  - `GET /events/schedules/{scheduleId}` — 회차 상세 조회 (공개)
  - `PATCH /events/schedules/{scheduleId}/status` — 상태 변경 (ADMIN)

## Test plan
- [x] `ScheduleStatusTest` — 상태 전이 단위 테스트 (유효 4개 + 무효 7개 케이스)
- [x] `ScheduleServiceTest` — MockK 단위 테스트 (createSchedule 9개, getSchedules 3개, getSchedule 3개, changeScheduleStatus 3개)
- [x] `ScheduleControllerTest` — MockMvc 단위 테스트 (엔드포인트별 성공/에러 HTTP 상태 코드 검증)
- [x] `ScheduleRepositoryIntegrationTest` — Testcontainers(PostgreSQL 18) 통합 테스트 (`existsByEventIdAndPlaySequence` true/false/다른공연/회차없음 4케이스)
- [x] `./gradlew :event-service:test` — 전체 테스트 통과
- [x] `./gradlew :event-service:build` — 빌드 성공

Closes #34 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schedule management for events: create, list, view details, and update schedule status via API.
  * Automatic seat initialization from venue templates with price-by-grade support.

* **Bug Fixes / Validation**
  * Enforced schedule timing and duplicate-play-sequence checks to prevent invalid creations.
  * Strict state-transition validation with clear error responses for invalid status changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->