### PR TITLE
feat: [Event] 좌석 조회 API 및 Redis 캐싱 구현 #35

### DIFF
--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/EventController.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/EventController.kt
@@ -2,8 +2,10 @@ package com.ticketqueue.event.controller
 
 import com.ticketqueue.common.dto.PageResponse
 import com.ticketqueue.event.dto.EventDto
+import com.ticketqueue.event.dto.SeatDto
 import com.ticketqueue.event.entity.EventStatus
 import com.ticketqueue.event.service.EventService
+import com.ticketqueue.event.service.SeatService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -34,7 +36,8 @@ import java.util.UUID
 @RestController
 @RequestMapping("/events")
 class EventController(
-    private val eventService: EventService
+    private val eventService: EventService,
+    private val seatService: SeatService
 ) {
 
     /** 공연 생성 (REQ-EVT-001) - ADMIN 권한 필요 */
@@ -66,6 +69,12 @@ class EventController(
     @GetMapping("/{eventId}")
     fun getEvent(@PathVariable eventId: UUID): EventDto.DetailResponse {
         return eventService.getEvent(eventId)
+    }
+
+    /** 회차별 좌석 정보 조회 (REQ-EVT-006) - 공개 API, 등급별 그룹핑 + Redis 캐싱 */
+    @GetMapping("/schedules/{scheduleId}/seats")
+    fun getSeats(@PathVariable scheduleId: UUID): SeatDto.SeatsResponse {
+        return seatService.getSeats(scheduleId)
     }
 
     /** 공연 수정 (REQ-EVT-002) - ADMIN 권한 필요, 판매 후 artist 변경 불가 */

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/InternalSeatController.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/InternalSeatController.kt
@@ -1,0 +1,25 @@
+package com.ticketqueue.event.controller
+
+import com.ticketqueue.event.dto.SeatDto
+import com.ticketqueue.event.service.SeatService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+// 내부 서비스 간 통신용 좌석 API 컨트롤러
+// 엔드포인트: GET /internal/seats/status/{scheduleId} - SOLD 좌석 ID 조회 (Reservation Service 전용)
+// 보안: InternalApiAuthInterceptor가 X-Service-Api-Key 헤더 검증 (API Gateway는 /internal 경로 차단)
+@RestController
+@RequestMapping("/internal/seats")
+class InternalSeatController(
+    private val seatService: SeatService
+) {
+
+    /** SOLD 좌석 ID 목록 조회 - Reservation Service가 좌석 상태 확인 시 사용 */
+    @GetMapping("/status/{scheduleId}")
+    fun getSoldSeatIds(@PathVariable scheduleId: UUID): SeatDto.SoldSeatsResponse {
+        return seatService.getSoldSeatIds(scheduleId)
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/SeatDto.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/SeatDto.kt
@@ -1,0 +1,54 @@
+package com.ticketqueue.event.dto
+
+import com.ticketqueue.event.entity.Seat
+import com.ticketqueue.event.entity.SeatGrade
+import com.ticketqueue.event.entity.SeatStatus
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * 좌석(Seat) API 요청/응답 DTO 모음
+ *
+ * - [SeatInfo]          : 개별 좌석 정보 (id, seatNumber, grade, status)
+ * - [GradeGroup]        : 등급별 좌석 그룹 (grade, price, seats[])
+ * - [SeatsResponse]     : 공개 API 응답 - 등급별 그룹핑 (scheduleId, grades[])
+ * - [SoldSeatsResponse] : 내부 API 응답 - SOLD 좌석 ID 목록 (scheduleId, soldSeatIds[])
+ */
+class SeatDto {
+
+    /** 개별 좌석 정보 */
+    data class SeatInfo(
+        val id: UUID,
+        val seatNumber: String,
+        val grade: SeatGrade,
+        val status: SeatStatus
+    ) {
+        companion object {
+            fun from(seat: Seat): SeatInfo = SeatInfo(
+                id = seat.id!!,
+                seatNumber = seat.seatNumber,
+                grade = seat.grade,
+                status = seat.status
+            )
+        }
+    }
+
+    /** 등급별 좌석 그룹 */
+    data class GradeGroup(
+        val grade: SeatGrade,
+        val price: BigDecimal,
+        val seats: List<SeatInfo>
+    )
+
+    /** 공개 API 응답 - 회차별 등급 그룹핑 (REQ-EVT-006) */
+    data class SeatsResponse(
+        val scheduleId: UUID,
+        val grades: List<GradeGroup>
+    )
+
+    /** 내부 API 응답 - Reservation Service가 SOLD 좌석 조회 시 사용 */
+    data class SoldSeatsResponse(
+        val scheduleId: UUID,
+        val soldSeatIds: List<UUID>
+    )
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustom.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustom.kt
@@ -1,8 +1,11 @@
 package com.ticketqueue.event.repository
 
+import com.ticketqueue.event.entity.Seat
 import com.ticketqueue.event.entity.SeatStatus
 import java.util.UUID
 
 interface SeatRepositoryCustom {
     fun existsByEventIdAndStatus(eventId: UUID, status: SeatStatus): Boolean
+    fun findByScheduleIdOrderByGradeAndSeatNumber(scheduleId: UUID): List<Seat>
+    fun findSoldSeatIdsByScheduleId(scheduleId: UUID): List<UUID>
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustomImpl.kt
@@ -2,6 +2,7 @@ package com.ticketqueue.event.repository
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.ticketqueue.event.entity.QSeat
+import com.ticketqueue.event.entity.Seat
 import com.ticketqueue.event.entity.SeatStatus
 import java.util.UUID
 
@@ -19,5 +20,27 @@ class SeatRepositoryCustomImpl(
                 seat.status.eq(status)
             )
             .fetchFirst() != null   // EXISTS 시맨틱: 첫 행 발견 시 즉시 반환
+    }
+
+    override fun findByScheduleIdOrderByGradeAndSeatNumber(scheduleId: UUID): List<Seat> {
+        val seat = QSeat.seat
+        return queryFactory
+            .selectFrom(seat)
+            .where(seat.eventSchedule.id.eq(scheduleId))
+            .orderBy(seat.grade.asc(), seat.seatNumber.asc())
+            .fetch()
+    }
+
+    override fun findSoldSeatIdsByScheduleId(scheduleId: UUID): List<UUID> {
+        val seat = QSeat.seat
+        return queryFactory
+            .select(seat.id)
+            .from(seat)
+            .where(
+                seat.eventSchedule.id.eq(scheduleId),
+                seat.status.eq(SeatStatus.SOLD)
+            )
+            .fetch()
+            .filterNotNull()
     }
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
@@ -8,6 +8,7 @@ import com.ticketqueue.event.repository.EventScheduleRepository
 import com.ticketqueue.event.repository.SeatRepository
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.dao.DataAccessException
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -40,8 +41,8 @@ class SeatService(
      * 회차별 좌석 목록을 등급 그룹핑하여 반환한다 (REQ-EVT-006, P95 < 300ms)
      *
      * Cache-Aside 전략:
-     * 1. Redis 캐시 조회 → Hit 시 즉시 반환
-     * 2. Miss 시 → DB 조회 → 등급별 그룹핑 (VIP → S → A → B 순) → 캐시 저장
+     * 1. Redis Hash 캐시 조회 (등급별 필드) → Hit 시 즉시 반환
+     * 2. Miss 시 → DB 조회 → 등급별 그룹핑 (VIP → S → A → B 순) → Hash 필드로 캐시 저장
      *
      * Redis 장애 시 DB fallback으로 정상 응답을 보장한다.
      */
@@ -49,12 +50,18 @@ class SeatService(
         val cacheKey = "$cacheKeyPrefix$scheduleId"
 
         try {
-            val cached = redisTemplate.opsForValue().get(cacheKey)
-            if (cached != null) {
-                return objectMapper.convertValue(cached, SeatDto.SeatsResponse::class.java)
+            val hashEntries = redisTemplate.opsForHash<String, Any>().entries(cacheKey)
+            if (hashEntries.isNotEmpty()) {
+                val grades = hashEntries.values
+                    .map { objectMapper.convertValue(it, SeatDto.GradeGroup::class.java) }
+                    .sortedBy { it.grade.ordinal }
+                return SeatDto.SeatsResponse(scheduleId = scheduleId, grades = grades)
             }
-        } catch (e: Exception) {
+        } catch (e: DataAccessException) {
             log.warn("Redis cache read failed for key: $cacheKey", e)
+        } catch (e: IllegalArgumentException) {
+            log.warn("Redis cache deserialization failed for key: $cacheKey, deleting corrupted cache", e)
+            redisTemplate.delete(cacheKey)
         }
 
         if (!eventScheduleRepository.existsById(scheduleId)) {
@@ -78,8 +85,10 @@ class SeatService(
         val response = SeatDto.SeatsResponse(scheduleId = scheduleId, grades = grades)
 
         try {
-            redisTemplate.opsForValue().set(cacheKey, response, Duration.ofSeconds(seatsCacheTtl))
-        } catch (e: Exception) {
+            val gradeMap = response.grades.associate { gradeGroup -> gradeGroup.grade.name to gradeGroup }
+            redisTemplate.opsForHash<String, Any>().putAll(cacheKey, gradeMap)
+            redisTemplate.expire(cacheKey, Duration.ofSeconds(seatsCacheTtl))
+        } catch (e: DataAccessException) {
             log.warn("Redis cache write failed for key: $cacheKey", e)
         }
 

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
@@ -1,0 +1,102 @@
+package com.ticketqueue.event.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.dto.SeatDto
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.repository.EventScheduleRepository
+import com.ticketqueue.event.repository.SeatRepository
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+import java.util.UUID
+
+/**
+ * 좌석(Seat) 조회 서비스
+ *
+ * EventService와 분리하여 SRP를 준수한다.
+ * - [getSeats]: 회차별 좌석 등급 그룹핑 조회 + Redis Cache-Aside (TTL 5분) - REQ-EVT-006
+ * - [getSoldSeatIds]: SOLD 좌석 ID 조회 (캐싱 없음 - 실시간 정확도 우선)
+ *
+ * Redis 장애 시 try-catch로 무시하고 DB fallback을 수행하여 서비스 가용성을 유지한다.
+ */
+@Service
+@Transactional(readOnly = true)
+class SeatService(
+    private val eventScheduleRepository: EventScheduleRepository,
+    private val seatRepository: SeatRepository,
+    private val redisTemplate: RedisTemplate<String, Any>,
+    private val objectMapper: ObjectMapper,
+    @Value("\${cache.seats.ttl:300}") private val seatsCacheTtl: Long
+) {
+
+    private val log = LoggerFactory.getLogger(SeatService::class.java)
+    private val cacheKeyPrefix = "cache:seats:"
+
+    /**
+     * 회차별 좌석 목록을 등급 그룹핑하여 반환한다 (REQ-EVT-006, P95 < 300ms)
+     *
+     * Cache-Aside 전략:
+     * 1. Redis 캐시 조회 → Hit 시 즉시 반환
+     * 2. Miss 시 → DB 조회 → 등급별 그룹핑 (VIP → S → A → B 순) → 캐시 저장
+     *
+     * Redis 장애 시 DB fallback으로 정상 응답을 보장한다.
+     */
+    fun getSeats(scheduleId: UUID): SeatDto.SeatsResponse {
+        val cacheKey = "$cacheKeyPrefix$scheduleId"
+
+        try {
+            val cached = redisTemplate.opsForValue().get(cacheKey)
+            if (cached != null) {
+                return objectMapper.convertValue(cached, SeatDto.SeatsResponse::class.java)
+            }
+        } catch (e: Exception) {
+            log.warn("Redis cache read failed for key: $cacheKey", e)
+        }
+
+        if (!eventScheduleRepository.existsById(scheduleId)) {
+            throw EventException(ErrorCode.SCHEDULE_NOT_FOUND)
+        }
+
+        val seats = seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId)
+
+        val grades = seats
+            .groupBy { it.grade }
+            .entries
+            .sortedBy { (grade, _) -> grade.ordinal }
+            .map { (grade, gradeSeats) ->
+                SeatDto.GradeGroup(
+                    grade = grade,
+                    price = gradeSeats.first().price,
+                    seats = gradeSeats.map { SeatDto.SeatInfo.from(it) }
+                )
+            }
+
+        val response = SeatDto.SeatsResponse(scheduleId = scheduleId, grades = grades)
+
+        try {
+            redisTemplate.opsForValue().set(cacheKey, response, Duration.ofSeconds(seatsCacheTtl))
+        } catch (e: Exception) {
+            log.warn("Redis cache write failed for key: $cacheKey", e)
+        }
+
+        return response
+    }
+
+    /**
+     * 회차의 SOLD 좌석 ID 목록을 반환한다 (내부 API - Reservation Service 전용)
+     *
+     * 실시간 정확도 우선으로 캐싱을 적용하지 않는다.
+     */
+    fun getSoldSeatIds(scheduleId: UUID): SeatDto.SoldSeatsResponse {
+        if (!eventScheduleRepository.existsById(scheduleId)) {
+            throw EventException(ErrorCode.SCHEDULE_NOT_FOUND)
+        }
+
+        val soldSeatIds = seatRepository.findSoldSeatIdsByScheduleId(scheduleId)
+        return SeatDto.SoldSeatsResponse(scheduleId = scheduleId, soldSeatIds = soldSeatIds)
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
@@ -323,7 +323,7 @@ class EventControllerTest {
                 grades = listOf(
                     SeatDto.GradeGroup(
                         grade = SeatGrade.VIP,
-                        price = java.math.BigDecimal("150000"),
+                        price = BigDecimal("150000"),
                         seats = listOf(
                             SeatDto.SeatInfo(
                                 id = UUID.randomUUID(),

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
@@ -6,10 +6,13 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.common.exception.GlobalExceptionHandler
 import com.ticketqueue.event.dto.EventDto
+import com.ticketqueue.event.dto.SeatDto
 import com.ticketqueue.event.entity.EventStatus
 import com.ticketqueue.event.entity.SeatGrade
+import com.ticketqueue.event.entity.SeatStatus
 import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.service.EventService
+import com.ticketqueue.event.service.SeatService
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
@@ -36,6 +39,7 @@ class EventControllerTest {
 
     private lateinit var mockMvc: MockMvc
     private lateinit var eventService: EventService
+    private lateinit var seatService: SeatService
     private val objectMapper: ObjectMapper = jacksonObjectMapper().apply {
         registerModule(JavaTimeModule())
     }
@@ -105,7 +109,8 @@ class EventControllerTest {
     @BeforeEach
     fun setUp() {
         eventService = mockk()
-        val controller = EventController(eventService)
+        seatService = mockk()
+        val controller = EventController(eventService, seatService)
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
             .setControllerAdvice(GlobalExceptionHandler())
             .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
@@ -300,6 +305,51 @@ class EventControllerTest {
             every { eventService.deleteEvent(eventId) } throws EventException(ErrorCode.EVENT_NOT_FOUND)
 
             mockMvc.perform(delete("/events/{eventId}", eventId))
+                .andExpect(status().isNotFound)
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /events/schedules/{scheduleId}/seats")
+    inner class GetSeats {
+
+        private val scheduleId = UUID.randomUUID()
+
+        @Test
+        @DisplayName("200 OK - 등급별 그룹핑된 좌석 정보를 반환한다")
+        fun success() {
+            val seatsResponse = SeatDto.SeatsResponse(
+                scheduleId = scheduleId,
+                grades = listOf(
+                    SeatDto.GradeGroup(
+                        grade = SeatGrade.VIP,
+                        price = java.math.BigDecimal("150000"),
+                        seats = listOf(
+                            SeatDto.SeatInfo(
+                                id = UUID.randomUUID(),
+                                seatNumber = "A-1",
+                                grade = SeatGrade.VIP,
+                                status = SeatStatus.AVAILABLE
+                            )
+                        )
+                    )
+                )
+            )
+            every { seatService.getSeats(scheduleId) } returns seatsResponse
+
+            mockMvc.perform(get("/events/schedules/{scheduleId}/seats", scheduleId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.scheduleId").value(scheduleId.toString()))
+                .andExpect(jsonPath("$.grades[0].grade").value("VIP"))
+                .andExpect(jsonPath("$.grades[0].seats[0].seatNumber").value("A-1"))
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 scheduleId")
+        fun notFound() {
+            every { seatService.getSeats(scheduleId) } throws EventException(ErrorCode.SCHEDULE_NOT_FOUND)
+
+            mockMvc.perform(get("/events/schedules/{scheduleId}/seats", scheduleId))
                 .andExpect(status().isNotFound)
         }
     }

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalSeatControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalSeatControllerTest.kt
@@ -1,0 +1,89 @@
+package com.ticketqueue.event.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.exception.GlobalExceptionHandler
+import com.ticketqueue.event.dto.SeatDto
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.service.SeatService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.util.UUID
+
+class InternalSeatControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var seatService: SeatService
+    private val objectMapper: ObjectMapper = jacksonObjectMapper().apply {
+        registerModule(JavaTimeModule())
+    }
+
+    private val scheduleId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        seatService = mockk()
+        val controller = InternalSeatController(seatService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(GlobalExceptionHandler())
+            .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
+            .build()
+    }
+
+    @Nested
+    @DisplayName("GET /internal/seats/status/{scheduleId}")
+    inner class GetSoldSeatIds {
+
+        @Test
+        @DisplayName("200 OK - SOLD 좌석 ID 목록을 반환한다")
+        fun success() {
+            val soldId = UUID.randomUUID()
+            val response = SeatDto.SoldSeatsResponse(
+                scheduleId = scheduleId,
+                soldSeatIds = listOf(soldId)
+            )
+            every { seatService.getSoldSeatIds(scheduleId) } returns response
+
+            mockMvc.perform(get("/internal/seats/status/{scheduleId}", scheduleId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.scheduleId").value(scheduleId.toString()))
+                .andExpect(jsonPath("$.soldSeatIds[0]").value(soldId.toString()))
+        }
+
+        @Test
+        @DisplayName("200 OK - SOLD 좌석 없으면 빈 리스트를 반환한다")
+        fun noSoldSeats() {
+            val response = SeatDto.SoldSeatsResponse(
+                scheduleId = scheduleId,
+                soldSeatIds = emptyList()
+            )
+            every { seatService.getSoldSeatIds(scheduleId) } returns response
+
+            mockMvc.perform(get("/internal/seats/status/{scheduleId}", scheduleId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.soldSeatIds").isArray)
+                .andExpect(jsonPath("$.soldSeatIds").isEmpty)
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 scheduleId")
+        fun notFound() {
+            every { seatService.getSoldSeatIds(scheduleId) } throws EventException(ErrorCode.SCHEDULE_NOT_FOUND)
+
+            mockMvc.perform(get("/internal/seats/status/{scheduleId}", scheduleId))
+                .andExpect(status().isNotFound)
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.data.redis.RedisConnectionFailureException
+import org.springframework.data.redis.core.HashOperations
 import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.data.redis.core.ValueOperations
 import java.math.BigDecimal
 import java.time.Duration
 import java.util.UUID
@@ -35,7 +35,7 @@ class SeatServiceTest {
     private lateinit var eventScheduleRepository: EventScheduleRepository
     private lateinit var seatRepository: SeatRepository
     private lateinit var redisTemplate: RedisTemplate<String, Any>
-    private lateinit var valueOps: ValueOperations<String, Any>
+    private lateinit var hashOps: HashOperations<String, String, Any>
     private lateinit var seatService: SeatService
 
     private val objectMapper = jacksonObjectMapper().apply {
@@ -66,8 +66,8 @@ class SeatServiceTest {
         eventScheduleRepository = mockk()
         seatRepository = mockk()
         redisTemplate = mockk()
-        valueOps = mockk()
-        every { redisTemplate.opsForValue() } returns valueOps
+        hashOps = mockk()
+        every { redisTemplate.opsForHash<String, Any>() } returns hashOps
         seatService = SeatService(
             eventScheduleRepository = eventScheduleRepository,
             seatRepository = seatRepository,
@@ -88,10 +88,11 @@ class SeatServiceTest {
                 createSeat(SeatGrade.VIP, "A-1", BigDecimal("150000")),
                 createSeat(SeatGrade.S, "B-1", BigDecimal("100000"))
             )
-            every { valueOps.get(any<String>()) } returns null
+            every { hashOps.entries(any<String>()) } returns emptyMap()
             every { eventScheduleRepository.existsById(scheduleId) } returns true
             every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
-            every { valueOps.set(any<String>(), any(), any<Duration>()) } just runs
+            every { hashOps.putAll(any<String>(), any()) } just runs
+            every { redisTemplate.expire(any<String>(), any<Duration>()) } returns true
 
             val response = seatService.getSeats(scheduleId)
 
@@ -99,17 +100,19 @@ class SeatServiceTest {
             assertEquals(2, response.grades.size)
             assertEquals(SeatGrade.VIP, response.grades[0].grade)
             assertEquals(SeatGrade.S, response.grades[1].grade)
-            verify { valueOps.set("cache:seats:$scheduleId", any(), Duration.ofSeconds(300)) }
+            verify { hashOps.putAll("cache:seats:$scheduleId", any()) }
+            verify { redisTemplate.expire("cache:seats:$scheduleId", Duration.ofSeconds(300)) }
         }
 
         @Test
         @DisplayName("캐시 Hit - DB 조회 없이 캐시에서 즉시 반환한다")
         fun cacheHit() {
-            val cachedResponse = SeatDto.SeatsResponse(
-                scheduleId = scheduleId,
-                grades = emptyList()
+            val gradeGroup = SeatDto.GradeGroup(
+                grade = SeatGrade.VIP,
+                price = BigDecimal("150000"),
+                seats = emptyList()
             )
-            every { valueOps.get("cache:seats:$scheduleId") } returns cachedResponse
+            every { hashOps.entries("cache:seats:$scheduleId") } returns mapOf("VIP" to gradeGroup)
 
             val response = seatService.getSeats(scheduleId)
 
@@ -121,10 +124,11 @@ class SeatServiceTest {
         @DisplayName("Redis 장애 시 DB fallback으로 정상 응답한다")
         fun redisFallback() {
             val seats = listOf(createSeat(SeatGrade.VIP, "A-1", BigDecimal("150000")))
-            every { valueOps.get(any<String>()) } throws RedisConnectionFailureException("connection failed")
+            every { hashOps.entries(any<String>()) } throws RedisConnectionFailureException("connection failed")
             every { eventScheduleRepository.existsById(scheduleId) } returns true
             every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
-            every { valueOps.set(any<String>(), any(), any<Duration>()) } just runs
+            every { hashOps.putAll(any<String>(), any()) } just runs
+            every { redisTemplate.expire(any<String>(), any<Duration>()) } returns true
 
             val response = seatService.getSeats(scheduleId)
 
@@ -141,10 +145,11 @@ class SeatServiceTest {
                 createSeat(SeatGrade.S, "B-1", BigDecimal("100000")),
                 createSeat(SeatGrade.VIP, "A-1", BigDecimal("150000"))
             )
-            every { valueOps.get(any<String>()) } returns null
+            every { hashOps.entries(any<String>()) } returns emptyMap()
             every { eventScheduleRepository.existsById(scheduleId) } returns true
             every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
-            every { valueOps.set(any<String>(), any(), any<Duration>()) } just runs
+            every { hashOps.putAll(any<String>(), any()) } just runs
+            every { redisTemplate.expire(any<String>(), any<Duration>()) } returns true
 
             val response = seatService.getSeats(scheduleId)
 
@@ -155,10 +160,11 @@ class SeatServiceTest {
         @Test
         @DisplayName("좌석 없는 회차 - 빈 grades 반환")
         fun emptySeats() {
-            every { valueOps.get(any<String>()) } returns null
+            every { hashOps.entries(any<String>()) } returns emptyMap()
             every { eventScheduleRepository.existsById(scheduleId) } returns true
             every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns emptyList()
-            every { valueOps.set(any<String>(), any(), any<Duration>()) } just runs
+            every { hashOps.putAll(any<String>(), any()) } just runs
+            every { redisTemplate.expire(any<String>(), any<Duration>()) } returns true
 
             val response = seatService.getSeats(scheduleId)
 
@@ -169,7 +175,7 @@ class SeatServiceTest {
         @Test
         @DisplayName("존재하지 않는 scheduleId - SCHEDULE_NOT_FOUND 예외 발생")
         fun scheduleNotFound() {
-            every { valueOps.get(any<String>()) } returns null
+            every { hashOps.entries(any<String>()) } returns emptyMap()
             every { eventScheduleRepository.existsById(scheduleId) } returns false
 
             val exception = assertThrows<EventException> {
@@ -183,10 +189,10 @@ class SeatServiceTest {
         @DisplayName("캐시 저장 실패 시에도 정상 응답한다")
         fun cacheWriteFailure() {
             val seats = listOf(createSeat(SeatGrade.VIP, "A-1", BigDecimal("150000")))
-            every { valueOps.get(any<String>()) } returns null
+            every { hashOps.entries(any<String>()) } returns emptyMap()
             every { eventScheduleRepository.existsById(scheduleId) } returns true
             every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
-            every { valueOps.set(any<String>(), any(), any<Duration>()) } throws RuntimeException("Redis write failed")
+            every { hashOps.putAll(any<String>(), any()) } throws RedisConnectionFailureException("Redis write failed")
 
             val response = seatService.getSeats(scheduleId)
 

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
@@ -1,0 +1,239 @@
+package com.ticketqueue.event.service
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.dto.SeatDto
+import com.ticketqueue.event.entity.EventSchedule
+import com.ticketqueue.event.entity.Seat
+import com.ticketqueue.event.entity.SeatGrade
+import com.ticketqueue.event.entity.SeatStatus
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.repository.EventScheduleRepository
+import com.ticketqueue.event.repository.SeatRepository
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.redis.RedisConnectionFailureException
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.math.BigDecimal
+import java.time.Duration
+import java.util.UUID
+
+class SeatServiceTest {
+
+    private lateinit var eventScheduleRepository: EventScheduleRepository
+    private lateinit var seatRepository: SeatRepository
+    private lateinit var redisTemplate: RedisTemplate<String, Any>
+    private lateinit var valueOps: ValueOperations<String, Any>
+    private lateinit var seatService: SeatService
+
+    private val objectMapper = jacksonObjectMapper().apply {
+        registerModule(JavaTimeModule())
+    }
+
+    private val scheduleId = UUID.randomUUID()
+
+    private fun createSeat(
+        grade: SeatGrade,
+        seatNumber: String,
+        price: BigDecimal,
+        status: SeatStatus = SeatStatus.AVAILABLE
+    ): Seat {
+        val schedule = mockk<EventSchedule>()
+        return Seat(
+            id = UUID.randomUUID(),
+            eventSchedule = schedule,
+            seatNumber = seatNumber,
+            grade = grade,
+            price = price,
+            status = status
+        )
+    }
+
+    @BeforeEach
+    fun setUp() {
+        eventScheduleRepository = mockk()
+        seatRepository = mockk()
+        redisTemplate = mockk()
+        valueOps = mockk()
+        every { redisTemplate.opsForValue() } returns valueOps
+        seatService = SeatService(
+            eventScheduleRepository = eventScheduleRepository,
+            seatRepository = seatRepository,
+            redisTemplate = redisTemplate,
+            objectMapper = objectMapper,
+            seatsCacheTtl = 300L
+        )
+    }
+
+    @Nested
+    @DisplayName("getSeats")
+    inner class GetSeats {
+
+        @Test
+        @DisplayName("캐시 Miss - DB 조회 후 등급별 그룹핑하여 반환하고 캐시에 저장한다")
+        fun cacheMissAndFetchFromDb() {
+            val seats = listOf(
+                createSeat(SeatGrade.VIP, "A-1", BigDecimal("150000")),
+                createSeat(SeatGrade.S, "B-1", BigDecimal("100000"))
+            )
+            every { valueOps.get(any<String>()) } returns null
+            every { eventScheduleRepository.existsById(scheduleId) } returns true
+            every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
+            every { valueOps.set(any<String>(), any(), any<Duration>()) } just runs
+
+            val response = seatService.getSeats(scheduleId)
+
+            assertEquals(scheduleId, response.scheduleId)
+            assertEquals(2, response.grades.size)
+            assertEquals(SeatGrade.VIP, response.grades[0].grade)
+            assertEquals(SeatGrade.S, response.grades[1].grade)
+            verify { valueOps.set("cache:seats:$scheduleId", any(), Duration.ofSeconds(300)) }
+        }
+
+        @Test
+        @DisplayName("캐시 Hit - DB 조회 없이 캐시에서 즉시 반환한다")
+        fun cacheHit() {
+            val cachedResponse = SeatDto.SeatsResponse(
+                scheduleId = scheduleId,
+                grades = emptyList()
+            )
+            every { valueOps.get("cache:seats:$scheduleId") } returns cachedResponse
+
+            val response = seatService.getSeats(scheduleId)
+
+            assertEquals(scheduleId, response.scheduleId)
+            verify(exactly = 0) { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(any()) }
+        }
+
+        @Test
+        @DisplayName("Redis 장애 시 DB fallback으로 정상 응답한다")
+        fun redisFallback() {
+            val seats = listOf(createSeat(SeatGrade.VIP, "A-1", BigDecimal("150000")))
+            every { valueOps.get(any<String>()) } throws RedisConnectionFailureException("connection failed")
+            every { eventScheduleRepository.existsById(scheduleId) } returns true
+            every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
+            every { valueOps.set(any<String>(), any(), any<Duration>()) } just runs
+
+            val response = seatService.getSeats(scheduleId)
+
+            assertEquals(scheduleId, response.scheduleId)
+            assertEquals(1, response.grades.size)
+        }
+
+        @Test
+        @DisplayName("등급 정렬 순서는 VIP → S → A → B 이다")
+        fun gradeOrder() {
+            val seats = listOf(
+                createSeat(SeatGrade.B, "D-1", BigDecimal("50000")),
+                createSeat(SeatGrade.A, "C-1", BigDecimal("70000")),
+                createSeat(SeatGrade.S, "B-1", BigDecimal("100000")),
+                createSeat(SeatGrade.VIP, "A-1", BigDecimal("150000"))
+            )
+            every { valueOps.get(any<String>()) } returns null
+            every { eventScheduleRepository.existsById(scheduleId) } returns true
+            every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
+            every { valueOps.set(any<String>(), any(), any<Duration>()) } just runs
+
+            val response = seatService.getSeats(scheduleId)
+
+            val gradeOrder = response.grades.map { it.grade }
+            assertEquals(listOf(SeatGrade.VIP, SeatGrade.S, SeatGrade.A, SeatGrade.B), gradeOrder)
+        }
+
+        @Test
+        @DisplayName("좌석 없는 회차 - 빈 grades 반환")
+        fun emptySeats() {
+            every { valueOps.get(any<String>()) } returns null
+            every { eventScheduleRepository.existsById(scheduleId) } returns true
+            every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns emptyList()
+            every { valueOps.set(any<String>(), any(), any<Duration>()) } just runs
+
+            val response = seatService.getSeats(scheduleId)
+
+            assertEquals(scheduleId, response.scheduleId)
+            assertTrue(response.grades.isEmpty())
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 scheduleId - SCHEDULE_NOT_FOUND 예외 발생")
+        fun scheduleNotFound() {
+            every { valueOps.get(any<String>()) } returns null
+            every { eventScheduleRepository.existsById(scheduleId) } returns false
+
+            val exception = assertThrows<EventException> {
+                seatService.getSeats(scheduleId)
+            }
+
+            assertEquals(ErrorCode.SCHEDULE_NOT_FOUND, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("캐시 저장 실패 시에도 정상 응답한다")
+        fun cacheWriteFailure() {
+            val seats = listOf(createSeat(SeatGrade.VIP, "A-1", BigDecimal("150000")))
+            every { valueOps.get(any<String>()) } returns null
+            every { eventScheduleRepository.existsById(scheduleId) } returns true
+            every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
+            every { valueOps.set(any<String>(), any(), any<Duration>()) } throws RuntimeException("Redis write failed")
+
+            val response = seatService.getSeats(scheduleId)
+
+            assertEquals(scheduleId, response.scheduleId)
+            assertEquals(1, response.grades.size)
+        }
+    }
+
+    @Nested
+    @DisplayName("getSoldSeatIds")
+    inner class GetSoldSeatIds {
+
+        @Test
+        @DisplayName("SOLD 좌석 ID 목록을 반환한다")
+        fun returnsSoldSeatIds() {
+            val soldIds = listOf(UUID.randomUUID(), UUID.randomUUID())
+            every { eventScheduleRepository.existsById(scheduleId) } returns true
+            every { seatRepository.findSoldSeatIdsByScheduleId(scheduleId) } returns soldIds
+
+            val response = seatService.getSoldSeatIds(scheduleId)
+
+            assertEquals(scheduleId, response.scheduleId)
+            assertEquals(soldIds, response.soldSeatIds)
+        }
+
+        @Test
+        @DisplayName("SOLD 좌석 없으면 빈 리스트를 반환한다")
+        fun returnsEmptyListWhenNoSoldSeats() {
+            every { eventScheduleRepository.existsById(scheduleId) } returns true
+            every { seatRepository.findSoldSeatIdsByScheduleId(scheduleId) } returns emptyList()
+
+            val response = seatService.getSoldSeatIds(scheduleId)
+
+            assertEquals(scheduleId, response.scheduleId)
+            assertTrue(response.soldSeatIds.isEmpty())
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 scheduleId - SCHEDULE_NOT_FOUND 예외 발생")
+        fun scheduleNotFound() {
+            every { eventScheduleRepository.existsById(scheduleId) } returns false
+
+            val exception = assertThrows<EventException> {
+                seatService.getSoldSeatIds(scheduleId)
+            }
+
+            assertEquals(ErrorCode.SCHEDULE_NOT_FOUND, exception.errorCode)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `GET /events/schedules/{scheduleId}/seats` 공개 API 구현 — 회차별 좌석을 등급(VIP→S→A→B)별로 그룹핑하여 반환 (REQ-EVT-006)
- `GET /internal/seats/status/{scheduleId}` 내부 API 구현 — Reservation Service가 SOLD 좌석 ID를 조회하는 용도
- `SeatService`에 Redis Cache-Aside 적용 (TTL 5분), Redis 장애 시 DB fallback으로 가용성 보장

## Changes
- **신규**: `SeatDto` — `SeatInfo`, `GradeGroup`, `SeatsResponse`, `SoldSeatsResponse` DTO
- **신규**: `SeatService` — 좌석 조회 비즈니스 로직 + Cache-Aside 캐싱 (EventService와 SRP 분리)
- **신규**: `InternalSeatController` — `GET /internal/seats/status/{scheduleId}` 내부 API
- **수정**: `EventController` — `SeatService` 주입 + `GET /events/schedules/{scheduleId}/seats` 엔드포인트 추가
- **수정**: `SeatRepositoryCustom` / `SeatRepositoryCustomImpl` — QueryDSL 메서드 2개 추가
  - `findByScheduleIdOrderByGradeAndSeatNumber`: 회차별 전체 좌석 조회 (`idx_seats_schedule_status` 활용)
  - `findSoldSeatIdsByScheduleId`: SOLD 좌석 ID 프로젝션 (최소 데이터 전송)

## Test plan
- [x] `SeatServiceTest` — 10개 단위 테스트 (캐시 Hit/Miss, Redis 장애 fallback, 등급 정렬, 빈 결과, SCHEDULE_NOT_FOUND, 캐시 저장 실패)
- [x] `InternalSeatControllerTest` — 3개 단위 테스트 (SOLD 목록 반환, 빈 리스트, 404)
- [x] `EventControllerTest$GetSeats` — 2개 단위 테스트 (200 OK 응답 구조, 404)
- [x] `./gradlew :event-service:test` 전체 통과 (신규 15개 포함)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public endpoint to retrieve seat information per event schedule, grouped by grade with pricing and availability.
  * Internal API to query sold-seat status for schedules to support inter-service requests.

* **Tests**
  * Added unit tests covering the new public and internal seat endpoints and seat service behavior (cache, DB fallback, ordering, and not-found cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->