### PR TITLE
feat: [Queue] 서비스 초기 설정 - common 모듈 호환성, config.import, Lua 스크립트 #40

### DIFF
--- a/backend/common/src/main/kotlin/com/ticketqueue/common/config/QuerydslConfig.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/config/QuerydslConfig.kt
@@ -2,7 +2,9 @@ package com.ticketqueue.common.config
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import jakarta.persistence.EntityManager
+import jakarta.persistence.EntityManagerFactory
 import jakarta.persistence.PersistenceContext
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -10,8 +12,10 @@ import org.springframework.context.annotation.Configuration
  * Querydsl 설정
  * - JPAQueryFactory Bean을 제공하여 타입 안전한 JPQL 쿼리 작성 지원
  * - Custom Repository 구현체에서 벌크 연산 등에 사용
+ * - @ConditionalOnBean(EntityManagerFactory::class): JPA가 없는 서비스(Queue 등)에서 자동 제외
  */
 @Configuration
+@ConditionalOnBean(EntityManagerFactory::class)
 class QuerydslConfig(
     @PersistenceContext
     private val entityManager: EntityManager

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/QueueServiceApplication.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/QueueServiceApplication.kt
@@ -1,7 +1,6 @@
 package com.ticketqueue.queue
 
 import com.ticketqueue.common.config.CommonJpaConfig
-import com.ticketqueue.common.config.QuerydslConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
@@ -22,7 +21,7 @@ import org.springframework.context.annotation.FilterType
     excludeFilters = [
         ComponentScan.Filter(
             type = FilterType.ASSIGNABLE_TYPE,
-            classes = [QuerydslConfig::class, CommonJpaConfig::class]
+            classes = [CommonJpaConfig::class]
         )
     ]
 )

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/QueueServiceApplication.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/QueueServiceApplication.kt
@@ -1,13 +1,29 @@
 package com.ticketqueue.queue
 
+import com.ticketqueue.common.config.CommonJpaConfig
+import com.ticketqueue.common.config.QuerydslConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
 
 @SpringBootApplication(
-    scanBasePackages = ["com.ticketqueue.queue", "com.ticketqueue.common"],
-    excludeName = [
-        "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration",
-        "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration"
+    exclude = [
+        DataSourceAutoConfiguration::class,
+        HibernateJpaAutoConfiguration::class,
+        DataSourceTransactionManagerAutoConfiguration::class
+    ]
+)
+@ComponentScan(
+    basePackages = ["com.ticketqueue.queue", "com.ticketqueue.common"],
+    excludeFilters = [
+        ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = [QuerydslConfig::class, CommonJpaConfig::class]
+        )
     ]
 )
 class QueueServiceApplication

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/RedisConfig.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/RedisConfig.kt
@@ -2,9 +2,11 @@ package com.ticketqueue.queue.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.ClassPathResource
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.script.DefaultRedisScript
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.StringRedisSerializer
 
@@ -25,5 +27,22 @@ class RedisConfig {
     @Bean
     fun stringRedisTemplate(connectionFactory: RedisConnectionFactory): StringRedisTemplate {
         return StringRedisTemplate(connectionFactory)
+    }
+
+    /**
+     * 배치 승인 Lua 스크립트 (REQ-QUEUE-005)
+     *
+     * Sorted Set에서 상위 N명을 원자적으로 추출 및 제거한다.
+     *
+     * KEYS[1]: queue:{scheduleId}
+     * ARGV[1]: batchSize (기본 10)
+     * @return 승인된 userId 목록
+     */
+    @Bean
+    fun batchApproveScript(): DefaultRedisScript<List<*>> {
+        return DefaultRedisScript<List<*>>().apply {
+            setLocation(ClassPathResource("lua/batch-approve.lua"))
+            setResultType(List::class.java)
+        }
     }
 }

--- a/backend/queue-service/src/main/resources/application.yml
+++ b/backend/queue-service/src/main/resources/application.yml
@@ -4,27 +4,21 @@ server:
 spring:
   application:
     name: queue-service
-
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
-
-  data:
-    redis:
-      host: 192.168.50.111
-      port: 6379
+  config:
+    import:
+      - "optional:classpath:/application-common-${spring.profiles.active}.yml"
+      - "optional:aws-secretsmanager:queue-svc/secure-config"
+      - "optional:aws-secretsmanager:common/secure-config"
 
 queue:
   batch:
-    size: 10  # Approve 10 users per second
-    interval: 1000  # 1 second in milliseconds
+    size: 10
+    interval: 1000
   token:
-    ttl: 600  # 10 minutes in seconds
-  max-capacity: 50000  # Maximum users per schedule queue
+    ttl: 600
+  max-capacity: 50000
   active-user:
-    ttl: 600  # 10 minutes - prevent duplicate queue entry
+    ttl: 600
 
 management:
   endpoints:

--- a/backend/queue-service/src/main/resources/lua/batch-approve.lua
+++ b/backend/queue-service/src/main/resources/lua/batch-approve.lua
@@ -1,0 +1,21 @@
+--[[
+  배치 승인 Lua 스크립트 (REQ-QUEUE-005)
+
+  대기열 Sorted Set에서 상위 N명을 원자적으로 추출하고 제거한다.
+
+  KEYS[1] = queue:{scheduleId}
+  ARGV[1] = batchSize (기본 10)
+
+  Returns: 승인된 userId 목록
+]]
+
+local queueKey = KEYS[1]
+local batchSize = tonumber(ARGV[1]) or 10
+
+local members = redis.call('ZRANGE', queueKey, 0, batchSize - 1)
+
+if #members > 0 then
+    redis.call('ZREM', queueKey, unpack(members))
+end
+
+return members


### PR DESCRIPTION
## Summary
- Queue Service 기동 시 common 모듈의 JPA 의존 Config(`QuerydslConfig`, `CommonJpaConfig`)가 EntityManager 부재로 실패하는 문제 수정
- `application.yml`의 Redis 하드코딩 및 `autoconfigure.exclude` 중복 제거
- 배치 승인용 Lua 스크립트 및 `DefaultRedisScript` Bean 추가 (REQ-QUEUE-005)

## Changes
- `QueueServiceApplication.kt`: `excludeName` → `exclude`(클래스 참조) 타입 안전화, `DataSourceTransactionManagerAutoConfiguration` 추가, `@ComponentScan(excludeFilters)`로 `QuerydslConfig`·`CommonJpaConfig` 스캔 제외
- `application.yml`: `spring.config.import` 추가 (common profile 공유), Redis 하드코딩 제거, `autoconfigure.exclude` 제거 (Application 클래스로 일원화)
- `RedisConfig.kt`: `batchApproveScript()` Bean 추가 — `DefaultRedisScript`로 Lua 파일 로드
- `lua/batch-approve.lua` 신규 생성 — `ZRANGE` + `ZREM` 원자적 처리 (상위 N명 추출 및 제거)

Closes #40 

## Test plan
- [ ] `./gradlew :queue-service:build -x test` 빌드 성공 확인
- [ ] Docker 인프라(`docker-compose up -d`) 기동 후 `--spring.profiles.active=local`로 Queue Service 정상 부팅 (8083 포트 리스닝, ApplicationContext 로딩 오류 없음) 확인
- [ ] 다른 서비스 빌드(`./gradlew build -x test`) 영향 없음 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added atomic batch approval for processing multiple queue entries.

* **Refactor**
  * Externalized configuration to support optional external sources and improve deployment flexibility.
  * Updated component scanning and startup configuration for clearer module discovery.

* **Stability**
  * Conditional wiring for JPA-related query components to avoid startup issues when not present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->