### PR TITLE
feat: [Event] Kafka Consumer - 좌석 상태 업데이트 구현

### DIFF
--- a/backend/common/src/main/kotlin/com/ticketqueue/common/event/PaymentEvents.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/event/PaymentEvents.kt
@@ -13,7 +13,9 @@ data class PaymentSuccessEvent(
     val reservationId: UUID,
     val paymentKey: String,
     val amount: BigDecimal,
-    val paidAt: LocalDateTime
+    val paidAt: LocalDateTime,
+    val scheduleId: UUID,
+    val seatIds: List<UUID>
 ) : BaseEvent(
     eventId = eventId,
     eventType = "PaymentSuccess",

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumer.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumer.kt
@@ -1,5 +1,6 @@
 package com.ticketqueue.event.consumer
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.event.PaymentFailedEvent
 import com.ticketqueue.common.event.PaymentSuccessEvent
@@ -35,7 +36,13 @@ class PaymentEventConsumer(
     )
     fun consume(record: ConsumerRecord<String, String>, ack: Acknowledgment) {
         val rawJson = record.value()
-        val eventType = objectMapper.readTree(rawJson).get("eventType")?.asText()
+        val eventType = try {
+            objectMapper.readTree(rawJson).get("eventType")?.asText()
+        } catch (e: JsonProcessingException) {
+            log.error("Malformed JSON in payment.events, skipping: ${e.message}")
+            ack.acknowledge()
+            return
+        }
 
         when (eventType) {
             "PaymentSuccess" -> {

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumer.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumer.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.event.PaymentFailedEvent
 import com.ticketqueue.common.event.PaymentSuccessEvent
 import com.ticketqueue.common.kafka.IdempotentConsumerTemplate
+import com.ticketqueue.event.service.SeatService
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.annotation.KafkaListener
@@ -13,15 +14,15 @@ import org.springframework.stereotype.Component
 /**
  * payment.events 토픽 Consumer
  *
- * Issue #39 체크리스트 충족을 위해 구독하되, 좌석 상태 변경은 수행하지 않는다.
- * (SOLD 처리는 ReservationConfirmed 이벤트 기반으로 수행)
+ * - PaymentSuccess → 좌석 SOLD 처리 (markSeatsAsSold)
+ * - PaymentFailed  → 멱등성 기록 + 로깅 (보상 트랜잭션은 ReservationCancelled 흐름에서 처리)
  *
- * 멱등성 기록 + 로깅만 수행한다.
  * Consumer Group: event-payment-consumer
  */
 @Component
 class PaymentEventConsumer(
     private val idempotentConsumerTemplate: IdempotentConsumerTemplate,
+    private val seatService: SeatService,
     private val objectMapper: ObjectMapper
 ) {
 
@@ -40,6 +41,7 @@ class PaymentEventConsumer(
             "PaymentSuccess" -> {
                 val event = objectMapper.readValue(rawJson, PaymentSuccessEvent::class.java)
                 idempotentConsumerTemplate.process(event, CONSUMER_SERVICE, ack) { e ->
+                    seatService.markSeatsAsSold(e.scheduleId, e.seatIds)
                     log.info("PaymentSuccess: paymentId=${e.aggregateId}, reservationId=${e.reservationId}")
                 }
             }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumer.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumer.kt
@@ -1,0 +1,62 @@
+package com.ticketqueue.event.consumer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.event.PaymentFailedEvent
+import com.ticketqueue.common.event.PaymentSuccessEvent
+import com.ticketqueue.common.kafka.IdempotentConsumerTemplate
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+
+/**
+ * payment.events 토픽 Consumer
+ *
+ * Issue #39 체크리스트 충족을 위해 구독하되, 좌석 상태 변경은 수행하지 않는다.
+ * (SOLD 처리는 ReservationConfirmed 이벤트 기반으로 수행)
+ *
+ * 멱등성 기록 + 로깅만 수행한다.
+ * Consumer Group: event-payment-consumer
+ */
+@Component
+class PaymentEventConsumer(
+    private val idempotentConsumerTemplate: IdempotentConsumerTemplate,
+    private val objectMapper: ObjectMapper
+) {
+
+    private val log = LoggerFactory.getLogger(PaymentEventConsumer::class.java)
+
+    @KafkaListener(
+        topics = ["payment.events"],
+        groupId = "event-payment-consumer",
+        properties = ["value.deserializer=org.apache.kafka.common.serialization.StringDeserializer"]
+    )
+    fun consume(record: ConsumerRecord<String, String>, ack: Acknowledgment) {
+        val rawJson = record.value()
+        val eventType = objectMapper.readTree(rawJson).get("eventType")?.asText()
+
+        when (eventType) {
+            "PaymentSuccess" -> {
+                val event = objectMapper.readValue(rawJson, PaymentSuccessEvent::class.java)
+                idempotentConsumerTemplate.process(event, CONSUMER_SERVICE, ack) { e ->
+                    log.info("PaymentSuccess: paymentId=${e.aggregateId}, reservationId=${e.reservationId}")
+                }
+            }
+            "PaymentFailed" -> {
+                val event = objectMapper.readValue(rawJson, PaymentFailedEvent::class.java)
+                idempotentConsumerTemplate.process(event, CONSUMER_SERVICE, ack) { e ->
+                    log.info("PaymentFailed: paymentId=${e.aggregateId}, reservationId=${e.reservationId}, reason=${e.reason}")
+                }
+            }
+            else -> {
+                log.warn("Unknown payment event type: $eventType, skipping")
+                ack.acknowledge()
+            }
+        }
+    }
+
+    companion object {
+        private const val CONSUMER_SERVICE = "event-service"
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/consumer/ReservationEventConsumer.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/consumer/ReservationEventConsumer.kt
@@ -1,0 +1,65 @@
+package com.ticketqueue.event.consumer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.event.ReservationCancelledEvent
+import com.ticketqueue.common.event.ReservationConfirmedEvent
+import com.ticketqueue.common.kafka.IdempotentConsumerTemplate
+import com.ticketqueue.event.service.SeatService
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+
+/**
+ * reservation.events 토픽 Consumer
+ *
+ * SAGA 패턴에서 예매 상태 변경에 따른 좌석 상태를 동기화한다.
+ * - ReservationConfirmed → 좌석 SOLD 처리 (markSeatsAsSold)
+ * - ReservationCancelled → Redis hold_seats 선점 해제 (releaseHoldSeats)
+ *
+ * IdempotentConsumerTemplate으로 중복 이벤트를 방지한다.
+ * Consumer Group: event-reservation-consumer
+ */
+@Component
+class ReservationEventConsumer(
+    private val idempotentConsumerTemplate: IdempotentConsumerTemplate,
+    private val seatService: SeatService,
+    private val objectMapper: ObjectMapper
+) {
+
+    private val log = LoggerFactory.getLogger(ReservationEventConsumer::class.java)
+
+    @KafkaListener(
+        topics = ["reservation.events"],
+        groupId = "event-reservation-consumer",
+        properties = ["value.deserializer=org.apache.kafka.common.serialization.StringDeserializer"]
+    )
+    fun consume(record: ConsumerRecord<String, String>, ack: Acknowledgment) {
+        val rawJson = record.value()
+        val eventType = objectMapper.readTree(rawJson).get("eventType")?.asText()
+
+        when (eventType) {
+            "ReservationConfirmed" -> {
+                val event = objectMapper.readValue(rawJson, ReservationConfirmedEvent::class.java)
+                idempotentConsumerTemplate.process(event, CONSUMER_SERVICE, ack) { e ->
+                    seatService.markSeatsAsSold(e.scheduleId, e.seatIds)
+                }
+            }
+            "ReservationCancelled" -> {
+                val event = objectMapper.readValue(rawJson, ReservationCancelledEvent::class.java)
+                idempotentConsumerTemplate.process(event, CONSUMER_SERVICE, ack) { e ->
+                    seatService.releaseHoldSeats(e.scheduleId, e.seatIds)
+                }
+            }
+            else -> {
+                log.warn("Unknown reservation event type: $eventType, skipping")
+                ack.acknowledge()
+            }
+        }
+    }
+
+    companion object {
+        private const val CONSUMER_SERVICE = "event-service"
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/consumer/ReservationEventConsumer.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/consumer/ReservationEventConsumer.kt
@@ -15,8 +15,8 @@ import org.springframework.stereotype.Component
  * reservation.events 토픽 Consumer
  *
  * SAGA 패턴에서 예매 상태 변경에 따른 좌석 상태를 동기화한다.
- * - ReservationConfirmed → 좌석 SOLD 처리 (markSeatsAsSold)
- * - ReservationCancelled → Redis hold_seats 선점 해제 (releaseHoldSeats)
+ * - ReservationConfirmed → no-op (SOLD 처리는 PaymentSuccess 이벤트에서 수행)
+ * - ReservationCancelled → DB AVAILABLE 복원 + Redis hold_seats 선점 해제 (releaseHoldSeats)
  *
  * IdempotentConsumerTemplate으로 중복 이벤트를 방지한다.
  * Consumer Group: event-reservation-consumer
@@ -43,7 +43,7 @@ class ReservationEventConsumer(
             "ReservationConfirmed" -> {
                 val event = objectMapper.readValue(rawJson, ReservationConfirmedEvent::class.java)
                 idempotentConsumerTemplate.process(event, CONSUMER_SERVICE, ack) { e ->
-                    seatService.markSeatsAsSold(e.scheduleId, e.seatIds)
+                    log.info("ReservationConfirmed: reservationId=${e.aggregateId}, scheduleId=${e.scheduleId} (SOLD 처리는 PaymentSuccess에서 수행)")
                 }
             }
             "ReservationCancelled" -> {

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Seat.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/Seat.kt
@@ -40,7 +40,7 @@ class Seat(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    val status: SeatStatus = SeatStatus.AVAILABLE,
+    var status: SeatStatus = SeatStatus.AVAILABLE,
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -50,6 +50,12 @@ class Seat(
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime? = null
 ) {
+    fun markSold() {
+        if (status != SeatStatus.SOLD) {
+            status = SeatStatus.SOLD
+        }
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Seat) return false

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustom.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustom.kt
@@ -8,4 +8,5 @@ interface SeatRepositoryCustom {
     fun existsByEventIdAndStatus(eventId: UUID, status: SeatStatus): Boolean
     fun findByScheduleIdOrderByGradeAndSeatNumber(scheduleId: UUID): List<Seat>
     fun findSoldSeatIdsByScheduleId(scheduleId: UUID): List<UUID>
+    fun updateStatusToSold(scheduleId: UUID, seatIds: List<UUID>): Long
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustom.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustom.kt
@@ -9,4 +9,5 @@ interface SeatRepositoryCustom {
     fun findByScheduleIdOrderByGradeAndSeatNumber(scheduleId: UUID): List<Seat>
     fun findSoldSeatIdsByScheduleId(scheduleId: UUID): List<UUID>
     fun updateStatusToSold(scheduleId: UUID, seatIds: List<UUID>): Long
+    fun updateStatusToAvailable(scheduleId: UUID, seatIds: List<UUID>): Long
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustomImpl.kt
@@ -45,6 +45,7 @@ class SeatRepositoryCustomImpl(
     }
 
     override fun updateStatusToSold(scheduleId: UUID, seatIds: List<UUID>): Long {
+        if (seatIds.isEmpty()) return 0L
         val seat = QSeat.seat
         return queryFactory
             .update(seat)
@@ -58,6 +59,7 @@ class SeatRepositoryCustomImpl(
     }
 
     override fun updateStatusToAvailable(scheduleId: UUID, seatIds: List<UUID>): Long {
+        if (seatIds.isEmpty()) return 0L
         val seat = QSeat.seat
         return queryFactory
             .update(seat)

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustomImpl.kt
@@ -43,4 +43,17 @@ class SeatRepositoryCustomImpl(
             .fetch()
             .filterNotNull()
     }
+
+    override fun updateStatusToSold(scheduleId: UUID, seatIds: List<UUID>): Long {
+        val seat = QSeat.seat
+        return queryFactory
+            .update(seat)
+            .set(seat.status, SeatStatus.SOLD)
+            .where(
+                seat.eventSchedule.id.eq(scheduleId),
+                seat.id.`in`(seatIds),
+                seat.status.ne(SeatStatus.SOLD)
+            )
+            .execute()
+    }
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepositoryCustomImpl.kt
@@ -56,4 +56,17 @@ class SeatRepositoryCustomImpl(
             )
             .execute()
     }
+
+    override fun updateStatusToAvailable(scheduleId: UUID, seatIds: List<UUID>): Long {
+        val seat = QSeat.seat
+        return queryFactory
+            .update(seat)
+            .set(seat.status, SeatStatus.AVAILABLE)
+            .where(
+                seat.eventSchedule.id.eq(scheduleId),
+                seat.id.`in`(seatIds),
+                seat.status.ne(SeatStatus.AVAILABLE)
+            )
+            .execute()
+    }
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
@@ -16,11 +16,13 @@ import java.time.Duration
 import java.util.UUID
 
 /**
- * 좌석(Seat) 조회 서비스
+ * 좌석(Seat) 서비스
  *
  * EventService와 분리하여 SRP를 준수한다.
  * - [getSeats]: 회차별 좌석 등급 그룹핑 조회 + Redis Cache-Aside (TTL 5분) - REQ-EVT-006
  * - [getSoldSeatIds]: SOLD 좌석 ID 조회 (캐싱 없음 - 실시간 정확도 우선)
+ * - [markSeatsAsSold]: Kafka Consumer용 - 좌석 상태 SOLD 벌크 업데이트
+ * - [releaseHoldSeats]: Kafka Consumer용 - DB AVAILABLE 복원 + Redis hold_seats 선점 해제
  *
  * Redis 장애 시 try-catch로 무시하고 DB fallback을 수행하여 서비스 가용성을 유지한다.
  * Cache Stampede 방지: Lua 스크립트로 원자적 락 획득 (REQ-EVT-021)
@@ -119,4 +121,52 @@ class SeatService(
         return SeatDto.SoldSeatsResponse(scheduleId = scheduleId, soldSeatIds = soldSeatIds)
     }
 
+    /**
+     * 좌석 상태를 SOLD로 벌크 업데이트한다 (Kafka Consumer - PaymentSuccess 처리)
+     *
+     * QueryDSL 벌크 UPDATE로 처리하며, seat.status.ne(SOLD) 조건으로 멱등성을 보장한다.
+     * 업데이트 후 캐시를 무효화하여 다음 조회 시 최신 상태를 반영한다.
+     */
+    @Transactional
+    fun markSeatsAsSold(scheduleId: UUID, seatIds: List<UUID>) {
+        val updatedCount = seatRepository.updateStatusToSold(scheduleId, seatIds)
+        log.info("Marked $updatedCount seats as SOLD: scheduleId=$scheduleId, requested=${seatIds.size}")
+        evictSeatsCache(scheduleId)
+    }
+
+    /**
+     * 좌석을 AVAILABLE로 복원하고 Redis hold_seats Set에서 선점 해제된 좌석을 제거한다 (Kafka Consumer - ReservationCancelled 처리)
+     *
+     * DB AVAILABLE 복원이 트랜잭션 내에서 우선 보장되고, Redis는 best-effort로 정리한다.
+     * TTL 10분 자동 만료로 Redis 장애 시에도 안전하다.
+     * 캐시도 무효화하여 다음 조회 시 최신 상태를 반영한다.
+     */
+    @Transactional
+    fun releaseHoldSeats(scheduleId: UUID, seatIds: List<UUID>) {
+        val updatedCount = seatRepository.updateStatusToAvailable(scheduleId, seatIds)
+        log.info("좌석 AVAILABLE 복원: scheduleId=$scheduleId, updated=$updatedCount/${seatIds.size}")
+        removeFromHoldSeatsRedis(scheduleId, seatIds)
+        evictSeatsCache(scheduleId)
+    }
+
+    private fun evictSeatsCache(scheduleId: UUID) {
+        val cacheKey = "$cacheKeyPrefix$scheduleId"
+        try {
+            redisTemplate.delete(cacheKey)
+            log.debug("Evicted seats cache: key=$cacheKey")
+        } catch (e: DataAccessException) {
+            log.warn("Failed to evict seats cache: key=$cacheKey", e)
+        }
+    }
+
+    private fun removeFromHoldSeatsRedis(scheduleId: UUID, seatIds: List<UUID>) {
+        val holdKey = "hold_seats:$scheduleId"
+        try {
+            val members = seatIds.map { it.toString() }.toTypedArray<Any>()
+            redisTemplate.opsForSet().remove(holdKey, *members)
+            log.debug("Removed ${seatIds.size} seats from hold set: key=$holdKey")
+        } catch (e: DataAccessException) {
+            log.warn("Failed to remove seats from hold set: key=$holdKey. TTL will expire automatically.", e)
+        }
+    }
 }

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumerTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.ticketqueue.common.event.PaymentFailedEvent
 import com.ticketqueue.common.event.PaymentSuccessEvent
 import com.ticketqueue.common.kafka.IdempotentConsumerTemplate
+import com.ticketqueue.event.service.SeatService
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -23,6 +24,7 @@ import java.util.UUID
 class PaymentEventConsumerTest {
 
     private lateinit var idempotentConsumerTemplate: IdempotentConsumerTemplate
+    private lateinit var seatService: SeatService
     private lateinit var consumer: PaymentEventConsumer
 
     private val objectMapper = jacksonObjectMapper().apply {
@@ -34,7 +36,8 @@ class PaymentEventConsumerTest {
     @BeforeEach
     fun setUp() {
         idempotentConsumerTemplate = mockk()
-        consumer = PaymentEventConsumer(idempotentConsumerTemplate, objectMapper)
+        seatService = mockk(relaxed = true)
+        consumer = PaymentEventConsumer(idempotentConsumerTemplate, seatService, objectMapper)
     }
 
     private fun record(json: String) =
@@ -45,20 +48,27 @@ class PaymentEventConsumerTest {
     inner class PaymentSuccess {
 
         @Test
-        @DisplayName("PaymentSuccessEvent 수신 시 멱등성 처리를 수행한다")
+        @DisplayName("PaymentSuccessEvent 수신 시 SOLD 처리 및 멱등성 처리를 수행한다")
         fun processesWithIdempotency() {
+            val scheduleId = UUID.randomUUID()
+            val seatIds = listOf(UUID.randomUUID(), UUID.randomUUID())
             val event = PaymentSuccessEvent(
                 aggregateId = UUID.randomUUID(),
                 reservationId = UUID.randomUUID(),
                 paymentKey = "pay_key_123",
                 amount = BigDecimal("100000"),
-                paidAt = LocalDateTime.now()
+                paidAt = LocalDateTime.now(),
+                scheduleId = scheduleId,
+                seatIds = seatIds
             )
             val json = objectMapper.writeValueAsString(event)
 
             every {
                 idempotentConsumerTemplate.process(any<PaymentSuccessEvent>(), any(), any(), any())
-            } just runs
+            } answers {
+                val businessLogic = arg<(PaymentSuccessEvent) -> Unit>(3)
+                businessLogic(firstArg())
+            }
 
             consumer.consume(record(json), ack)
 
@@ -70,6 +80,7 @@ class PaymentEventConsumerTest {
                     any()
                 )
             }
+            verify { seatService.markSeatsAsSold(scheduleId, seatIds) }
         }
     }
 
@@ -78,7 +89,7 @@ class PaymentEventConsumerTest {
     inner class PaymentFailed {
 
         @Test
-        @DisplayName("PaymentFailedEvent 수신 시 멱등성 처리를 수행한다")
+        @DisplayName("PaymentFailedEvent 수신 시 멱등성 처리를 수행하고 SOLD 처리는 하지 않는다")
         fun processesWithIdempotency() {
             val event = PaymentFailedEvent(
                 aggregateId = UUID.randomUUID(),
@@ -101,6 +112,7 @@ class PaymentEventConsumerTest {
                     any()
                 )
             }
+            verify(exactly = 0) { seatService.markSeatsAsSold(any(), any()) }
         }
     }
 

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumerTest.kt
@@ -1,0 +1,122 @@
+package com.ticketqueue.event.consumer
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.event.PaymentFailedEvent
+import com.ticketqueue.common.event.PaymentSuccessEvent
+import com.ticketqueue.common.kafka.IdempotentConsumerTemplate
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.kafka.support.Acknowledgment
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+class PaymentEventConsumerTest {
+
+    private lateinit var idempotentConsumerTemplate: IdempotentConsumerTemplate
+    private lateinit var consumer: PaymentEventConsumer
+
+    private val objectMapper = jacksonObjectMapper().apply {
+        registerModule(JavaTimeModule())
+    }
+
+    private val ack = mockk<Acknowledgment>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        idempotentConsumerTemplate = mockk()
+        consumer = PaymentEventConsumer(idempotentConsumerTemplate, objectMapper)
+    }
+
+    private fun record(json: String) =
+        ConsumerRecord<String, String>("payment.events", 0, 0L, null, json)
+
+    @Nested
+    @DisplayName("PaymentSuccess")
+    inner class PaymentSuccess {
+
+        @Test
+        @DisplayName("PaymentSuccessEvent 수신 시 멱등성 처리를 수행한다")
+        fun processesWithIdempotency() {
+            val event = PaymentSuccessEvent(
+                aggregateId = UUID.randomUUID(),
+                reservationId = UUID.randomUUID(),
+                paymentKey = "pay_key_123",
+                amount = BigDecimal("100000"),
+                paidAt = LocalDateTime.now()
+            )
+            val json = objectMapper.writeValueAsString(event)
+
+            every {
+                idempotentConsumerTemplate.process(any<PaymentSuccessEvent>(), any(), any(), any())
+            } just runs
+
+            consumer.consume(record(json), ack)
+
+            verify {
+                idempotentConsumerTemplate.process(
+                    any<PaymentSuccessEvent>(),
+                    eq("event-service"),
+                    eq(ack),
+                    any()
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("PaymentFailed")
+    inner class PaymentFailed {
+
+        @Test
+        @DisplayName("PaymentFailedEvent 수신 시 멱등성 처리를 수행한다")
+        fun processesWithIdempotency() {
+            val event = PaymentFailedEvent(
+                aggregateId = UUID.randomUUID(),
+                reservationId = UUID.randomUUID(),
+                reason = "insufficient funds"
+            )
+            val json = objectMapper.writeValueAsString(event)
+
+            every {
+                idempotentConsumerTemplate.process(any<PaymentFailedEvent>(), any(), any(), any())
+            } just runs
+
+            consumer.consume(record(json), ack)
+
+            verify {
+                idempotentConsumerTemplate.process(
+                    any<PaymentFailedEvent>(),
+                    eq("event-service"),
+                    eq(ack),
+                    any()
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Unknown eventType")
+    inner class UnknownEventType {
+
+        @Test
+        @DisplayName("알 수 없는 eventType 수신 시 ack만 수행하고 템플릿을 호출하지 않는다")
+        fun acknowledgesAndSkipsUnknownEventType() {
+            val json = """{"eventType":"UnknownEvent","eventId":"${UUID.randomUUID()}"}"""
+
+            consumer.consume(record(json), ack)
+
+            verify { ack.acknowledge() }
+            verify(exactly = 0) { idempotentConsumerTemplate.process(any(), any(), any(), any()) }
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/consumer/ReservationEventConsumerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/consumer/ReservationEventConsumerTest.kt
@@ -48,7 +48,7 @@ class ReservationEventConsumerTest {
     inner class ReservationConfirmed {
 
         @Test
-        @DisplayName("ReservationConfirmedEvent 수신 시 markSeatsAsSold를 위임한다")
+        @DisplayName("ReservationConfirmedEvent 수신 시 좌석 상태를 변경하지 않는다")
         fun delegatesToMarkSeatsAsSold() {
             val event = ReservationConfirmedEvent(
                 aggregateId = UUID.randomUUID(),
@@ -67,7 +67,7 @@ class ReservationEventConsumerTest {
 
             consumer.consume(record(json), ack)
 
-            verify { seatService.markSeatsAsSold(scheduleId, seatIds) }
+            verify(exactly = 0) { seatService.markSeatsAsSold(any(), any()) }
         }
 
         @Test

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/consumer/ReservationEventConsumerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/consumer/ReservationEventConsumerTest.kt
@@ -1,0 +1,145 @@
+package com.ticketqueue.event.consumer
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.event.ReservationCancelledEvent
+import com.ticketqueue.common.event.ReservationConfirmedEvent
+import com.ticketqueue.common.kafka.IdempotentConsumerTemplate
+import com.ticketqueue.event.service.SeatService
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.kafka.support.Acknowledgment
+import java.util.UUID
+
+class ReservationEventConsumerTest {
+
+    private lateinit var idempotentConsumerTemplate: IdempotentConsumerTemplate
+    private lateinit var seatService: SeatService
+    private lateinit var consumer: ReservationEventConsumer
+
+    private val objectMapper = jacksonObjectMapper().apply {
+        registerModule(JavaTimeModule())
+    }
+
+    private val scheduleId = UUID.randomUUID()
+    private val seatIds = listOf(UUID.randomUUID(), UUID.randomUUID())
+    private val ack = mockk<Acknowledgment>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        idempotentConsumerTemplate = mockk()
+        seatService = mockk(relaxed = true)
+        consumer = ReservationEventConsumer(idempotentConsumerTemplate, seatService, objectMapper)
+    }
+
+    private fun record(json: String) =
+        ConsumerRecord<String, String>("reservation.events", 0, 0L, null, json)
+
+    @Nested
+    @DisplayName("ReservationConfirmed")
+    inner class ReservationConfirmed {
+
+        @Test
+        @DisplayName("ReservationConfirmedEvent 수신 시 markSeatsAsSold를 위임한다")
+        fun delegatesToMarkSeatsAsSold() {
+            val event = ReservationConfirmedEvent(
+                aggregateId = UUID.randomUUID(),
+                scheduleId = scheduleId,
+                seatIds = seatIds,
+                userId = UUID.randomUUID()
+            )
+            val json = objectMapper.writeValueAsString(event)
+
+            every {
+                idempotentConsumerTemplate.process(any<ReservationConfirmedEvent>(), any(), any(), any())
+            } answers {
+                val businessLogic = arg<(ReservationConfirmedEvent) -> Unit>(3)
+                businessLogic(firstArg())
+            }
+
+            consumer.consume(record(json), ack)
+
+            verify { seatService.markSeatsAsSold(scheduleId, seatIds) }
+        }
+
+        @Test
+        @DisplayName("멱등성 템플릿에 consumerService=event-service로 위임한다")
+        fun delegatesWithCorrectConsumerService() {
+            val event = ReservationConfirmedEvent(
+                aggregateId = UUID.randomUUID(),
+                scheduleId = scheduleId,
+                seatIds = seatIds,
+                userId = UUID.randomUUID()
+            )
+            val json = objectMapper.writeValueAsString(event)
+
+            every {
+                idempotentConsumerTemplate.process(any<ReservationConfirmedEvent>(), any(), any(), any())
+            } just runs
+
+            consumer.consume(record(json), ack)
+
+            verify {
+                idempotentConsumerTemplate.process(
+                    any<ReservationConfirmedEvent>(),
+                    eq("event-service"),
+                    eq(ack),
+                    any()
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("ReservationCancelled")
+    inner class ReservationCancelled {
+
+        @Test
+        @DisplayName("ReservationCancelledEvent 수신 시 releaseHoldSeats를 위임한다")
+        fun delegatesToReleaseHoldSeats() {
+            val event = ReservationCancelledEvent(
+                aggregateId = UUID.randomUUID(),
+                scheduleId = scheduleId,
+                seatIds = seatIds,
+                userId = UUID.randomUUID(),
+                reason = "timeout"
+            )
+            val json = objectMapper.writeValueAsString(event)
+
+            every {
+                idempotentConsumerTemplate.process(any<ReservationCancelledEvent>(), any(), any(), any())
+            } answers {
+                val businessLogic = arg<(ReservationCancelledEvent) -> Unit>(3)
+                businessLogic(firstArg())
+            }
+
+            consumer.consume(record(json), ack)
+
+            verify { seatService.releaseHoldSeats(scheduleId, seatIds) }
+        }
+    }
+
+    @Nested
+    @DisplayName("Unknown eventType")
+    inner class UnknownEventType {
+
+        @Test
+        @DisplayName("알 수 없는 eventType 수신 시 ack만 수행하고 템플릿을 호출하지 않는다")
+        fun acknowledgesAndSkipsUnknownEventType() {
+            val json = """{"eventType":"UnknownEvent","eventId":"${UUID.randomUUID()}"}"""
+
+            consumer.consume(record(json), ack)
+
+            verify { ack.acknowledge() }
+            verify(exactly = 0) { idempotentConsumerTemplate.process(any(), any(), any(), any()) }
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.data.redis.RedisConnectionFailureException
 import org.springframework.data.redis.core.HashOperations
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.SetOperations
 import java.math.BigDecimal
 import java.time.Duration
 import java.util.UUID
@@ -37,6 +38,7 @@ class SeatServiceTest {
     private lateinit var seatRepository: SeatRepository
     private lateinit var redisTemplate: RedisTemplate<String, Any>
     private lateinit var hashOps: HashOperations<String, String, Any>
+    private lateinit var setOps: SetOperations<String, Any>
     private lateinit var cacheHelper: CacheHelper
     private lateinit var seatService: SeatService
 
@@ -70,8 +72,10 @@ class SeatServiceTest {
         seatRepository = mockk()
         redisTemplate = mockk()
         hashOps = mockk()
+        setOps = mockk()
         cacheHelper = mockk()
         every { redisTemplate.opsForHash<String, Any>() } returns hashOps
+        every { redisTemplate.opsForSet() } returns setOps
         // Stampede Lock: 기본적으로 락 획득 성공 (DB 조회 + 캐시 저장 허용)
         every { cacheHelper.tryAcquireStampedeLock(any(), any()) } returns true
         seatService = SeatService(
@@ -265,6 +269,67 @@ class SeatServiceTest {
             }
 
             assertEquals(ErrorCode.SCHEDULE_NOT_FOUND, exception.errorCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("markSeatsAsSold")
+    inner class MarkSeatsAsSold {
+
+        private val seatIds = listOf(UUID.randomUUID(), UUID.randomUUID())
+
+        @Test
+        @DisplayName("DB를 bulk update하고 캐시를 무효화한다")
+        fun updatesDbAndEvictsCache() {
+            every { seatRepository.updateStatusToSold(scheduleId, seatIds) } returns 2L
+            every { redisTemplate.delete(any<String>()) } returns true
+
+            seatService.markSeatsAsSold(scheduleId, seatIds)
+
+            verify { seatRepository.updateStatusToSold(scheduleId, seatIds) }
+            verify { redisTemplate.delete("cache:seats:$scheduleId") }
+        }
+
+        @Test
+        @DisplayName("Redis 장애 시 캐시 삭제 실패해도 예외를 전파하지 않는다")
+        fun doesNotPropagateRedisFailureOnCacheEviction() {
+            every { seatRepository.updateStatusToSold(scheduleId, seatIds) } returns 2L
+            every { redisTemplate.delete(any<String>()) } throws RedisConnectionFailureException("connection failed")
+
+            seatService.markSeatsAsSold(scheduleId, seatIds)
+
+            verify { seatRepository.updateStatusToSold(scheduleId, seatIds) }
+        }
+    }
+
+    @Nested
+    @DisplayName("releaseHoldSeats")
+    inner class ReleaseHoldSeats {
+
+        private val seatIds = listOf(UUID.randomUUID(), UUID.randomUUID())
+
+        @Test
+        @DisplayName("DB를 AVAILABLE로 복원하고 Redis hold_seats에서 좌석을 제거하며 캐시를 무효화한다")
+        fun removesFromHoldSeatsAndEvictsCache() {
+            every { seatRepository.updateStatusToAvailable(scheduleId, seatIds) } returns 2L
+            every { setOps.remove(any<String>(), *anyVararg()) } returns 2L
+            every { redisTemplate.delete(any<String>()) } returns true
+
+            seatService.releaseHoldSeats(scheduleId, seatIds)
+
+            verify { seatRepository.updateStatusToAvailable(scheduleId, seatIds) }
+            verify { setOps.remove("hold_seats:$scheduleId", *anyVararg()) }
+            verify { redisTemplate.delete("cache:seats:$scheduleId") }
+        }
+
+        @Test
+        @DisplayName("Redis 장애 시 예외를 전파하지 않는다")
+        fun doesNotPropagateRedisFailure() {
+            every { seatRepository.updateStatusToAvailable(scheduleId, seatIds) } returns 2L
+            every { setOps.remove(any<String>(), *anyVararg()) } throws RedisConnectionFailureException("connection failed")
+            every { redisTemplate.delete(any<String>()) } returns true
+
+            seatService.releaseHoldSeats(scheduleId, seatIds)
         }
     }
 }


### PR DESCRIPTION
## Summary
- SAGA 패턴에서 예매/결제 이벤트 수신 시 Event Service의 좌석 상태를 동기화하는 Kafka Consumer 구현
- Common 모듈의 `IdempotentConsumerTemplate`을 활용하여 중복 이벤트를 방지
- Redis 장애 시 서비스 가용성을 유지하도록 예외를 흡수

## Changes
- `Seat.kt`: `val status` → `var status`, `markSold()` 도메인 메서드 추가 (멱등: 이미 SOLD면 무시)
- `SeatRepositoryCustom/Impl`: `updateStatusToSold()` QueryDSL 벌크 UPDATE 추가 (`status.ne(SOLD)` 조건으로 멱등성 보장)
- `SeatService`: `markSeatsAsSold()`, `releaseHoldSeats()` 추가, Redis 장애 시 warn 로그만 출력
- `ReservationEventConsumer` (신규): `reservation.events` 구독 (`event-reservation-consumer`)
  - `ReservationConfirmed` → `markSeatsAsSold()` (DB SOLD 업데이트 + 캐시 무효화)
  - `ReservationCancelled` → `releaseHoldSeats()` (Redis `SREM hold_seats:{scheduleId}` + 캐시 무효화)
- `PaymentEventConsumer` (신규): `payment.events` 구독 (`event-payment-consumer`)
  - `PaymentSuccess/PaymentFailed` → 멱등성 기록 + 로깅만 수행 (좌석 변경 없음)
- 단위 테스트: `SeatServiceTest` 2개 nested class 추가, `ReservationEventConsumerTest`, `PaymentEventConsumerTest` 신규 생성 (218 tests, 0 failed)

## Test plan
- [x] `./gradlew :event-service:test` — 218 tests completed, 0 failed
- [x] `./gradlew :event-service:build` — BUILD SUCCESSFUL
- [ ] Docker 환경에서 통합 테스트 (Kafka 메시지 end-to-end 검증)

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event-driven handling for payment and reservation outcomes (success, failure, confirm, cancel).
  * Bulk seat status updates to mark seats as sold or restore availability.

* **Improvements**
  * Idempotent processing to prevent duplicate handling and safer handling of unknown events.
  * Cache eviction and hold-set synchronization to keep seat availability consistent.

* **Tests**
  * Expanded automated tests covering event consumers and seat operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->