### PR TITLE
feat: [Event] Redis 캐싱 전략 구현 - Cache-Aside, Stampede Lock, 캐시 무효화

### DIFF
--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/CacheProperties.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/CacheProperties.kt
@@ -1,0 +1,22 @@
+package com.ticketqueue.event.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Redis 캐시 TTL 설정 (REQ-EVT-017)
+ *
+ * application.yml의 `cache.*` 프로퍼티를 중앙 관리한다.
+ * - event.ttl: 공연 목록/상세 캐시 TTL (기본 5분)
+ * - schedule.ttl: 회차 상세 캐시 TTL (기본 5분)
+ * - seats.ttl: 좌석 재고 통계 캐시 TTL (기본 5분)
+ * - layout.ttl: 좌석 배치도 캐시 TTL (기본 24시간 — 홀 구조는 거의 변경되지 않음)
+ */
+@ConfigurationProperties(prefix = "cache")
+data class CacheProperties(
+    val event: CacheTtl = CacheTtl(),
+    val schedule: CacheTtl = CacheTtl(),
+    val seats: CacheTtl = CacheTtl(),
+    val layout: CacheTtl = CacheTtl(ttl = 86400L)
+) {
+    data class CacheTtl(val ttl: Long = 300L)
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/CacheProperties.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/CacheProperties.kt
@@ -18,5 +18,9 @@ data class CacheProperties(
     val seats: CacheTtl = CacheTtl(),
     val layout: CacheTtl = CacheTtl(ttl = 86400L)
 ) {
-    data class CacheTtl(val ttl: Long = 300L)
+    data class CacheTtl(val ttl: Long = 300L) {
+        init {
+            require(ttl > 0) { "Cache TTL must be positive, but was $ttl" }
+        }
+    }
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/RedisConfig.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/RedisConfig.kt
@@ -1,13 +1,18 @@
 package com.ticketqueue.event.config
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.ClassPathResource
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.script.DefaultRedisScript
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.StringRedisSerializer
+import org.springframework.scripting.support.ResourceScriptSource
 
 @Configuration
+@EnableConfigurationProperties(CacheProperties::class)
 class RedisConfig {
 
     @Bean
@@ -18,6 +23,19 @@ class RedisConfig {
             valueSerializer = GenericJackson2JsonRedisSerializer()
             hashKeySerializer = StringRedisSerializer()
             hashValueSerializer = GenericJackson2JsonRedisSerializer()
+        }
+    }
+
+    /**
+     * Cache Stampede 방지 Lua 스크립트 빈 등록 (REQ-EVT-021)
+     *
+     * SET NX EX 원자적 락 획득 — 동시 다발적 캐시 Miss 시 단 하나의 요청만 DB 조회를 수행한다.
+     */
+    @Bean
+    fun cacheStampedeLockScript(): DefaultRedisScript<Long> {
+        return DefaultRedisScript<Long>().apply {
+            setScriptSource(ResourceScriptSource(ClassPathResource("lua/cache-stampede-lock.lua")))
+            resultType = Long::class.java
         }
     }
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/CacheHelper.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/CacheHelper.kt
@@ -1,0 +1,50 @@
+package com.ticketqueue.event.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.script.DefaultRedisScript
+import org.springframework.data.redis.serializer.GenericToStringSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import org.springframework.stereotype.Component
+
+/**
+ * Cache Stampede Lock 공통 유틸리티 컴포넌트
+ *
+ * EventService, ScheduleService, SeatService의 중복 tryAcquireStampedeLock 로직을 통합한다.
+ *
+ * 버그 수정 (REQ-EVT-021):
+ * - 기존: redisTemplate.execute(script, keys, ttl.toString()) 는 기본 value serializer
+ *   (GenericJackson2JsonRedisSerializer)로 args를 직렬화하여 "10" (JSON 따옴표 포함)을 전달
+ *   → Lua SET NX EX 인자 파싱 실패 → catch에서 true 반환 → lock 실질적 미작동
+ * - 수정: StringRedisSerializer를 argsSerializer로 명시하여 10 (raw bytes)으로 전달
+ */
+@Component
+class CacheHelper(
+    private val redisTemplate: RedisTemplate<String, Any>,
+    private val cacheStampedeLockScript: DefaultRedisScript<Long>
+) {
+
+    private val log = LoggerFactory.getLogger(CacheHelper::class.java)
+
+    /**
+     * Cache Stampede Lock 획득 시도
+     *
+     * Lua 스크립트로 SET NX EX 원자적 실행. 락 획득 시 true 반환.
+     * Redis 장애 시 true 반환하여 DB 조회와 캐시 저장을 허용한다 (안전 방향).
+     */
+    fun tryAcquireStampedeLock(lockKey: String, ttlSeconds: Long): Boolean {
+        return try {
+            val result = redisTemplate.execute(
+                cacheStampedeLockScript,
+                StringRedisSerializer(),
+                GenericToStringSerializer(Long::class.java),
+                listOf(lockKey),
+                ttlSeconds.toString()
+            )
+            result == 1L
+        } catch (e: Exception) {
+            log.warn("Stampede lock execution failed for key: $lockKey, treating as acquired", e)
+            true
+        }
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
@@ -3,6 +3,7 @@ package com.ticketqueue.event.service
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.config.CacheProperties
 import com.ticketqueue.event.dto.EventDto
 import com.ticketqueue.event.dto.SeatTemplateDto
 import com.ticketqueue.event.entity.Event
@@ -17,13 +18,34 @@ import com.ticketqueue.event.repository.EventScheduleRepository
 import com.ticketqueue.event.repository.HallRepository
 import com.ticketqueue.event.repository.SeatRepository
 import com.ticketqueue.event.repository.VenueRepository
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataAccessException
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ScanOptions
+import org.springframework.data.redis.core.script.DefaultRedisScript
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
+import java.time.Duration
 import java.time.LocalDateTime
 import java.util.UUID
+
+/**
+ * 공연 목록/상세 캐시에서 사용하는 페이지 래퍼 DTO
+ *
+ * GenericJackson2JsonRedisSerializer는 LocalDateTime 처리를 위해 Spring 관리
+ * ObjectMapper가 필요하므로, 직렬화는 objectMapper.writeValueAsString()을 사용한다.
+ * internal로 선언하여 동일 모듈 내 테스트에서도 접근 가능하다.
+ */
+internal data class CachedEventList(
+    val content: List<EventDto.ListResponse>,
+    val page: Int,
+    val size: Int,
+    val totalElements: Long
+)
 
 /**
  * 공연(Event) 관리 서비스
@@ -32,6 +54,13 @@ import java.util.UUID
  * - 공연 생성 시 Hall의 seatTemplate을 기반으로 회차별 좌석 자동 초기화
  * - Soft Delete: deleted_at 컬럼으로 논리 삭제, SOLD 좌석이 있으면 삭제 불가
  * - 수정 범위 차등: 판매 시작 후에는 artist 변경 불가 (REQ-EVT-002)
+ *
+ * Cache-Aside 전략 (REQ-EVT-017):
+ * - 공연 상세: `cache:event:{eventId}` (String JSON, TTL 5분)
+ * - 공연 목록: `cache:event:list:{page}:{size}:{filters}` (String JSON, TTL 5분)
+ * - Cache Stampede 방지: Lua 스크립트로 원자적 락 획득 (REQ-EVT-021)
+ * - 캐시 무효화: 생성/수정/삭제 시 관련 캐시 모두 제거 (REQ-EVT-019)
+ * - Redis 장애 시 DB fallback으로 서비스 가용성 유지
  */
 @Service
 @Transactional(readOnly = true)
@@ -41,16 +70,25 @@ class EventService(
     private val seatRepository: SeatRepository,
     private val venueRepository: VenueRepository,
     private val hallRepository: HallRepository,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val redisTemplate: RedisTemplate<String, Any>,
+    private val cacheProperties: CacheProperties,
+    private val cacheStampedeLockScript: DefaultRedisScript<Long>
 ) {
+
+    private val log = LoggerFactory.getLogger(EventService::class.java)
+
+    private companion object {
+        const val EVENT_DETAIL_PREFIX = "cache:event:"
+        const val EVENT_LIST_PREFIX = "cache:event:list:"
+        const val EVENT_LOCK_PREFIX = "cache:lock:event:"
+        const val STAMPEDE_LOCK_TTL = 10L // seconds
+    }
 
     /**
      * 공연 생성 - 회차 및 좌석 일괄 생성 (REQ-EVT-001)
      *
-     * 1. Venue/Hall 존재 및 귀속 검증
-     * 2. 회차 순번 중복 및 시간 유효성 검증
-     * 3. Hall seatTemplate 파싱
-     * 4. Event → EventSchedule → Seat 순서로 저장
+     * 생성 성공 후 공연 목록 캐시를 무효화한다.
      */
     @Transactional
     fun createEvent(request: EventDto.CreateRequest): EventDto.CreateResponse {
@@ -60,33 +98,27 @@ class EventService(
         val hall = hallRepository.findById(request.hallId)
             .orElseThrow { EventException(ErrorCode.HALL_NOT_FOUND) }
 
-        // 홀이 해당 공연장에 속하는지 검증
         if (hall.venue.id != venue.id) {
             throw EventException(ErrorCode.HALL_NOT_IN_VENUE)
         }
 
-        // 회차 순번 중복 검증
         val sequences = request.schedules.map { it.playSequence }
         if (sequences.size != sequences.toSet().size) {
             throw EventException(ErrorCode.DUPLICATE_PLAY_SEQUENCE)
         }
 
-        // 회차 시간 유효성 검증
         request.schedules.forEach { s ->
             if (!s.eventStartAt.isBefore(s.eventEndAt) || !s.saleStartAt.isBefore(s.saleEndAt)) {
                 throw EventException(ErrorCode.INVALID_SCHEDULE_TIME)
             }
-            // 판매 종료 시각은 공연 시작 이전이어야 함 (티켓 판매는 공연 전에 마감)
             if (!s.saleEndAt.isBefore(s.eventStartAt)) {
                 throw EventException(ErrorCode.INVALID_SCHEDULE_TIME)
             }
-            // 공연 시작 시각은 현재 시각 이후여야 함 (과거 날짜 공연 등록 방지)
             if (!s.eventStartAt.isAfter(LocalDateTime.now())) {
                 throw EventException(ErrorCode.INVALID_SCHEDULE_TIME)
             }
         }
 
-        // 좌석 템플릿 파싱 (공연 저장 전 검증하여 fail-fast)
         val seatTemplate = try {
             objectMapper.readValue(hall.seatTemplate, SeatTemplateDto::class.java)
         } catch (e: JsonProcessingException) {
@@ -112,20 +144,209 @@ class EventService(
             seatRepository.saveAll(seats)
         }
 
-        return EventDto.CreateResponse.from(event)
+        val response = EventDto.CreateResponse.from(event)
+        invalidateEventListCaches()
+        return response
     }
 
     /**
-     * 회차에 속하는 좌석 목록을 생성한다.
+     * 공연 목록 조회 (페이징, 필터링, 검색) - REQ-EVT-004, P95 < 200ms
      *
-     * Hall의 seatTemplate(rows × seatsPerRow)과 priceByGrade를 조합하여
-     * 회차별 Seat 엔티티를 초기화한다.
-     *
-     * @param schedule    좌석이 속할 회차 엔티티
-     * @param seatTemplate Hall에 저장된 좌석 배치 정보
-     * @param priceByGrade 등급별 가격 (CreateRequest에서 전달)
-     * @return 생성된 Seat 엔티티 목록 (아직 DB 미저장 상태)
+     * Cache-Aside 전략:
+     * 1. String JSON 캐시 조회 → hit 시 즉시 반환
+     * 2. miss 시 → Stampede Lock 시도 → DB 조회 → 캐시 저장
      */
+    fun getEvents(
+        page: Int,
+        size: Int,
+        status: EventStatus?,
+        city: String?,
+        keyword: String?
+    ): Page<EventDto.ListResponse> {
+        val coercedPage = page.coerceAtLeast(0)
+        val coercedSize = size.coerceIn(1, 100)
+        val cacheKey = buildListCacheKey(coercedPage, coercedSize, status, city, keyword)
+
+        // 1. Cache read
+        try {
+            val cached = redisTemplate.opsForValue().get(cacheKey) as? String
+            if (cached != null) {
+                val cachedList = objectMapper.readValue(cached, CachedEventList::class.java)
+                return PageImpl(
+                    cachedList.content,
+                    PageRequest.of(cachedList.page, cachedList.size),
+                    cachedList.totalElements
+                )
+            }
+        } catch (e: DataAccessException) {
+            log.warn("Redis cache read failed for key: $cacheKey", e)
+        } catch (e: JsonProcessingException) {
+            log.warn("Redis cache deserialization failed for key: $cacheKey, skipping cache", e)
+            try { redisTemplate.delete(cacheKey) } catch (ignored: DataAccessException) {}
+        }
+
+        // 2. Stampede Lock
+        val lockKey = "${EVENT_LOCK_PREFIX}list:$cacheKey"
+        val lockAcquired = tryAcquireStampedeLock(lockKey)
+
+        // 3. DB query
+        val pageable = PageRequest.of(coercedPage, coercedSize)
+        val result = eventRepository.findEventList(pageable, status, city, keyword)
+
+        // 4. Cache write (락 획득 성공 시에만)
+        if (lockAcquired) {
+            try {
+                val cachedList = CachedEventList(
+                    content = result.content,
+                    page = result.number,
+                    size = result.size,
+                    totalElements = result.totalElements
+                )
+                val json = objectMapper.writeValueAsString(cachedList)
+                redisTemplate.opsForValue().set(cacheKey, json, Duration.ofSeconds(cacheProperties.event.ttl))
+            } catch (e: DataAccessException) {
+                log.warn("Redis cache write failed for key: $cacheKey", e)
+            } catch (e: JsonProcessingException) {
+                log.warn("Redis cache serialization failed for key: $cacheKey", e)
+            }
+        }
+
+        return result
+    }
+
+    /**
+     * 공연 상세 조회 - REQ-EVT-005, P95 < 100ms
+     *
+     * Cache-Aside 전략:
+     * 1. String JSON 캐시 조회 → hit 시 즉시 반환
+     * 2. miss 시 → Stampede Lock 시도 → DB 조회 → 캐시 저장
+     */
+    fun getEvent(eventId: UUID): EventDto.DetailResponse {
+        val cacheKey = "$EVENT_DETAIL_PREFIX$eventId"
+
+        // 1. Cache read
+        try {
+            val cached = redisTemplate.opsForValue().get(cacheKey) as? String
+            if (cached != null) {
+                return objectMapper.readValue(cached, EventDto.DetailResponse::class.java)
+            }
+        } catch (e: DataAccessException) {
+            log.warn("Redis cache read failed for key: $cacheKey", e)
+        } catch (e: JsonProcessingException) {
+            log.warn("Redis cache deserialization failed for key: $cacheKey, skipping cache", e)
+            try { redisTemplate.delete(cacheKey) } catch (ignored: DataAccessException) {}
+        }
+
+        // 2. Stampede Lock
+        val lockKey = "$EVENT_LOCK_PREFIX$eventId"
+        val lockAcquired = tryAcquireStampedeLock(lockKey)
+
+        // 3. DB query
+        val event = eventRepository.findEventWithVenueAndHall(eventId)
+            ?: throw EventException(ErrorCode.EVENT_NOT_FOUND)
+
+        val schedules = eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId)
+        val scheduleIds = schedules.map { it.id!! }
+        val availableScheduleIds = eventRepository.findScheduleIdsWithAvailableSeats(scheduleIds)
+
+        val scheduleDateGroups = schedules
+            .map { schedule ->
+                EventDto.ScheduleTimeInfo.from(schedule, isSoldOut = schedule.id!! !in availableScheduleIds)
+            }
+            .groupBy { it.eventStartAt.toLocalDate() }
+            .map { (date, times) ->
+                EventDto.ScheduleDateGroup(date = date, times = times.sortedBy { it.eventStartAt })
+            }
+            .sortedBy { it.date }
+
+        val detailResponse = EventDto.DetailResponse(
+            id = event.id!!,
+            title = event.title,
+            artist = event.artist,
+            description = event.description,
+            venueId = event.venue.id!!,
+            venueName = event.venue.name,
+            hallId = event.hall.id!!,
+            hallName = event.hall.name,
+            status = event.status,
+            schedules = scheduleDateGroups,
+            createdAt = event.createdAt!!,
+            updatedAt = event.updatedAt!!
+        )
+
+        // 4. Cache write (락 획득 성공 시에만)
+        if (lockAcquired) {
+            try {
+                val json = objectMapper.writeValueAsString(detailResponse)
+                redisTemplate.opsForValue().set(cacheKey, json, Duration.ofSeconds(cacheProperties.event.ttl))
+            } catch (e: DataAccessException) {
+                log.warn("Redis cache write failed for key: $cacheKey", e)
+            } catch (e: JsonProcessingException) {
+                log.warn("Redis cache serialization failed for key: $cacheKey", e)
+            }
+        }
+
+        return detailResponse
+    }
+
+    /**
+     * 공연 수정 (PATCH) - REQ-EVT-002
+     *
+     * 수정 성공 후 공연 상세 및 목록 캐시를 무효화한다.
+     */
+    @Transactional
+    fun updateEvent(eventId: UUID, request: EventDto.UpdateRequest): EventDto.UpdateResponse {
+        val event = findActiveEvent(eventId)
+        val hasSaleStarted = eventScheduleRepository.existsByEventIdAndSaleStartAtLessThanEqual(eventId, LocalDateTime.now())
+
+        if (hasSaleStarted && request.artist != null) {
+            throw EventException(ErrorCode.EVENT_NOT_MODIFIABLE)
+        }
+
+        event.update(
+            title = request.title,
+            artist = request.artist,
+            description = request.description
+        )
+
+        val response = EventDto.UpdateResponse.from(event)
+        invalidateEventDetailCache(eventId)
+        invalidateEventListCaches()
+        return response
+    }
+
+    /**
+     * 공연 Soft Delete - REQ-EVT-003
+     *
+     * 삭제 성공 후 공연 상세 및 목록 캐시를 무효화한다.
+     */
+    @Transactional
+    fun deleteEvent(eventId: UUID): EventDto.DeleteResponse {
+        val event = eventRepository.findByIdForUpdate(eventId)
+            ?: throw EventException(ErrorCode.EVENT_NOT_FOUND)
+
+        if (event.deletedAt != null) {
+            throw EventException(ErrorCode.EVENT_ALREADY_DELETED)
+        }
+
+        if (seatRepository.existsByEventIdAndStatus(eventId, SeatStatus.SOLD)) {
+            throw EventException(ErrorCode.EVENT_HAS_RESERVATIONS)
+        }
+
+        event.softDelete()
+
+        invalidateEventDetailCache(eventId)
+        invalidateEventListCaches()
+        return EventDto.DeleteResponse(message = "Event deleted successfully")
+    }
+
+    // ===== Private Helper Methods =====
+
+    private fun findActiveEvent(eventId: UUID): Event {
+        return eventRepository.findByIdAndDeletedAtIsNull(eventId)
+            ?: throw EventException(ErrorCode.EVENT_NOT_FOUND)
+    }
+
     private fun initializeSeats(
         schedule: EventSchedule,
         seatTemplate: SeatTemplateDto,
@@ -148,110 +369,69 @@ class EventService(
     }
 
     /**
-     * 공연 목록 조회 (페이징, 필터링, 검색) - REQ-EVT-004, P95 < 200ms
+     * Cache Stampede Lock 획득 시도
+     *
+     * Lua 스크립트로 SET NX EX 원자적 실행. 락 획득 시 true 반환.
+     * Redis 장애 시 true 반환하여 DB 조회와 캐시 저장을 허용한다 (안전 방향).
      */
-    fun getEvents(
+    private fun tryAcquireStampedeLock(lockKey: String): Boolean {
+        return try {
+            val result = redisTemplate.execute(cacheStampedeLockScript, listOf(lockKey), STAMPEDE_LOCK_TTL.toString())
+            result == 1L
+        } catch (e: Exception) {
+            log.warn("Stampede lock execution failed for key: $lockKey, treating as acquired", e)
+            true
+        }
+    }
+
+    /**
+     * 공연 상세 캐시 단건 삭제 (REQ-EVT-019)
+     */
+    internal fun invalidateEventDetailCache(eventId: UUID) {
+        try {
+            redisTemplate.delete("$EVENT_DETAIL_PREFIX$eventId")
+        } catch (e: DataAccessException) {
+            log.warn("Redis event detail cache invalidation failed for eventId: $eventId", e)
+        }
+    }
+
+    /**
+     * 공연 목록 캐시 전체 삭제 (REQ-EVT-019)
+     *
+     * SCAN 명령으로 `cache:event:list:*` 패턴 키를 모두 조회 후 일괄 삭제한다.
+     * KEYS 명령 대신 SCAN을 사용하여 프로덕션 환경 성능 이슈를 방지한다.
+     */
+    internal fun invalidateEventListCaches() {
+        try {
+            val keys = mutableListOf<String>()
+            redisTemplate.execute { conn ->
+                conn.scan(
+                    ScanOptions.scanOptions().match("${EVENT_LIST_PREFIX}*").count(100).build()
+                ).use { cursor ->
+                    cursor.forEach { keyBytes -> keys.add(String(keyBytes)) }
+                }
+                null
+            }
+            if (keys.isNotEmpty()) {
+                redisTemplate.delete(keys)
+            }
+        } catch (e: DataAccessException) {
+            log.warn("Redis event list cache invalidation failed", e)
+        }
+    }
+
+    private fun buildListCacheKey(
         page: Int,
         size: Int,
         status: EventStatus?,
         city: String?,
         keyword: String?
-    ): Page<EventDto.ListResponse> {
-        val pageable = PageRequest.of(page.coerceAtLeast(0), size.coerceIn(1, 100))
-        return eventRepository.findEventList(pageable, status, city, keyword)
-    }
-
-    /**
-     * 공연 상세 조회 - REQ-EVT-005, P95 < 100ms
-     *
-     * 회차를 날짜별로 그룹핑하고, 회차별 매진 여부(isSoldOut)를 계산한다.
-     * isSoldOut: AVAILABLE 좌석이 하나도 없으면 true
-     */
-    fun getEvent(eventId: UUID): EventDto.DetailResponse {
-        val event = eventRepository.findEventWithVenueAndHall(eventId)
-            ?: throw EventException(ErrorCode.EVENT_NOT_FOUND)
-
-        val schedules = eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId)
-
-        val scheduleIds = schedules.map { it.id!! }
-        val availableScheduleIds = eventRepository.findScheduleIdsWithAvailableSeats(scheduleIds)
-
-        val scheduleDateGroups = schedules
-            .map { schedule ->
-                EventDto.ScheduleTimeInfo.from(schedule, isSoldOut = schedule.id!! !in availableScheduleIds)
-            }
-            .groupBy { it.eventStartAt.toLocalDate() }
-            .map { (date, times) ->
-                EventDto.ScheduleDateGroup(date = date, times = times.sortedBy { it.eventStartAt })
-            }
-            .sortedBy { it.date }
-
-        return EventDto.DetailResponse(
-            id = event.id!!,
-            title = event.title,
-            artist = event.artist,
-            description = event.description,
-            venueId = event.venue.id!!,
-            venueName = event.venue.name,
-            hallId = event.hall.id!!,
-            hallName = event.hall.name,
-            status = event.status,
-            schedules = scheduleDateGroups,
-            createdAt = event.createdAt!!,
-            updatedAt = event.updatedAt!!
-        )
-    }
-
-    /**
-     * 공연 수정 (PATCH) - REQ-EVT-002
-     *
-     * 판매 시작 여부: 해당 공연의 어느 회차든 saleStartAt이 현재 시각 이전이면 "판매 시작됨"
-     * - 판매 전: title, artist, description 모두 수정 가능
-     * - 판매 후: title, description만 수정 가능 (artist 변경 시 409 반환)
-     */
-    @Transactional
-    fun updateEvent(eventId: UUID, request: EventDto.UpdateRequest): EventDto.UpdateResponse {
-        val event = findActiveEvent(eventId)
-        // 전체 스케줄 로드 대신 EXISTS 쿼리 1개로 판매 시작 여부 확인 (N → 1 쿼리)
-        val hasSaleStarted = eventScheduleRepository.existsByEventIdAndSaleStartAtLessThanEqual(eventId, LocalDateTime.now())
-
-        if (hasSaleStarted && request.artist != null) {
-            throw EventException(ErrorCode.EVENT_NOT_MODIFIABLE)
-        }
-
-        event.update(
-            title = request.title,
-            artist = request.artist,
-            description = request.description
-        )
-
-        return EventDto.UpdateResponse.from(event)
-    }
-
-    /**
-     * 공연 Soft Delete - REQ-EVT-003
-     *
-     * SOLD 좌석이 하나라도 있으면 삭제 불가 (데이터 정합성 보장)
-     */
-    @Transactional
-    fun deleteEvent(eventId: UUID): EventDto.DeleteResponse {
-        val event = eventRepository.findByIdForUpdate(eventId)
-            ?: throw EventException(ErrorCode.EVENT_NOT_FOUND)
-
-        if (event.deletedAt != null) {
-            throw EventException(ErrorCode.EVENT_ALREADY_DELETED)
-        }
-
-        if (seatRepository.existsByEventIdAndStatus(eventId, SeatStatus.SOLD)) {
-            throw EventException(ErrorCode.EVENT_HAS_RESERVATIONS)
-        }
-
-        event.softDelete()
-        return EventDto.DeleteResponse(message = "Event deleted successfully")
-    }
-
-    private fun findActiveEvent(eventId: UUID): Event {
-        return eventRepository.findByIdAndDeletedAtIsNull(eventId)
-            ?: throw EventException(ErrorCode.EVENT_NOT_FOUND)
+    ): String {
+        val parts = mutableListOf<String>()
+        status?.let { parts.add("s=${it.name}") }
+        city?.let { parts.add("c=$it") }
+        keyword?.let { parts.add("k=$it") }
+        val filters = if (parts.isEmpty()) "all" else parts.joinToString(":")
+        return "$EVENT_LIST_PREFIX$page:$size:$filters"
     }
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
@@ -25,7 +25,6 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.core.ScanOptions
-import org.springframework.data.redis.core.script.DefaultRedisScript
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -73,7 +72,7 @@ class EventService(
     private val objectMapper: ObjectMapper,
     private val redisTemplate: RedisTemplate<String, Any>,
     private val cacheProperties: CacheProperties,
-    private val cacheStampedeLockScript: DefaultRedisScript<Long>
+    private val cacheHelper: CacheHelper
 ) {
 
     private val log = LoggerFactory.getLogger(EventService::class.java)
@@ -187,7 +186,7 @@ class EventService(
 
         // 2. Stampede Lock
         val lockKey = "${EVENT_LOCK_PREFIX}list:$cacheKey"
-        val lockAcquired = tryAcquireStampedeLock(lockKey)
+        val lockAcquired = cacheHelper.tryAcquireStampedeLock(lockKey, STAMPEDE_LOCK_TTL)
 
         // 3. DB query
         val pageable = PageRequest.of(coercedPage, coercedSize)
@@ -239,7 +238,7 @@ class EventService(
 
         // 2. Stampede Lock
         val lockKey = "$EVENT_LOCK_PREFIX$eventId"
-        val lockAcquired = tryAcquireStampedeLock(lockKey)
+        val lockAcquired = cacheHelper.tryAcquireStampedeLock(lockKey, STAMPEDE_LOCK_TTL)
 
         // 3. DB query
         val event = eventRepository.findEventWithVenueAndHall(eventId)
@@ -369,22 +368,6 @@ class EventService(
     }
 
     /**
-     * Cache Stampede Lock 획득 시도
-     *
-     * Lua 스크립트로 SET NX EX 원자적 실행. 락 획득 시 true 반환.
-     * Redis 장애 시 true 반환하여 DB 조회와 캐시 저장을 허용한다 (안전 방향).
-     */
-    private fun tryAcquireStampedeLock(lockKey: String): Boolean {
-        return try {
-            val result = redisTemplate.execute(cacheStampedeLockScript, listOf(lockKey), STAMPEDE_LOCK_TTL.toString())
-            result == 1L
-        } catch (e: Exception) {
-            log.warn("Stampede lock execution failed for key: $lockKey, treating as acquired", e)
-            true
-        }
-    }
-
-    /**
      * 공연 상세 캐시 단건 삭제 (REQ-EVT-019)
      */
     internal fun invalidateEventDetailCache(eventId: UUID) {
@@ -403,17 +386,23 @@ class EventService(
      */
     internal fun invalidateEventListCaches() {
         try {
-            val keys = mutableListOf<String>()
             redisTemplate.execute { conn ->
                 conn.scan(
                     ScanOptions.scanOptions().match("${EVENT_LIST_PREFIX}*").count(100).build()
                 ).use { cursor ->
-                    cursor.forEach { keyBytes -> keys.add(String(keyBytes)) }
+                    val batch = mutableListOf<String>()
+                    cursor.forEach { keyBytes ->
+                        batch.add(String(keyBytes))
+                        if (batch.size >= 100) {
+                            redisTemplate.delete(batch)
+                            batch.clear()
+                        }
+                    }
+                    if (batch.isNotEmpty()) {
+                        redisTemplate.delete(batch)
+                    }
                 }
                 null
-            }
-            if (keys.isNotEmpty()) {
-                redisTemplate.delete(keys)
             }
         } catch (e: DataAccessException) {
             log.warn("Redis event list cache invalidation failed", e)

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/HallService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/HallService.kt
@@ -3,6 +3,7 @@ package com.ticketqueue.event.service
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.config.CacheProperties
 import com.ticketqueue.event.dto.HallDto
 import com.ticketqueue.event.dto.SeatTemplateDto
 import com.ticketqueue.event.entity.Hall
@@ -10,8 +11,12 @@ import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.repository.EventRepository
 import com.ticketqueue.event.repository.HallRepository
 import com.ticketqueue.event.repository.VenueRepository
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataAccessException
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
 import java.util.UUID
 
 /**
@@ -21,6 +26,11 @@ import java.util.UUID
  * 좌석 템플릿(SeatTemplateDto)은 DTO 형태로 수신하여 검증 후 JSON 문자열로 직렬화하여 저장하고,
  * 조회 시에는 JSON 문자열을 다시 DTO로 역직렬화하여 반환한다.
  * ObjectMapper를 통해 SeatTemplateDto <-> JSONB 변환을 처리한다.
+ *
+ * Cache-Aside 전략 (REQ-EVT-017):
+ * - 홀 상세(좌석 배치도): `cache:layout:{hallId}` (String JSON, TTL 24시간)
+ * - 홀 구조는 변경 빈도가 매우 낮으므로 Stampede Lock 미적용
+ * - 캐시 무효화: 수정/삭제 시 해당 홀 캐시 제거 (REQ-EVT-019)
  */
 @Service
 @Transactional(readOnly = true)
@@ -28,8 +38,16 @@ class HallService(
     private val hallRepository: HallRepository,
     private val venueRepository: VenueRepository,
     private val eventRepository: EventRepository,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val redisTemplate: RedisTemplate<String, Any>,
+    private val cacheProperties: CacheProperties
 ) {
+
+    private val log = LoggerFactory.getLogger(HallService::class.java)
+
+    private companion object {
+        const val LAYOUT_CACHE_PREFIX = "cache:layout:"
+    }
 
     /**
      * 홀 생성
@@ -38,28 +56,18 @@ class HallService(
      * 2. 동일 공연장 내 홀 이름 중복 검증
      * 3. 좌석 템플릿 비즈니스 검증 (행-등급 매핑 일관성)
      * 4. SeatTemplateDto를 JSON 문자열로 직렬화하여 JSONB 컬럼에 저장
-     *
-     * @param venueId 홀이 속할 공연장 ID
-     * @param request 홀 생성 요청 (이름, 수용 인원, 좌석 템플릿)
-     * @return 생성된 홀 정보
-     * @throws EventException 공연장이 존재하지 않거나 (VENUE_NOT_FOUND),
-     *         동일 이름의 홀이 이미 존재하거나 (HALL_NAME_DUPLICATE),
-     *         좌석 템플릿 매핑이 올바르지 않을 경우 (INVALID_SEAT_TEMPLATE_MAPPING)
      */
     @Transactional
     fun createHall(venueId: UUID, request: HallDto.CreateRequest): HallDto.Response {
         val venue = venueRepository.findById(venueId)
             .orElseThrow { EventException(ErrorCode.VENUE_NOT_FOUND) }
 
-        // 동일 공연장 내 홀 이름 중복 검증
         if (hallRepository.existsByVenueIdAndName(venueId, request.name)) {
             throw EventException(ErrorCode.HALL_NAME_DUPLICATE)
         }
 
-        // 좌석 템플릿 비즈니스 검증
         validateSeatTemplate(request.seatTemplate)
 
-        // SeatTemplateDto -> JSON 문자열로 직렬화하여 JSONB 컬럼에 저장
         val seatTemplateJson = objectMapper.writeValueAsString(request.seatTemplate)
         val hall = Hall(
             venue = venue,
@@ -73,10 +81,6 @@ class HallService(
 
     /**
      * 특정 공연장의 홀 목록 조회
-     *
-     * @param venueId 공연장 ID
-     * @return 해당 공연장에 속한 홀 목록
-     * @throws EventException 공연장이 존재하지 않을 경우 (VENUE_NOT_FOUND)
      */
     fun getHalls(venueId: UUID): List<HallDto.Response> {
         if (!venueRepository.existsById(venueId)) {
@@ -87,55 +91,68 @@ class HallService(
     }
 
     /**
-     * 홀 상세 조회
+     * 홀 상세 조회 (좌석 배치도 포함) - Cache-Aside 적용
      *
-     * DB에 JSONB로 저장된 좌석 템플릿을 SeatTemplateDto로 역직렬화하여 응답에 포함한다.
+     * 홀 구조는 변경 빈도가 낮으므로 TTL 24시간을 적용하며,
+     * 관리자 전용 저빈도 API이므로 Stampede Lock은 적용하지 않는다.
      *
-     * @param venueId 공연장 ID
-     * @param hallId 홀 ID
-     * @return 홀 상세 정보 (좌석 템플릿 포함)
-     * @throws EventException 홀이 존재하지 않거나 (HALL_NOT_FOUND),
-     *         좌석 템플릿 데이터가 손상된 경우 (INVALID_SEAT_TEMPLATE)
+     * Cache-Aside 전략:
+     * 1. String JSON 캐시 조회 → hit 시 즉시 반환
+     * 2. miss 시 → DB 조회 → 캐시 저장
      */
     fun getHall(venueId: UUID, hallId: UUID): HallDto.DetailResponse {
+        val cacheKey = "$LAYOUT_CACHE_PREFIX$hallId"
+
+        // 1. Cache read
+        try {
+            val cached = redisTemplate.opsForValue().get(cacheKey) as? String
+            if (cached != null) {
+                return objectMapper.readValue(cached, HallDto.DetailResponse::class.java)
+            }
+        } catch (e: DataAccessException) {
+            log.warn("Redis cache read failed for key: $cacheKey", e)
+        } catch (e: JsonProcessingException) {
+            log.warn("Redis cache deserialization failed for key: $cacheKey, skipping cache", e)
+            try { redisTemplate.delete(cacheKey) } catch (ignored: DataAccessException) {}
+        }
+
+        // 2. DB query
         val hall = findHallByVenueIdAndId(venueId, hallId)
-        // JSONB 문자열 -> SeatTemplateDto 역직렬화 (에러 핸들링)
         val seatTemplate = try {
             objectMapper.readValue(hall.seatTemplate, SeatTemplateDto::class.java)
         } catch (e: JsonProcessingException) {
             throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE, cause = e)
         }
-        return HallDto.DetailResponse.from(hall, seatTemplate)
+        val detailResponse = HallDto.DetailResponse.from(hall, seatTemplate)
+
+        // 3. Cache write
+        try {
+            val json = objectMapper.writeValueAsString(detailResponse)
+            redisTemplate.opsForValue().set(cacheKey, json, Duration.ofSeconds(cacheProperties.layout.ttl))
+        } catch (e: DataAccessException) {
+            log.warn("Redis cache write failed for key: $cacheKey", e)
+        } catch (e: JsonProcessingException) {
+            log.warn("Redis cache serialization failed for key: $cacheKey", e)
+        }
+
+        return detailResponse
     }
 
     /**
      * 홀 부분 수정 (PATCH)
      *
-     * 1. 이름 변경 요청 시에만 중복 검증 수행 (기존 이름과 다를 때만)
-     *    - 자기 자신을 제외한 동일 공연장 내 이름 중복 체크 (idNot 조건)
-     * 2. seatTemplate이 요청에 포함된 경우 비즈니스 검증 후 JSON 직렬화 수행
-     * 3. null 필드는 엔티티의 update()에서 무시됨 (기존 값 유지)
-     *
-     * @param venueId 공연장 ID
-     * @param hallId 수정할 홀 ID
-     * @param request 수정할 필드 (null인 필드는 변경하지 않음)
-     * @return 수정된 홀 정보
-     * @throws EventException 홀이 존재하지 않거나 (HALL_NOT_FOUND),
-     *         동일 이름의 홀이 이미 존재하거나 (HALL_NAME_DUPLICATE),
-     *         좌석 템플릿 매핑이 올바르지 않을 경우 (INVALID_SEAT_TEMPLATE_MAPPING)
+     * 수정 성공 후 해당 홀의 좌석 배치도 캐시를 무효화한다.
      */
     @Transactional
     fun updateHall(venueId: UUID, hallId: UUID, request: HallDto.UpdateRequest): HallDto.UpdateResponse {
         val hall = findHallByVenueIdAndId(venueId, hallId)
 
-        // 이름이 실제로 변경될 때만 중복 검증 (자기 자신 제외)
         if (request.name != null && request.name != hall.name) {
             if (hallRepository.existsByVenueIdAndNameExcluding(venueId, request.name, hallId)) {
                 throw EventException(ErrorCode.HALL_NAME_DUPLICATE)
             }
         }
 
-        // seatTemplate이 요청에 포함된 경우 비즈니스 검증 및 JSON 직렬화
         val seatTemplateJson = request.seatTemplate?.let {
             validateSeatTemplate(it)
             objectMapper.writeValueAsString(it)
@@ -145,30 +162,26 @@ class HallService(
             capacity = request.capacity,
             seatTemplate = seatTemplateJson
         )
+
+        invalidateLayoutCache(hallId)
         return HallDto.UpdateResponse.from(hall)
     }
 
     /**
      * 홀 삭제
      *
-     * 삭제 전 해당 홀에 등록된 이벤트가 있는지 확인하여 데이터 무결성을 보장한다.
-     *
-     * @param venueId 공연장 ID
-     * @param hallId 삭제할 홀 ID
-     * @return 삭제 완료 메시지
-     * @throws EventException 홀이 존재하지 않거나 (HALL_NOT_FOUND),
-     *         연관된 이벤트가 있을 경우 (HALL_HAS_EVENTS)
+     * 삭제 성공 후 해당 홀의 좌석 배치도 캐시를 무효화한다.
      */
     @Transactional
     fun deleteHall(venueId: UUID, hallId: UUID): HallDto.DeleteResponse {
         val hall = findHallByVenueIdAndId(venueId, hallId)
 
-        // 이벤트가 등록된 홀은 삭제 불가
         if (eventRepository.existsByHallId(hallId)) {
             throw EventException(ErrorCode.HALL_HAS_EVENTS)
         }
 
         hallRepository.delete(hall)
+        invalidateLayoutCache(hallId)
         return HallDto.DeleteResponse(message = "홀이 삭제되었습니다.")
     }
 
@@ -179,24 +192,25 @@ class HallService(
 
     /**
      * 좌석 템플릿 비즈니스 검증
-     *
-     * 1. 모든 행(rows)이 gradeMapping에 매핑되어 있는지 확인
-     * 2. 중복 행 이름 검증
-     *
-     * @param seatTemplate 검증할 좌석 템플릿
-     * @throws EventException 좌석 템플릿 매핑이 올바르지 않을 경우 (INVALID_SEAT_TEMPLATE_MAPPING)
      */
     private fun validateSeatTemplate(seatTemplate: SeatTemplateDto) {
-        // 중복 행 이름 검증
         val uniqueRows = seatTemplate.rows.toSet()
         if (uniqueRows.size != seatTemplate.rows.size) {
             throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING)
         }
-
-        // rows와 gradeMapping 키가 완전히 일치하는지 양방향 검증
-        // 정방향: 매핑 누락 행 검출 / 역방향: 잉여 매핑 키 검출
         if (uniqueRows != seatTemplate.gradeMapping.keys) {
             throw EventException(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING)
+        }
+    }
+
+    /**
+     * 홀 좌석 배치도 캐시 삭제 (REQ-EVT-019)
+     */
+    private fun invalidateLayoutCache(hallId: UUID) {
+        try {
+            redisTemplate.delete("$LAYOUT_CACHE_PREFIX$hallId")
+        } catch (e: DataAccessException) {
+            log.warn("Redis layout cache invalidation failed for hallId: $hallId", e)
         }
     }
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.dao.DataAccessException
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.data.redis.core.script.DefaultRedisScript
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -48,7 +47,7 @@ class ScheduleService(
     private val objectMapper: ObjectMapper,
     private val redisTemplate: RedisTemplate<String, Any>,
     private val cacheProperties: CacheProperties,
-    private val cacheStampedeLockScript: DefaultRedisScript<Long>,
+    private val cacheHelper: CacheHelper,
     private val eventService: EventService
 ) {
 
@@ -152,7 +151,7 @@ class ScheduleService(
 
         // 2. Stampede Lock
         val lockKey = "$SCHEDULE_LOCK_PREFIX$scheduleId"
-        val lockAcquired = tryAcquireStampedeLock(lockKey)
+        val lockAcquired = cacheHelper.tryAcquireStampedeLock(lockKey, STAMPEDE_LOCK_TTL)
 
         // 3. DB query
         val schedule = eventScheduleRepository.findById(scheduleId)
@@ -241,16 +240,6 @@ class ScheduleService(
             (1..seatTemplate.seatsPerRow).map { seatIndex ->
                 Seat(eventSchedule = schedule, seatNumber = "${row}-${seatIndex}", grade = grade, price = price)
             }
-        }
-    }
-
-    private fun tryAcquireStampedeLock(lockKey: String): Boolean {
-        return try {
-            val result = redisTemplate.execute(cacheStampedeLockScript, listOf(lockKey), STAMPEDE_LOCK_TTL.toString())
-            result == 1L
-        } catch (e: Exception) {
-            log.warn("Stampede lock execution failed for key: $lockKey, treating as acquired", e)
-            true
         }
     }
 

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.common.util.DateTimeUtils
+import com.ticketqueue.event.config.CacheProperties
 import com.ticketqueue.event.dto.ScheduleDto
 import com.ticketqueue.event.dto.SeatTemplateDto
 import com.ticketqueue.event.entity.EventSchedule
@@ -13,10 +14,15 @@ import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.repository.EventRepository
 import com.ticketqueue.event.repository.EventScheduleRepository
 import com.ticketqueue.event.repository.SeatRepository
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataAccessException
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.script.DefaultRedisScript
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
+import java.time.Duration
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -27,6 +33,11 @@ import java.util.UUID
  * - 회차 생성 시 Hall seatTemplate 기반 좌석 자동 초기화 (EventService와 동일 로직)
  * - 상태 전이: UPCOMING → ONGOING/CANCELLED, ONGOING → ENDED/CANCELLED (도메인 메서드 위임)
  * - REQ-EVT-001, REQ-EVT-007
+ *
+ * Cache-Aside 전략 (REQ-EVT-017):
+ * - 회차 상세: `cache:schedule:{scheduleId}` (String JSON, TTL 5분)
+ * - Cache Stampede 방지: Lua 스크립트 락 (REQ-EVT-021)
+ * - 캐시 무효화: 회차 생성/상태 변경 시 관련 캐시 제거 (REQ-EVT-019)
  */
 @Service
 @Transactional(readOnly = true)
@@ -34,17 +45,25 @@ class ScheduleService(
     private val eventRepository: EventRepository,
     private val eventScheduleRepository: EventScheduleRepository,
     private val seatRepository: SeatRepository,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val redisTemplate: RedisTemplate<String, Any>,
+    private val cacheProperties: CacheProperties,
+    private val cacheStampedeLockScript: DefaultRedisScript<Long>,
+    private val eventService: EventService
 ) {
+
+    private val log = LoggerFactory.getLogger(ScheduleService::class.java)
+
+    private companion object {
+        const val SCHEDULE_DETAIL_PREFIX = "cache:schedule:"
+        const val SCHEDULE_LOCK_PREFIX = "cache:lock:schedule:"
+        const val STAMPEDE_LOCK_TTL = 10L
+    }
 
     /**
      * 특정 공연에 회차를 추가한다 (좌석 자동 초기화 포함)
      *
-     * 1. Event 존재 및 softDelete 여부 확인
-     * 2. playSequence 중복 검증
-     * 3. 시간 유효성 검증 (4가지 규칙)
-     * 4. seatTemplate 파싱 (fail-fast)
-     * 5. EventSchedule 저장 → 좌석 일괄 초기화
+     * 생성 성공 후 부모 공연 상세 캐시와 목록 캐시를 무효화한다.
      */
     @Transactional
     fun createSchedule(eventId: UUID, request: ScheduleDto.CreateRequest): ScheduleDto.CreateResponse {
@@ -81,7 +100,11 @@ class ScheduleService(
         val seats = initializeSeats(schedule, seatTemplate, request.priceByGrade)
         seatRepository.saveAll(seats)
 
-        return ScheduleDto.CreateResponse.from(schedule)
+        val response = ScheduleDto.CreateResponse.from(schedule)
+        // 부모 공연 상세 캐시 및 목록 캐시 무효화
+        eventService.invalidateEventDetailCache(eventId)
+        eventService.invalidateEventListCaches()
+        return response
     }
 
     /**
@@ -105,23 +128,59 @@ class ScheduleService(
     }
 
     /**
-     * 회차 상세를 조회한다
+     * 회차 상세를 조회한다 - Cache-Aside 적용
      *
-     * LAZY event 접근으로 추가 쿼리 1회 발생 (단건 조회라 허용)
+     * Cache-Aside 전략:
+     * 1. String JSON 캐시 조회 → hit 시 즉시 반환
+     * 2. miss 시 → Stampede Lock 시도 → DB 조회 → 캐시 저장
      */
     fun getSchedule(scheduleId: UUID): ScheduleDto.DetailResponse {
+        val cacheKey = "$SCHEDULE_DETAIL_PREFIX$scheduleId"
+
+        // 1. Cache read
+        try {
+            val cached = redisTemplate.opsForValue().get(cacheKey) as? String
+            if (cached != null) {
+                return objectMapper.readValue(cached, ScheduleDto.DetailResponse::class.java)
+            }
+        } catch (e: DataAccessException) {
+            log.warn("Redis cache read failed for key: $cacheKey", e)
+        } catch (e: JsonProcessingException) {
+            log.warn("Redis cache deserialization failed for key: $cacheKey, skipping cache", e)
+            try { redisTemplate.delete(cacheKey) } catch (ignored: DataAccessException) {}
+        }
+
+        // 2. Stampede Lock
+        val lockKey = "$SCHEDULE_LOCK_PREFIX$scheduleId"
+        val lockAcquired = tryAcquireStampedeLock(lockKey)
+
+        // 3. DB query
         val schedule = eventScheduleRepository.findById(scheduleId)
             .orElseThrow { EventException(ErrorCode.SCHEDULE_NOT_FOUND) }
 
         val availableScheduleIds = eventRepository.findScheduleIdsWithAvailableSeats(listOf(scheduleId))
         val isSoldOut = scheduleId !in availableScheduleIds
+        val detailResponse = ScheduleDto.DetailResponse.from(schedule, isSoldOut)
 
-        return ScheduleDto.DetailResponse.from(schedule, isSoldOut)
+        // 4. Cache write (락 획득 성공 시에만)
+        if (lockAcquired) {
+            try {
+                val json = objectMapper.writeValueAsString(detailResponse)
+                redisTemplate.opsForValue().set(cacheKey, json, Duration.ofSeconds(cacheProperties.schedule.ttl))
+            } catch (e: DataAccessException) {
+                log.warn("Redis cache write failed for key: $cacheKey", e)
+            } catch (e: JsonProcessingException) {
+                log.warn("Redis cache serialization failed for key: $cacheKey", e)
+            }
+        }
+
+        return detailResponse
     }
 
     /**
      * 회차 상태를 변경한다
      *
+     * 상태 변경 성공 후 회차 상세, 부모 공연 상세, 공연 목록 캐시를 무효화한다.
      * 유효하지 않은 전이 시 EventSchedule.changeStatus()에서 INVALID_SCHEDULE_STATUS 예외 발생
      */
     @Transactional
@@ -132,6 +191,11 @@ class ScheduleService(
         val previousStatus = schedule.status
         schedule.changeStatus(request.status)
 
+        val eventId = schedule.event.id!!
+        invalidateScheduleDetailCache(scheduleId)
+        eventService.invalidateEventDetailCache(eventId)
+        eventService.invalidateEventListCaches()
+
         return ScheduleDto.ChangeStatusResponse(
             id = schedule.id!!,
             previousStatus = previousStatus,
@@ -139,6 +203,8 @@ class ScheduleService(
             updatedAt = schedule.updatedAt!!
         )
     }
+
+    // ===== Private Helper Methods =====
 
     private fun validateScheduleTime(
         eventStartAt: LocalDateTime,
@@ -175,6 +241,24 @@ class ScheduleService(
             (1..seatTemplate.seatsPerRow).map { seatIndex ->
                 Seat(eventSchedule = schedule, seatNumber = "${row}-${seatIndex}", grade = grade, price = price)
             }
+        }
+    }
+
+    private fun tryAcquireStampedeLock(lockKey: String): Boolean {
+        return try {
+            val result = redisTemplate.execute(cacheStampedeLockScript, listOf(lockKey), STAMPEDE_LOCK_TTL.toString())
+            result == 1L
+        } catch (e: Exception) {
+            log.warn("Stampede lock execution failed for key: $lockKey, treating as acquired", e)
+            true
+        }
+    }
+
+    internal fun invalidateScheduleDetailCache(scheduleId: UUID) {
+        try {
+            redisTemplate.delete("$SCHEDULE_DETAIL_PREFIX$scheduleId")
+        } catch (e: DataAccessException) {
+            log.warn("Redis schedule cache invalidation failed for scheduleId: $scheduleId", e)
         }
     }
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
@@ -2,14 +2,15 @@ package com.ticketqueue.event.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.config.CacheProperties
 import com.ticketqueue.event.dto.SeatDto
 import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.repository.EventScheduleRepository
 import com.ticketqueue.event.repository.SeatRepository
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.dao.DataAccessException
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.script.DefaultRedisScript
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Duration
@@ -23,6 +24,7 @@ import java.util.UUID
  * - [getSoldSeatIds]: SOLD 좌석 ID 조회 (캐싱 없음 - 실시간 정확도 우선)
  *
  * Redis 장애 시 try-catch로 무시하고 DB fallback을 수행하여 서비스 가용성을 유지한다.
+ * Cache Stampede 방지: Lua 스크립트로 원자적 락 획득 (REQ-EVT-021)
  */
 @Service
 @Transactional(readOnly = true)
@@ -31,18 +33,21 @@ class SeatService(
     private val seatRepository: SeatRepository,
     private val redisTemplate: RedisTemplate<String, Any>,
     private val objectMapper: ObjectMapper,
-    @Value("\${cache.seats.ttl:300}") private val seatsCacheTtl: Long
+    private val cacheProperties: CacheProperties,
+    private val cacheStampedeLockScript: DefaultRedisScript<Long>
 ) {
 
     private val log = LoggerFactory.getLogger(SeatService::class.java)
     private val cacheKeyPrefix = "cache:seats:"
+    private val lockKeyPrefix = "cache:lock:seats:"
+    private val stampedeLockTtl = 10L
 
     /**
      * 회차별 좌석 목록을 등급 그룹핑하여 반환한다 (REQ-EVT-006, P95 < 300ms)
      *
      * Cache-Aside 전략:
      * 1. Redis Hash 캐시 조회 (등급별 필드) → Hit 시 즉시 반환
-     * 2. Miss 시 → DB 조회 → 등급별 그룹핑 (VIP → S → A → B 순) → Hash 필드로 캐시 저장
+     * 2. Miss 시 → Stampede Lock 시도 → DB 조회 → 등급별 그룹핑 → Hash 필드로 캐시 저장
      *
      * Redis 장애 시 DB fallback으로 정상 응답을 보장한다.
      */
@@ -84,12 +89,18 @@ class SeatService(
 
         val response = SeatDto.SeatsResponse(scheduleId = scheduleId, grades = grades)
 
-        try {
-            val gradeMap = response.grades.associate { gradeGroup -> gradeGroup.grade.name to gradeGroup }
-            redisTemplate.opsForHash<String, Any>().putAll(cacheKey, gradeMap)
-            redisTemplate.expire(cacheKey, Duration.ofSeconds(seatsCacheTtl))
-        } catch (e: DataAccessException) {
-            log.warn("Redis cache write failed for key: $cacheKey", e)
+        // Stampede Lock 획득 성공 시에만 캐시 저장
+        val lockKey = "$lockKeyPrefix$scheduleId"
+        val lockAcquired = tryAcquireStampedeLock(lockKey)
+
+        if (lockAcquired) {
+            try {
+                val gradeMap = response.grades.associate { gradeGroup -> gradeGroup.grade.name to gradeGroup }
+                redisTemplate.opsForHash<String, Any>().putAll(cacheKey, gradeMap)
+                redisTemplate.expire(cacheKey, Duration.ofSeconds(cacheProperties.seats.ttl))
+            } catch (e: DataAccessException) {
+                log.warn("Redis cache write failed for key: $cacheKey", e)
+            }
         }
 
         return response
@@ -107,5 +118,15 @@ class SeatService(
 
         val soldSeatIds = seatRepository.findSoldSeatIdsByScheduleId(scheduleId)
         return SeatDto.SoldSeatsResponse(scheduleId = scheduleId, soldSeatIds = soldSeatIds)
+    }
+
+    private fun tryAcquireStampedeLock(lockKey: String): Boolean {
+        return try {
+            val result = redisTemplate.execute(cacheStampedeLockScript, listOf(lockKey), stampedeLockTtl.toString())
+            result == 1L
+        } catch (e: Exception) {
+            log.warn("Stampede lock execution failed for key: $lockKey, treating as acquired", e)
+            true
+        }
     }
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
@@ -10,7 +10,6 @@ import com.ticketqueue.event.repository.SeatRepository
 import org.slf4j.LoggerFactory
 import org.springframework.dao.DataAccessException
 import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.data.redis.core.script.DefaultRedisScript
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Duration
@@ -34,7 +33,7 @@ class SeatService(
     private val redisTemplate: RedisTemplate<String, Any>,
     private val objectMapper: ObjectMapper,
     private val cacheProperties: CacheProperties,
-    private val cacheStampedeLockScript: DefaultRedisScript<Long>
+    private val cacheHelper: CacheHelper
 ) {
 
     private val log = LoggerFactory.getLogger(SeatService::class.java)
@@ -91,7 +90,7 @@ class SeatService(
 
         // Stampede Lock 획득 성공 시에만 캐시 저장
         val lockKey = "$lockKeyPrefix$scheduleId"
-        val lockAcquired = tryAcquireStampedeLock(lockKey)
+        val lockAcquired = cacheHelper.tryAcquireStampedeLock(lockKey, stampedeLockTtl)
 
         if (lockAcquired) {
             try {
@@ -120,13 +119,4 @@ class SeatService(
         return SeatDto.SoldSeatsResponse(scheduleId = scheduleId, soldSeatIds = soldSeatIds)
     }
 
-    private fun tryAcquireStampedeLock(lockKey: String): Boolean {
-        return try {
-            val result = redisTemplate.execute(cacheStampedeLockScript, listOf(lockKey), stampedeLockTtl.toString())
-            result == 1L
-        } catch (e: Exception) {
-            log.warn("Stampede lock execution failed for key: $lockKey, treating as acquired", e)
-            true
-        }
-    }
 }

--- a/backend/event-service/src/main/resources/application.yml
+++ b/backend/event-service/src/main/resources/application.yml
@@ -33,6 +33,8 @@ cache:
     ttl: 300
   seats:
     ttl: 300
+  layout:
+    ttl: 86400  # 24 hours — 홀 좌석 배치도는 거의 변경되지 않음
 
 internal:
   api:

--- a/backend/event-service/src/main/resources/lua/cache-stampede-lock.lua
+++ b/backend/event-service/src/main/resources/lua/cache-stampede-lock.lua
@@ -1,0 +1,18 @@
+-- Cache Stampede 방지 Lua 스크립트 (REQ-EVT-021)
+--
+-- SET NX EX 를 원자적으로 실행하여 락을 획득한다.
+-- 동시 다발적 캐시 Miss 시 단 하나의 요청만 DB 조회 + 캐시 저장을 수행하게 한다.
+--
+-- KEYS[1] = 락 키 (예: cache:lock:event:{eventId})
+-- ARGV[1] = 락 TTL (초)
+--
+-- Returns:
+--   1 : 락 획득 성공 (이 요청이 DB 조회 및 캐시 저장을 담당)
+--   0 : 락 이미 존재 (다른 요청이 이미 처리 중)
+
+local result = redis.call('SET', KEYS[1], '1', 'NX', 'EX', ARGV[1])
+if result then
+    return 1
+else
+    return 0
+end

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
@@ -3,6 +3,7 @@ package com.ticketqueue.event.service
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.config.CacheProperties
 import com.ticketqueue.event.dto.EventDto
 import com.ticketqueue.event.dto.SeatTemplateDto
 import com.ticketqueue.event.entity.Event
@@ -32,9 +33,17 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.dao.DataAccessException
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.redis.RedisConnectionFailureException
+import org.springframework.data.redis.core.RedisCallback
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import org.springframework.data.redis.core.script.DefaultRedisScript
 import java.math.BigDecimal
+import java.time.Duration
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.Optional
 import java.util.UUID
@@ -47,8 +56,12 @@ class EventServiceTest {
     private lateinit var venueRepository: VenueRepository
     private lateinit var hallRepository: HallRepository
     private lateinit var objectMapper: ObjectMapper
+    private lateinit var redisTemplate: RedisTemplate<String, Any>
+    private lateinit var valueOps: ValueOperations<String, Any>
+    private lateinit var stampedeLockScript: DefaultRedisScript<Long>
     private lateinit var eventService: EventService
 
+    private val cacheProperties = CacheProperties()
     private val venueId = UUID.randomUUID()
     private val hallId = UUID.randomUUID()
     private val eventId = UUID.randomUUID()
@@ -107,9 +120,26 @@ class EventServiceTest {
         venueRepository = mockk()
         hallRepository = mockk()
         objectMapper = mockk()
+        redisTemplate = mockk()
+        valueOps = mockk(relaxed = true)
+        stampedeLockScript = mockk()
+
+        // Redis 기본 동작: 캐시 Miss, 락 획득 성공, 조용한 삭제
+        every { redisTemplate.opsForValue() } returns valueOps
+        every { valueOps.get(any<String>()) } returns null
+        every {
+            redisTemplate.execute(any<DefaultRedisScript<Long>>(), any<List<String>>(), any<String>())
+        } returns 1L
+        every { redisTemplate.execute(any<RedisCallback<Any?>>()) } returns null
+        every { redisTemplate.delete(any<String>()) } returns true
+        every { redisTemplate.delete(any<Collection<String>>()) } returns 0L
+        // ObjectMapper 기본: 직렬화 성공 (캐시 저장용)
+        every { objectMapper.writeValueAsString(any()) } returns "{}"
+
         eventService = EventService(
             eventRepository, eventScheduleRepository, seatRepository,
-            venueRepository, hallRepository, objectMapper
+            venueRepository, hallRepository, objectMapper,
+            redisTemplate, cacheProperties, stampedeLockScript
         )
     }
 
@@ -159,6 +189,7 @@ class EventServiceTest {
             assertEquals(eventId, result.id)
             assertEquals("BTS World Tour", result.title)
             verify { seatRepository.saveAll(any<List<Seat>>()) }
+            verify { redisTemplate.execute(any<RedisCallback<Any?>>()) }  // list cache 무효화 SCAN 수행
         }
 
         @Test
@@ -194,7 +225,7 @@ class EventServiceTest {
                 priceByGrade = priceByGrade,
                 schedules = listOf(
                     scheduleRequest,
-                    scheduleRequest.copy(eventStartAt = now.plusDays(60)) // playSequence 중복
+                    scheduleRequest.copy(eventStartAt = now.plusDays(60))
                 )
             )
 
@@ -212,7 +243,7 @@ class EventServiceTest {
             val hall = createHall(venue)
             val invalidSchedule = scheduleRequest.copy(
                 eventStartAt = now.plusDays(30).plusHours(3),
-                eventEndAt = now.plusDays(30) // 종료가 시작보다 앞섬
+                eventEndAt = now.plusDays(30)
             )
             val request = EventDto.CreateRequest(
                 title = "BTS World Tour", artist = "BTS",
@@ -286,7 +317,7 @@ class EventServiceTest {
             val templateWithMissingGrade = SeatTemplateDto(
                 rows = listOf("A", "B"),
                 seatsPerRow = 1,
-                gradeMapping = mapOf("A" to "VIP") // B 행 매핑 없음
+                gradeMapping = mapOf("A" to "VIP")
             )
             val request = EventDto.CreateRequest(
                 title = "BTS World Tour", artist = "BTS",
@@ -313,12 +344,12 @@ class EventServiceTest {
             val templateWithSGrade = SeatTemplateDto(
                 rows = listOf("A"),
                 seatsPerRow = 1,
-                gradeMapping = mapOf("A" to "S") // S 등급인데 가격 없음
+                gradeMapping = mapOf("A" to "S")
             )
             val request = EventDto.CreateRequest(
                 title = "BTS World Tour", artist = "BTS",
                 venueId = venueId, hallId = hallId,
-                priceByGrade = mapOf(SeatGrade.VIP to BigDecimal("100000")), // S 가격 없음
+                priceByGrade = mapOf(SeatGrade.VIP to BigDecimal("100000")),
                 schedules = listOf(scheduleRequest)
             )
             every { venueRepository.findById(venueId) } returns Optional.of(venue)
@@ -338,7 +369,7 @@ class EventServiceTest {
             val hall = createHall(venue)
             val invalidSchedule = scheduleRequest.copy(
                 saleStartAt = now.plusDays(29),
-                saleEndAt = now.plusDays(1) // saleEnd < saleStart
+                saleEndAt = now.plusDays(1)
             )
             val request = EventDto.CreateRequest(
                 title = "BTS World Tour", artist = "BTS",
@@ -358,7 +389,7 @@ class EventServiceTest {
             val venue = createVenue()
             val hall = createHall(venue)
             val invalidSchedule = scheduleRequest.copy(
-                saleEndAt = now.plusDays(31) // eventStartAt(+30일) 이후라 판매 마감 불가
+                saleEndAt = now.plusDays(31)
             )
             val request = EventDto.CreateRequest(
                 title = "BTS World Tour", artist = "BTS",
@@ -381,7 +412,7 @@ class EventServiceTest {
                 eventStartAt = now.minusDays(1),
                 eventEndAt = now.minusDays(1).plusHours(2),
                 saleStartAt = now.minusDays(30),
-                saleEndAt = now.minusDays(2) // saleEndAt < eventStartAt 조건 충족
+                saleEndAt = now.minusDays(2)
             )
             val request = EventDto.CreateRequest(
                 title = "BTS World Tour", artist = "BTS",
@@ -461,7 +492,7 @@ class EventServiceTest {
             eventService.createEvent(request)
 
             val savedSeats = seatsSlot.captured
-            assertEquals(2, savedSeats.size) // rows=["A"], seatsPerRow=2 → 2개
+            assertEquals(2, savedSeats.size)
             assertEquals("A-1", savedSeats[0].seatNumber)
             assertEquals("A-2", savedSeats[1].seatNumber)
             assertTrue(savedSeats.all { it.grade == SeatGrade.VIP })
@@ -517,6 +548,56 @@ class EventServiceTest {
             eventService.getEvents(-1, 200, null, null, null)
 
             verify { eventRepository.findEventList(match { it.pageNumber == 0 && it.pageSize == 100 }, null, null, null) }
+        }
+
+        @Test
+        @DisplayName("캐시 Hit - DB 조회 없이 캐시에서 즉시 반환한다")
+        fun cacheHit() {
+            val cachedContent = listOf(
+                EventDto.ListResponse(
+                    id = eventId, title = "BTS World Tour", artist = "BTS",
+                    venueName = "올림픽공원", startDate = now.plusDays(30),
+                    endDate = now.plusDays(31), status = EventStatus.OPEN
+                )
+            )
+            val cachedList = CachedEventList(content = cachedContent, page = 0, size = 20, totalElements = 1L)
+            val cacheKey = "cache:event:list:0:20:all"
+            val cachedJson = "{\"cached\":\"list\"}"
+
+            every { valueOps.get(cacheKey) } returns cachedJson
+            every { objectMapper.readValue(cachedJson, CachedEventList::class.java) } returns cachedList
+
+            val result = eventService.getEvents(0, 20, null, null, null)
+
+            assertEquals(1, result.totalElements)
+            assertEquals("BTS World Tour", result.content[0].title)
+            verify(exactly = 0) { eventRepository.findEventList(any(), any(), any(), any()) }
+        }
+
+        @Test
+        @DisplayName("캐시 Miss - DB 조회 후 캐시에 저장한다")
+        fun cacheMissWritesToCache() {
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(emptyList<EventDto.ListResponse>(), pageable, 0)
+            every { eventRepository.findEventList(any(), null, null, null) } returns page
+
+            eventService.getEvents(0, 20, null, null, null)
+
+            verify { objectMapper.writeValueAsString(any<CachedEventList>()) }
+            verify { valueOps.set(any<String>(), any(), any<Duration>()) }
+        }
+
+        @Test
+        @DisplayName("Redis 장애 시 DB fallback으로 정상 응답한다")
+        fun redisFallback() {
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(emptyList<EventDto.ListResponse>(), pageable, 0)
+            every { valueOps.get(any<String>()) } throws RedisConnectionFailureException("connection failed")
+            every { eventRepository.findEventList(any(), null, null, null) } returns page
+
+            val result = eventService.getEvents(0, 20, null, null, null)
+
+            assertEquals(0, result.totalElements)
         }
     }
 
@@ -586,7 +667,6 @@ class EventServiceTest {
             val hall = createHall(venue)
             val event = createEvent(venue, hall)
             val scheduleId2 = UUID.randomUUID()
-            // 자정을 넘지 않도록 정오(12:00) 기준으로 고정 — 시간대 flakiness 방지
             val baseTime = now.toLocalDate().atTime(12, 0).plusDays(30)
             val scheduleEarly = EventSchedule(
                 id = scheduleId, event = event, playSequence = 1,
@@ -596,7 +676,7 @@ class EventServiceTest {
             )
             val scheduleLate = EventSchedule(
                 id = scheduleId2, event = event, playSequence = 2,
-                eventStartAt = baseTime.plusHours(3), // 같은 날 15:00 — 자정 경계 없음
+                eventStartAt = baseTime.plusHours(3),
                 eventEndAt = baseTime.plusHours(5),
                 saleStartAt = now.plusDays(1), saleEndAt = now.plusDays(29),
                 createdAt = now, updatedAt = now
@@ -646,6 +726,67 @@ class EventServiceTest {
             val result = eventService.getEvent(eventId)
 
             assertTrue(result.schedules.isEmpty())
+        }
+
+        @Test
+        @DisplayName("캐시 Hit - DB 조회 없이 캐시에서 즉시 반환한다")
+        fun cacheHit() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+            val detailResponse = EventDto.DetailResponse(
+                id = eventId, title = "BTS World Tour", artist = "BTS",
+                description = null, venueId = venueId, venueName = "올림픽공원",
+                hallId = hallId, hallName = "KSPO DOME", status = EventStatus.PREPARING,
+                schedules = emptyList(), createdAt = now, updatedAt = now
+            )
+            val cacheKey = "cache:event:$eventId"
+            val cachedJson = "{\"cached\":\"event\"}"
+
+            every { valueOps.get(cacheKey) } returns cachedJson
+            every { objectMapper.readValue(cachedJson, EventDto.DetailResponse::class.java) } returns detailResponse
+
+            val result = eventService.getEvent(eventId)
+
+            assertEquals(eventId, result.id)
+            verify(exactly = 0) { eventRepository.findEventWithVenueAndHall(any()) }
+        }
+
+        @Test
+        @DisplayName("캐시 Miss - DB 조회 후 캐시에 저장한다")
+        fun cacheMissWritesToCache() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+
+            every { eventRepository.findEventWithVenueAndHall(eventId) } returns event
+            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns listOf(schedule)
+            every { eventRepository.findScheduleIdsWithAvailableSeats(any()) } returns setOf(scheduleId)
+
+            eventService.getEvent(eventId)
+
+            verify { objectMapper.writeValueAsString(any<EventDto.DetailResponse>()) }
+            verify { valueOps.set("cache:event:$eventId", any(), any<Duration>()) }
+        }
+
+        @Test
+        @DisplayName("Redis 장애 시 DB fallback으로 정상 응답한다")
+        fun redisFallback() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+
+            every { valueOps.get(any<String>()) } throws RedisConnectionFailureException("connection failed")
+            every { eventRepository.findEventWithVenueAndHall(eventId) } returns event
+            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns listOf(schedule)
+            every { eventRepository.findScheduleIdsWithAvailableSeats(any()) } returns setOf(scheduleId)
+
+            val result = eventService.getEvent(eventId)
+
+            assertEquals(eventId, result.id)
         }
     }
 
@@ -727,8 +868,8 @@ class EventServiceTest {
             val result = eventService.updateEvent(eventId, EventDto.UpdateRequest(description = "새 설명"))
 
             assertEquals("새 설명", result.description)
-            assertEquals("BTS World Tour", result.title) // 변경 없음
-            assertEquals("BTS", result.artist)           // 변경 없음
+            assertEquals("BTS World Tour", result.title)
+            assertEquals("BTS", result.artist)
         }
 
         @Test
@@ -744,6 +885,22 @@ class EventServiceTest {
             val result = eventService.updateEvent(eventId, EventDto.UpdateRequest(description = ""))
 
             assertNull(result.description)
+        }
+
+        @Test
+        @DisplayName("수정 성공 시 상세 캐시와 목록 캐시를 모두 무효화한다")
+        fun cacheInvalidationOnUpdate() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.existsByEventIdAndSaleStartAtLessThanEqual(eventId, any()) } returns false
+
+            eventService.updateEvent(eventId, EventDto.UpdateRequest(title = "새 제목"))
+
+            verify { redisTemplate.delete("cache:event:$eventId") }
+            verify { redisTemplate.execute(any<RedisCallback<Any?>>()) }  // list cache SCAN
         }
     }
 
@@ -764,7 +921,7 @@ class EventServiceTest {
             val result = eventService.deleteEvent(eventId)
 
             assertNotNull(result.message)
-            assertNotNull(event.deletedAt) // soft delete로 deletedAt이 채워졌는지 확인
+            assertNotNull(event.deletedAt)
         }
 
         @Test
@@ -819,6 +976,22 @@ class EventServiceTest {
 
             val deletedAt = event.deletedAt!!
             assertTrue(!deletedAt.isBefore(before) && !deletedAt.isAfter(after))
+        }
+
+        @Test
+        @DisplayName("삭제 성공 시 상세 캐시와 목록 캐시를 모두 무효화한다")
+        fun cacheInvalidationOnDelete() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            every { eventRepository.findByIdForUpdate(eventId) } returns event
+            every { seatRepository.existsByEventIdAndStatus(eventId, SeatStatus.SOLD) } returns false
+
+            eventService.deleteEvent(eventId)
+
+            verify { redisTemplate.delete("cache:event:$eventId") }
+            verify { redisTemplate.execute(any<RedisCallback<Any?>>()) }  // list cache SCAN
         }
     }
 }

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
@@ -40,7 +40,6 @@ import org.springframework.data.redis.RedisConnectionFailureException
 import org.springframework.data.redis.core.RedisCallback
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.core.ValueOperations
-import org.springframework.data.redis.core.script.DefaultRedisScript
 import java.math.BigDecimal
 import java.time.Duration
 import java.time.LocalDate
@@ -58,7 +57,7 @@ class EventServiceTest {
     private lateinit var objectMapper: ObjectMapper
     private lateinit var redisTemplate: RedisTemplate<String, Any>
     private lateinit var valueOps: ValueOperations<String, Any>
-    private lateinit var stampedeLockScript: DefaultRedisScript<Long>
+    private lateinit var cacheHelper: CacheHelper
     private lateinit var eventService: EventService
 
     private val cacheProperties = CacheProperties()
@@ -122,14 +121,12 @@ class EventServiceTest {
         objectMapper = mockk()
         redisTemplate = mockk()
         valueOps = mockk(relaxed = true)
-        stampedeLockScript = mockk()
+        cacheHelper = mockk()
 
         // Redis 기본 동작: 캐시 Miss, 락 획득 성공, 조용한 삭제
         every { redisTemplate.opsForValue() } returns valueOps
         every { valueOps.get(any<String>()) } returns null
-        every {
-            redisTemplate.execute(any<DefaultRedisScript<Long>>(), any<List<String>>(), any<String>())
-        } returns 1L
+        every { cacheHelper.tryAcquireStampedeLock(any(), any()) } returns true
         every { redisTemplate.execute(any<RedisCallback<Any?>>()) } returns null
         every { redisTemplate.delete(any<String>()) } returns true
         every { redisTemplate.delete(any<Collection<String>>()) } returns 0L
@@ -139,7 +136,7 @@ class EventServiceTest {
         eventService = EventService(
             eventRepository, eventScheduleRepository, seatRepository,
             venueRepository, hallRepository, objectMapper,
-            redisTemplate, cacheProperties, stampedeLockScript
+            redisTemplate, cacheProperties, cacheHelper
         )
     }
 
@@ -599,6 +596,20 @@ class EventServiceTest {
 
             assertEquals(0, result.totalElements)
         }
+
+        @Test
+        @DisplayName("Stampede Lock 미획득 시 DB 조회는 수행하지만 캐시 저장은 건너뛴다")
+        fun stampedeLockNotAcquired() {
+            val pageable = PageRequest.of(0, 20)
+            val page = PageImpl(emptyList<EventDto.ListResponse>(), pageable, 0)
+            every { eventRepository.findEventList(any(), null, null, null) } returns page
+            every { cacheHelper.tryAcquireStampedeLock(any(), any()) } returns false
+
+            val result = eventService.getEvents(0, 20, null, null, null)
+
+            assertEquals(0, result.totalElements)
+            verify(exactly = 0) { valueOps.set(any(), any(), any<Duration>()) }
+        }
     }
 
     @Nested
@@ -787,6 +798,25 @@ class EventServiceTest {
             val result = eventService.getEvent(eventId)
 
             assertEquals(eventId, result.id)
+        }
+
+        @Test
+        @DisplayName("Stampede Lock 미획득 시 DB 조회는 수행하지만 캐시 저장은 건너뛴다")
+        fun stampedeLockNotAcquired() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+
+            every { eventRepository.findEventWithVenueAndHall(eventId) } returns event
+            every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns listOf(schedule)
+            every { eventRepository.findScheduleIdsWithAvailableSeats(any()) } returns setOf(scheduleId)
+            every { cacheHelper.tryAcquireStampedeLock(any(), any()) } returns false
+
+            val result = eventService.getEvent(eventId)
+
+            assertEquals(eventId, result.id)
+            verify(exactly = 0) { valueOps.set(any(), any(), any<Duration>()) }
         }
     }
 

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/HallServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/HallServiceTest.kt
@@ -1,8 +1,10 @@
 package com.ticketqueue.event.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.config.CacheProperties
 import com.ticketqueue.event.dto.HallDto
 import com.ticketqueue.event.dto.SeatTemplateDto
 import com.ticketqueue.event.entity.Hall
@@ -21,6 +23,10 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.data.redis.RedisConnectionFailureException
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.time.Duration
 import java.time.LocalDateTime
 import java.util.Optional
 import java.util.UUID
@@ -31,8 +37,11 @@ class HallServiceTest {
     private lateinit var venueRepository: VenueRepository
     private lateinit var eventRepository: EventRepository
     private lateinit var objectMapper: ObjectMapper
+    private lateinit var redisTemplate: RedisTemplate<String, Any>
+    private lateinit var valueOps: ValueOperations<String, Any>
     private lateinit var hallService: HallService
 
+    private val cacheProperties = CacheProperties()
     private val venueId = UUID.randomUUID()
     private val hallId = UUID.randomUUID()
     private val now = LocalDateTime.now()
@@ -73,8 +82,18 @@ class HallServiceTest {
         hallRepository = mockk()
         venueRepository = mockk()
         eventRepository = mockk()
-        objectMapper = jacksonObjectMapper()
-        hallService = HallService(hallRepository, venueRepository, eventRepository, objectMapper)
+        objectMapper = jacksonObjectMapper().apply { registerModule(JavaTimeModule()) }
+        redisTemplate = mockk()
+        valueOps = mockk(relaxed = true)
+
+        every { redisTemplate.opsForValue() } returns valueOps
+        every { valueOps.get(any<String>()) } returns null
+        every { redisTemplate.delete(any<String>()) } returns true
+
+        hallService = HallService(
+            hallRepository, venueRepository, eventRepository,
+            objectMapper, redisTemplate, cacheProperties
+        )
     }
 
     @Nested
@@ -272,6 +291,45 @@ class HallServiceTest {
             }
             assertEquals(ErrorCode.INVALID_SEAT_TEMPLATE, exception.errorCode)
         }
+
+        @Test
+        @DisplayName("캐시 Hit - DB 조회 없이 캐시에서 즉시 반환한다")
+        fun cacheHit() {
+            val hall = createHall()
+            val detailResponse = HallDto.DetailResponse.from(hall, seatTemplateDto)
+            val cacheKey = "cache:layout:$hallId"
+            val cachedJson = objectMapper.writeValueAsString(detailResponse)
+
+            every { valueOps.get(cacheKey) } returns cachedJson
+
+            val result = hallService.getHall(venueId, hallId)
+
+            assertEquals(hallId, result.id)
+            verify(exactly = 0) { hallRepository.findByVenueIdAndId(any(), any()) }
+        }
+
+        @Test
+        @DisplayName("캐시 Miss - DB 조회 후 캐시에 저장한다")
+        fun cacheMissWritesToCache() {
+            val hall = createHall()
+            every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns hall
+
+            hallService.getHall(venueId, hallId)
+
+            verify { valueOps.set("cache:layout:$hallId", any(), any<Duration>()) }
+        }
+
+        @Test
+        @DisplayName("Redis 장애 시 DB fallback으로 정상 응답한다")
+        fun redisFallback() {
+            val hall = createHall()
+            every { valueOps.get(any<String>()) } throws RedisConnectionFailureException("connection failed")
+            every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns hall
+
+            val result = hallService.getHall(venueId, hallId)
+
+            assertEquals(hallId, result.id)
+        }
     }
 
     @Nested
@@ -339,6 +397,18 @@ class HallServiceTest {
             }
             assertEquals(ErrorCode.HALL_NAME_DUPLICATE, exception.errorCode)
         }
+
+        @Test
+        @DisplayName("수정 성공 시 좌석 배치도 캐시를 무효화한다")
+        fun cacheInvalidationOnUpdate() {
+            val hall = createHall()
+            val request = HallDto.UpdateRequest(capacity = 20000)
+            every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns hall
+
+            hallService.updateHall(venueId, hallId, request)
+
+            verify { redisTemplate.delete("cache:layout:$hallId") }
+        }
     }
 
     @Nested
@@ -381,6 +451,19 @@ class HallServiceTest {
                 hallService.deleteHall(venueId, hallId)
             }
             assertEquals(ErrorCode.HALL_HAS_EVENTS, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("삭제 성공 시 좌석 배치도 캐시를 무효화한다")
+        fun cacheInvalidationOnDelete() {
+            val hall = createHall()
+            every { hallRepository.findByVenueIdAndId(venueId, hallId) } returns hall
+            every { eventRepository.existsByHallId(hallId) } returns false
+            every { hallRepository.delete(hall) } returns Unit
+
+            hallService.deleteHall(venueId, hallId)
+
+            verify { redisTemplate.delete("cache:layout:$hallId") }
         }
     }
 }

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/HallServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/HallServiceTest.kt
@@ -316,7 +316,7 @@ class HallServiceTest {
 
             hallService.getHall(venueId, hallId)
 
-            verify { valueOps.set("cache:layout:$hallId", any(), any<Duration>()) }
+            verify { valueOps.set("cache:layout:$hallId", any(), eq(Duration.ofHours(24))) }
         }
 
         @Test

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.exception.ErrorCode
 import org.springframework.dao.DataIntegrityViolationException
+import com.ticketqueue.event.config.CacheProperties
 import com.ticketqueue.event.dto.ScheduleDto
 import com.ticketqueue.event.dto.SeatTemplateDto
 import com.ticketqueue.event.entity.Event
@@ -18,7 +19,9 @@ import com.ticketqueue.event.repository.EventRepository
 import com.ticketqueue.event.repository.EventScheduleRepository
 import com.ticketqueue.event.repository.SeatRepository
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -28,7 +31,12 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.data.redis.RedisConnectionFailureException
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import org.springframework.data.redis.core.script.DefaultRedisScript
 import java.math.BigDecimal
+import java.time.Duration
 import java.time.LocalDateTime
 import java.util.Optional
 import java.util.UUID
@@ -39,8 +47,13 @@ class ScheduleServiceTest {
     private lateinit var eventScheduleRepository: EventScheduleRepository
     private lateinit var seatRepository: SeatRepository
     private lateinit var objectMapper: ObjectMapper
+    private lateinit var redisTemplate: RedisTemplate<String, Any>
+    private lateinit var valueOps: ValueOperations<String, Any>
+    private lateinit var stampedeLockScript: DefaultRedisScript<Long>
+    private lateinit var eventService: EventService
     private lateinit var scheduleService: ScheduleService
 
+    private val cacheProperties = CacheProperties()
     private val venueId = UUID.randomUUID()
     private val hallId = UUID.randomUUID()
     private val eventId = UUID.randomUUID()
@@ -98,7 +111,26 @@ class ScheduleServiceTest {
         eventScheduleRepository = mockk()
         seatRepository = mockk()
         objectMapper = mockk()
-        scheduleService = ScheduleService(eventRepository, eventScheduleRepository, seatRepository, objectMapper)
+        redisTemplate = mockk()
+        valueOps = mockk(relaxed = true)
+        stampedeLockScript = mockk()
+        eventService = mockk()
+
+        every { redisTemplate.opsForValue() } returns valueOps
+        every { valueOps.get(any<String>()) } returns null
+        every {
+            redisTemplate.execute(any<DefaultRedisScript<Long>>(), any<List<String>>(), any<String>())
+        } returns 1L
+        every { redisTemplate.delete(any<String>()) } returns true
+        every { objectMapper.writeValueAsString(any()) } returns "{}"
+        // EventService 캐시 무효화 메서드 기본 동작
+        every { eventService.invalidateEventDetailCache(any()) } just runs
+        every { eventService.invalidateEventListCaches() } just runs
+
+        scheduleService = ScheduleService(
+            eventRepository, eventScheduleRepository, seatRepository,
+            objectMapper, redisTemplate, cacheProperties, stampedeLockScript, eventService
+        )
     }
 
     @Nested
@@ -125,6 +157,26 @@ class ScheduleServiceTest {
             assertEquals(eventId, result.eventId)
             assertEquals(1, result.playSequence)
             verify { seatRepository.saveAll(any<List<Seat>>()) }
+        }
+
+        @Test
+        @DisplayName("생성 성공 시 부모 공연 상세 캐시와 목록 캐시를 무효화한다")
+        fun cacheInvalidationOnCreate() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+
+            every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
+            every { eventScheduleRepository.existsByEventIdAndPlaySequence(eventId, 1) } returns false
+            every { objectMapper.readValue(any<String>(), SeatTemplateDto::class.java) } returns seatTemplate
+            every { eventScheduleRepository.save(any()) } returns schedule
+            every { seatRepository.saveAll(any<List<Seat>>()) } returns emptyList()
+
+            scheduleService.createSchedule(eventId, validCreateRequest())
+
+            verify { eventService.invalidateEventDetailCache(eventId) }
+            verify { eventService.invalidateEventListCaches() }
         }
 
         @Test
@@ -174,7 +226,7 @@ class ScheduleServiceTest {
             val event = createEvent(venue, hall)
             val request = validCreateRequest().copy(
                 eventStartAt = now.plusDays(30).plusHours(3),
-                eventEndAt = now.plusDays(30) // 종료 < 시작
+                eventEndAt = now.plusDays(30)
             )
 
             every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
@@ -192,7 +244,7 @@ class ScheduleServiceTest {
             val event = createEvent(venue, hall)
             val request = validCreateRequest().copy(
                 saleStartAt = now.plusDays(29),
-                saleEndAt = now.plusDays(1) // saleEnd < saleStart
+                saleEndAt = now.plusDays(1)
             )
 
             every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
@@ -209,7 +261,7 @@ class ScheduleServiceTest {
             val hall = createHall(venue)
             val event = createEvent(venue, hall)
             val request = validCreateRequest().copy(
-                saleEndAt = now.plusDays(31) // eventStartAt(+30일) 이후
+                saleEndAt = now.plusDays(31)
             )
 
             every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
@@ -265,7 +317,7 @@ class ScheduleServiceTest {
             val templateWithMissingGrade = SeatTemplateDto(
                 rows = listOf("A", "B"),
                 seatsPerRow = 1,
-                gradeMapping = mapOf("A" to "VIP") // B 행 매핑 없음
+                gradeMapping = mapOf("A" to "VIP")
             )
 
             every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
@@ -287,7 +339,7 @@ class ScheduleServiceTest {
             val templateWithSGrade = SeatTemplateDto(
                 rows = listOf("A"),
                 seatsPerRow = 1,
-                gradeMapping = mapOf("A" to "S") // S 등급인데 VIP 가격만 있음
+                gradeMapping = mapOf("A" to "S")
             )
             val requestWithoutSPrice = validCreateRequest().copy(
                 priceByGrade = mapOf(SeatGrade.VIP to BigDecimal("100000"))
@@ -324,13 +376,13 @@ class ScheduleServiceTest {
 
             every { eventRepository.findByIdAndDeletedAtIsNull(eventId) } returns event
             every { eventScheduleRepository.findByEventIdOrderByPlaySequence(eventId) } returns listOf(schedule1, schedule2)
-            every { eventRepository.findScheduleIdsWithAvailableSeats(any()) } returns setOf(scheduleId) // schedule1만 AVAILABLE
+            every { eventRepository.findScheduleIdsWithAvailableSeats(any()) } returns setOf(scheduleId)
 
             val result = scheduleService.getSchedules(eventId)
 
             assertEquals(2, result.size)
-            assertFalse(result[0].isSoldOut) // schedule1: AVAILABLE 있음
-            assertTrue(result[1].isSoldOut)  // schedule2: AVAILABLE 없음
+            assertFalse(result[0].isSoldOut)
+            assertTrue(result[1].isSoldOut)
         }
 
         @Test
@@ -384,6 +436,7 @@ class ScheduleServiceTest {
         @Test
         @DisplayName("존재하지 않는 회차 조회 시 SCHEDULE_NOT_FOUND 예외가 발생한다")
         fun notFound() {
+            every { valueOps.get(any<String>()) } returns null
             every { eventScheduleRepository.findById(scheduleId) } returns Optional.empty()
 
             val ex = assertThrows<EventException> { scheduleService.getSchedule(scheduleId) }
@@ -404,6 +457,60 @@ class ScheduleServiceTest {
             val result = scheduleService.getSchedule(scheduleId)
 
             assertTrue(result.isSoldOut)
+        }
+
+        @Test
+        @DisplayName("캐시 Hit - DB 조회 없이 캐시에서 즉시 반환한다")
+        fun cacheHit() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+            val detailResponse = ScheduleDto.DetailResponse.from(schedule, isSoldOut = false)
+            val cacheKey = "cache:schedule:$scheduleId"
+            val cachedJson = "{\"cached\":\"schedule\"}"
+
+            every { valueOps.get(cacheKey) } returns cachedJson
+            every { objectMapper.readValue(cachedJson, ScheduleDto.DetailResponse::class.java) } returns detailResponse
+
+            val result = scheduleService.getSchedule(scheduleId)
+
+            assertEquals(scheduleId, result.id)
+            verify(exactly = 0) { eventScheduleRepository.findById(any()) }
+        }
+
+        @Test
+        @DisplayName("캐시 Miss - DB 조회 후 캐시에 저장한다")
+        fun cacheMissWritesToCache() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+
+            every { eventScheduleRepository.findById(scheduleId) } returns Optional.of(schedule)
+            every { eventRepository.findScheduleIdsWithAvailableSeats(listOf(scheduleId)) } returns setOf(scheduleId)
+
+            scheduleService.getSchedule(scheduleId)
+
+            verify { objectMapper.writeValueAsString(any<ScheduleDto.DetailResponse>()) }
+            verify { valueOps.set("cache:schedule:$scheduleId", any(), any<Duration>()) }
+        }
+
+        @Test
+        @DisplayName("Redis 장애 시 DB fallback으로 정상 응답한다")
+        fun redisFallback() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+
+            every { valueOps.get(any<String>()) } throws RedisConnectionFailureException("connection failed")
+            every { eventScheduleRepository.findById(scheduleId) } returns Optional.of(schedule)
+            every { eventRepository.findScheduleIdsWithAvailableSeats(listOf(scheduleId)) } returns setOf(scheduleId)
+
+            val result = scheduleService.getSchedule(scheduleId)
+
+            assertEquals(scheduleId, result.id)
         }
     }
 
@@ -453,6 +560,24 @@ class ScheduleServiceTest {
                 scheduleService.changeScheduleStatus(scheduleId, ScheduleDto.ChangeStatusRequest(ScheduleStatus.ONGOING))
             }
             assertEquals(ErrorCode.SCHEDULE_NOT_FOUND, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("상태 변경 성공 시 회차 상세, 공연 상세, 목록 캐시를 모두 무효화한다")
+        fun cacheInvalidationOnStatusChange() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event, ScheduleStatus.UPCOMING)
+            val request = ScheduleDto.ChangeStatusRequest(status = ScheduleStatus.ONGOING)
+
+            every { eventScheduleRepository.findById(scheduleId) } returns Optional.of(schedule)
+
+            scheduleService.changeScheduleStatus(scheduleId, request)
+
+            verify { redisTemplate.delete("cache:schedule:$scheduleId") }
+            verify { eventService.invalidateEventDetailCache(eventId) }
+            verify { eventService.invalidateEventListCaches() }
         }
     }
 }

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.data.redis.RedisConnectionFailureException
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.core.ValueOperations
-import org.springframework.data.redis.core.script.DefaultRedisScript
 import java.math.BigDecimal
 import java.time.Duration
 import java.time.LocalDateTime
@@ -49,7 +48,7 @@ class ScheduleServiceTest {
     private lateinit var objectMapper: ObjectMapper
     private lateinit var redisTemplate: RedisTemplate<String, Any>
     private lateinit var valueOps: ValueOperations<String, Any>
-    private lateinit var stampedeLockScript: DefaultRedisScript<Long>
+    private lateinit var cacheHelper: CacheHelper
     private lateinit var eventService: EventService
     private lateinit var scheduleService: ScheduleService
 
@@ -113,14 +112,12 @@ class ScheduleServiceTest {
         objectMapper = mockk()
         redisTemplate = mockk()
         valueOps = mockk(relaxed = true)
-        stampedeLockScript = mockk()
+        cacheHelper = mockk()
         eventService = mockk()
 
         every { redisTemplate.opsForValue() } returns valueOps
         every { valueOps.get(any<String>()) } returns null
-        every {
-            redisTemplate.execute(any<DefaultRedisScript<Long>>(), any<List<String>>(), any<String>())
-        } returns 1L
+        every { cacheHelper.tryAcquireStampedeLock(any(), any()) } returns true
         every { redisTemplate.delete(any<String>()) } returns true
         every { objectMapper.writeValueAsString(any()) } returns "{}"
         // EventService 캐시 무효화 메서드 기본 동작
@@ -129,7 +126,7 @@ class ScheduleServiceTest {
 
         scheduleService = ScheduleService(
             eventRepository, eventScheduleRepository, seatRepository,
-            objectMapper, redisTemplate, cacheProperties, stampedeLockScript, eventService
+            objectMapper, redisTemplate, cacheProperties, cacheHelper, eventService
         )
     }
 

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.data.redis.RedisConnectionFailureException
 import org.springframework.data.redis.core.HashOperations
 import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.data.redis.core.script.DefaultRedisScript
 import java.math.BigDecimal
 import java.time.Duration
 import java.util.UUID
@@ -38,7 +37,7 @@ class SeatServiceTest {
     private lateinit var seatRepository: SeatRepository
     private lateinit var redisTemplate: RedisTemplate<String, Any>
     private lateinit var hashOps: HashOperations<String, String, Any>
-    private lateinit var cacheStampedeLockScript: DefaultRedisScript<Long>
+    private lateinit var cacheHelper: CacheHelper
     private lateinit var seatService: SeatService
 
     private val objectMapper = jacksonObjectMapper().apply {
@@ -71,19 +70,17 @@ class SeatServiceTest {
         seatRepository = mockk()
         redisTemplate = mockk()
         hashOps = mockk()
-        cacheStampedeLockScript = mockk()
+        cacheHelper = mockk()
         every { redisTemplate.opsForHash<String, Any>() } returns hashOps
         // Stampede Lock: 기본적으로 락 획득 성공 (DB 조회 + 캐시 저장 허용)
-        every {
-            redisTemplate.execute(any<DefaultRedisScript<Long>>(), any<List<String>>(), any<String>())
-        } returns 1L
+        every { cacheHelper.tryAcquireStampedeLock(any(), any()) } returns true
         seatService = SeatService(
             eventScheduleRepository = eventScheduleRepository,
             seatRepository = seatRepository,
             redisTemplate = redisTemplate,
             objectMapper = objectMapper,
             cacheProperties = cacheProperties,
-            cacheStampedeLockScript = cacheStampedeLockScript
+            cacheHelper = cacheHelper
         )
     }
 
@@ -218,9 +215,7 @@ class SeatServiceTest {
             every { eventScheduleRepository.existsById(scheduleId) } returns true
             every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
             // 락 미획득 (다른 요청이 이미 처리 중)
-            every {
-                redisTemplate.execute(any<DefaultRedisScript<Long>>(), any<List<String>>(), any<String>())
-            } returns 0L
+            every { cacheHelper.tryAcquireStampedeLock(any(), any()) } returns false
 
             val response = seatService.getSeats(scheduleId)
 

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
@@ -3,6 +3,7 @@ package com.ticketqueue.event.service
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.event.config.CacheProperties
 import com.ticketqueue.event.dto.SeatDto
 import com.ticketqueue.event.entity.EventSchedule
 import com.ticketqueue.event.entity.Seat
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.data.redis.RedisConnectionFailureException
 import org.springframework.data.redis.core.HashOperations
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.script.DefaultRedisScript
 import java.math.BigDecimal
 import java.time.Duration
 import java.util.UUID
@@ -36,11 +38,13 @@ class SeatServiceTest {
     private lateinit var seatRepository: SeatRepository
     private lateinit var redisTemplate: RedisTemplate<String, Any>
     private lateinit var hashOps: HashOperations<String, String, Any>
+    private lateinit var cacheStampedeLockScript: DefaultRedisScript<Long>
     private lateinit var seatService: SeatService
 
     private val objectMapper = jacksonObjectMapper().apply {
         registerModule(JavaTimeModule())
     }
+    private val cacheProperties = CacheProperties()
 
     private val scheduleId = UUID.randomUUID()
 
@@ -67,13 +71,19 @@ class SeatServiceTest {
         seatRepository = mockk()
         redisTemplate = mockk()
         hashOps = mockk()
+        cacheStampedeLockScript = mockk()
         every { redisTemplate.opsForHash<String, Any>() } returns hashOps
+        // Stampede Lock: 기본적으로 락 획득 성공 (DB 조회 + 캐시 저장 허용)
+        every {
+            redisTemplate.execute(any<DefaultRedisScript<Long>>(), any<List<String>>(), any<String>())
+        } returns 1L
         seatService = SeatService(
             eventScheduleRepository = eventScheduleRepository,
             seatRepository = seatRepository,
             redisTemplate = redisTemplate,
             objectMapper = objectMapper,
-            seatsCacheTtl = 300L
+            cacheProperties = cacheProperties,
+            cacheStampedeLockScript = cacheStampedeLockScript
         )
     }
 
@@ -198,6 +208,26 @@ class SeatServiceTest {
 
             assertEquals(scheduleId, response.scheduleId)
             assertEquals(1, response.grades.size)
+        }
+
+        @Test
+        @DisplayName("Stampede Lock 미획득 시 캐시 저장을 건너뛰고 정상 응답한다")
+        fun stampedeLockNotAcquired() {
+            val seats = listOf(createSeat(SeatGrade.VIP, "A-1", BigDecimal("150000")))
+            every { hashOps.entries(any<String>()) } returns emptyMap()
+            every { eventScheduleRepository.existsById(scheduleId) } returns true
+            every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
+            // 락 미획득 (다른 요청이 이미 처리 중)
+            every {
+                redisTemplate.execute(any<DefaultRedisScript<Long>>(), any<List<String>>(), any<String>())
+            } returns 0L
+
+            val response = seatService.getSeats(scheduleId)
+
+            assertEquals(scheduleId, response.scheduleId)
+            assertEquals(1, response.grades.size)
+            // 락 미획득 시 캐시 저장 미수행
+            verify(exactly = 0) { hashOps.putAll(any(), any()) }
         }
     }
 


### PR DESCRIPTION
## Summary
- Event Service의 Redis Cache-Aside 전략 구현 (REQ-EVT-017)
- Cache Stampede 방지를 위한 Lua 스크립트 기반 원자적 SET NX EX 락 (REQ-EVT-021)
- 생성/수정/삭제 시 관련 캐시 무효화 (SCAN 기반, KEYS 명령 미사용) (REQ-EVT-019)

## Changes
- `CacheProperties`: TTL 중앙 관리 (event/schedule/seats 5분, layout 24시간)
- `RedisConfig`: `CacheStampedeLockScript` 빈 등록 (Lua 스크립트 기반)
- `EventService`: 공연 목록/상세 Cache-Aside + Stampede Lock + SCAN 기반 목록 캐시 무효화
- `HallService`: 좌석 배치도 Cache-Aside (TTL 24시간, 저빈도 API라 Stampede Lock 미적용)
- `ScheduleService`: 회차 상세 Cache-Aside + Stampede Lock + 캐시 무효화 시 EventService 위임
- `SeatService`: 좌석 통계 Hash Cache-Aside + Stampede Lock
- `cache-stampede-lock.lua`: SET NX EX 원자적 실행 Lua 스크립트 신규 추가
- `application.yml`: `cache.*` TTL 설정 추가

## Test plan
- [x] `./gradlew :event-service:compileKotlin :event-service:compileTestKotlin` 컴파일 성공
- [x] `./gradlew :event-service:test` 전체 226개 테스트 통과 (신규 캐싱 테스트 13개 포함)
- [x] 캐시 Hit/Miss, Redis 장애 시 DB fallback, 캐시 무효화, Stampede Lock 미획득 시나리오 단위 테스트

Closes #36
Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Added intelligent Redis caching for events, schedules, seats and hall layouts to speed reads.
  * Implemented cache stampede protection to avoid thundering-herd issues under high load.
  * Introduced safer Redis fallbacks so reads still succeed if cache is unavailable.
* **Configuration**
  * Centralized cache TTLs with defaults: event/schedule/seats = 5 minutes, layout = 24 hours.
* **Reliability**
  * Cache invalidation on create/update/delete to keep data fresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->