### PR TITLE
feat: [Queue] 대기열 진입 API 구현 - POST /queue/enter

### DIFF
--- a/backend/common/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
+++ b/backend/common/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
@@ -26,6 +26,7 @@ enum class ErrorCode(
     // Queue
     QUEUE_FULL(HttpStatus.SERVICE_UNAVAILABLE, "QUEUE_FULL", "대기열이 가득 찼습니다. 잠시 후 다시 시도해주세요."),
     ALREADY_IN_QUEUE(HttpStatus.CONFLICT, "ALREADY_IN_QUEUE", "이미 대기열에 참여 중입니다."),
+    ALREADY_APPROVED(HttpStatus.CONFLICT, "ALREADY_APPROVED", "이미 대기열 승인이 완료되었습니다. 좌석 선택 페이지로 이동해주세요."),
     QUEUE_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "QUEUE_TOKEN_EXPIRED", "대기열 토큰이 만료되었습니다."),
     QUEUE_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "QUEUE_TOKEN_INVALID", "유효하지 않은 대기열 토큰입니다."),
 

--- a/backend/queue-service/build.gradle.kts
+++ b/backend/queue-service/build.gradle.kts
@@ -11,7 +11,9 @@ dependencies {
 
     // Spring Boot
     implementation(libs.spring.boot.starter.data.redis)
+    implementation(libs.spring.boot.starter.security)
 
     // Test
     testImplementation(libs.bundles.test.base)
+    testImplementation(libs.spring.security.test)
 }

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/GatewayAuthFilter.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/GatewayAuthFilter.kt
@@ -1,0 +1,46 @@
+package com.ticketqueue.queue.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * API Gateway 인증 헤더 기반 필터
+ *
+ * API Gateway에서 JWT 검증 후 전달하는 사용자 정보 헤더를 파싱하여
+ * Spring Security의 SecurityContext에 인증 객체를 설정한다.
+ *
+ * 동작 흐름:
+ * 1. 클라이언트 -> API Gateway: JWT 토큰 전송
+ * 2. API Gateway: JWT 검증 후 X-User-Id, X-User-Role 헤더 추가
+ * 3. API Gateway -> Queue Service: 헤더 포함 요청 전달
+ * 4. 이 필터: 헤더를 읽어 SecurityContext에 인증 정보 설정
+ *
+ * 헤더가 없는 경우(비인증 요청) SecurityContext를 설정하지 않으며,
+ * SecurityConfig의 authenticated() 규칙에 의해 401이 반환된다.
+ */
+@Component
+class GatewayAuthFilter : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val userId = request.getHeader("X-User-Id")
+        val userRole = request.getHeader("X-User-Role")
+
+        if (userId != null && userRole != null) {
+            val authorities = listOf(SimpleGrantedAuthority("ROLE_$userRole"))
+            val authentication = UsernamePasswordAuthenticationToken(userId, null, authorities)
+            SecurityContextHolder.getContext().authentication = authentication
+        }
+
+        filterChain.doFilter(request, response)
+    }
+}

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/RedisConfig.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/RedisConfig.kt
@@ -45,4 +45,23 @@ class RedisConfig {
             setResultType(List::class.java)
         }
     }
+
+    /**
+     * 대기열 진입 Lua 스크립트 (REQ-QUEUE-001, REQ-QUEUE-006, REQ-QUEUE-011)
+     *
+     * ZCARD, ZADD, SET 간의 Race Condition을 원자적으로 처리한다.
+     *
+     * KEYS[1]: queue:{scheduleId}
+     * KEYS[2]: queue:active:{userId}
+     * ARGV[1]: userId, ARGV[2]: timestamp, ARGV[3]: maxCapacity
+     * ARGV[4]: activeUserTtl, ARGV[5]: scheduleId
+     * @return [resultCode, value] 쌍
+     */
+    @Bean
+    fun queueEnterScript(): DefaultRedisScript<List<*>> {
+        return DefaultRedisScript<List<*>>().apply {
+            setLocation(ClassPathResource("lua/queue-enter.lua"))
+            setResultType(List::class.java)
+        }
+    }
 }

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/SecurityConfig.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/SecurityConfig.kt
@@ -1,0 +1,74 @@
+package com.ticketqueue.queue.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.dto.ErrorResponse
+import com.ticketqueue.common.exception.ErrorCode
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+/**
+ * Spring Security 설정
+ *
+ * Queue Service의 보안 정책을 정의한다.
+ * - CSRF 비활성화: Stateless API 서버
+ * - 세션 미사용: Gateway 헤더 기반 인증
+ * - /actuator/health, /actuator/info: 공개 (헬스체크/모니터링)
+ * - 그 외 모든 요청: 인증 필요 (X-User-Id + X-User-Role 헤더)
+ * - 커스텀 에러 핸들러: 표준 ErrorResponse 형식으로 401/403 반환
+ */
+@Configuration
+@EnableWebSecurity
+class SecurityConfig(
+    private val gatewayAuthFilter: GatewayAuthFilter,
+    private val objectMapper: ObjectMapper
+) {
+
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        return http
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { auth ->
+                auth
+                    .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                    .anyRequest().authenticated()
+            }
+            .exceptionHandling { exceptions ->
+                exceptions
+                    .authenticationEntryPoint(customAuthenticationEntryPoint())
+                    .accessDeniedHandler(customAccessDeniedHandler())
+            }
+            .addFilterBefore(gatewayAuthFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .build()
+    }
+
+    private fun customAuthenticationEntryPoint(): AuthenticationEntryPoint {
+        return AuthenticationEntryPoint { _: HttpServletRequest, response: HttpServletResponse, _: AuthenticationException ->
+            response.status = HttpServletResponse.SC_UNAUTHORIZED
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            response.characterEncoding = "UTF-8"
+            response.writer.write(objectMapper.writeValueAsString(ErrorResponse.of(ErrorCode.UNAUTHORIZED)))
+        }
+    }
+
+    private fun customAccessDeniedHandler(): AccessDeniedHandler {
+        return AccessDeniedHandler { _: HttpServletRequest, response: HttpServletResponse, _: AccessDeniedException ->
+            response.status = HttpServletResponse.SC_FORBIDDEN
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            response.characterEncoding = "UTF-8"
+            response.writer.write(objectMapper.writeValueAsString(ErrorResponse.of(ErrorCode.FORBIDDEN)))
+        }
+    }
+}

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/controller/QueueController.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/controller/QueueController.kt
@@ -1,6 +1,8 @@
 package com.ticketqueue.queue.controller
 
+import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.queue.dto.QueueDto
+import com.ticketqueue.queue.exception.QueueException
 import com.ticketqueue.queue.service.QueueService
 import jakarta.validation.Valid
 import org.springframework.security.core.Authentication
@@ -27,7 +29,8 @@ class QueueController(private val queueService: QueueService) {
         @Valid @RequestBody request: QueueDto.EnterRequest,
         authentication: Authentication
     ): QueueDto.EnterResponse {
-        val userId = UUID.fromString(authentication.principal as String)
+        val userId = runCatching { UUID.fromString(authentication.principal as String) }
+            .getOrElse { throw QueueException(ErrorCode.UNAUTHORIZED) }
         return queueService.enterQueue(userId, request.scheduleId!!)
     }
 }

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/controller/QueueController.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/controller/QueueController.kt
@@ -31,6 +31,8 @@ class QueueController(private val queueService: QueueService) {
     ): QueueDto.EnterResponse {
         val userId = runCatching { UUID.fromString(authentication.principal as String) }
             .getOrElse { throw QueueException(ErrorCode.UNAUTHORIZED) }
-        return queueService.enterQueue(userId, request.scheduleId!!)
+        val scheduleId = request.scheduleId
+            ?: throw QueueException(ErrorCode.INVALID_INPUT, "회차 ID는 필수입니다.")
+        return queueService.enterQueue(userId, scheduleId)
     }
 }

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/controller/QueueController.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/controller/QueueController.kt
@@ -1,0 +1,33 @@
+package com.ticketqueue.queue.controller
+
+import com.ticketqueue.queue.dto.QueueDto
+import com.ticketqueue.queue.service.QueueService
+import jakarta.validation.Valid
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+/**
+ * 대기열 REST 컨트롤러
+ *
+ * GatewayAuthFilter가 X-User-Id를 Authentication.principal(String)에 설정하므로,
+ * authentication.principal을 UUID로 파싱하여 서비스에 전달한다.
+ *
+ * 에러 응답은 common 모듈의 GlobalExceptionHandler가 자동 처리한다.
+ */
+@RestController
+@RequestMapping("/queue")
+class QueueController(private val queueService: QueueService) {
+
+    @PostMapping("/enter")
+    fun enter(
+        @Valid @RequestBody request: QueueDto.EnterRequest,
+        authentication: Authentication
+    ): QueueDto.EnterResponse {
+        val userId = UUID.fromString(authentication.principal as String)
+        return queueService.enterQueue(userId, request.scheduleId!!)
+    }
+}

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/dto/QueueDto.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/dto/QueueDto.kt
@@ -1,0 +1,25 @@
+package com.ticketqueue.queue.dto
+
+import jakarta.validation.constraints.NotNull
+import java.util.UUID
+
+enum class QueueStatus {
+    WAITING,  // 대기 중 (대기열 진입 직후 상태)
+    ACTIVE    // 대기열 통과 (Queue Token 발급됨)
+}
+
+class QueueDto {
+
+    data class EnterRequest(
+        @field:NotNull(message = "회차 ID는 필수입니다.")
+        val scheduleId: UUID?
+    )
+
+    data class EnterResponse(
+        val status: QueueStatus,
+        val scheduleId: UUID,
+        val rank: Long,              // 1-based 대기 순번
+        val estimatedWaitTime: Long, // 예상 대기 시간 (초)
+        val token: String?           // WAITING 상태에서는 null
+    )
+}

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
@@ -60,23 +60,14 @@ class QueueService(
             throw QueueException(ErrorCode.INTERNAL_SERVER_ERROR, "대기열 서비스에 일시적인 오류가 발생했습니다.", e)
         }
 
-        val code = (result[0] as Long).toInt()
+        val code = (result.getOrNull(0) as? Long)?.toInt()
+            ?: throw QueueException(ErrorCode.INTERNAL_SERVER_ERROR, "대기열 처리 결과를 읽을 수 없습니다.")
 
         return when (code) {
-            0 -> {
-                val rank = (result[1] as Long) + 1
-                logger.info("Queue entered: userId={}, scheduleId={}, rank={}", userId, scheduleId, rank)
-                QueueDto.EnterResponse(
-                    status = QueueStatus.WAITING,
-                    scheduleId = scheduleId,
-                    rank = rank,
-                    estimatedWaitTime = calculateWaitTime(rank),
-                    token = null
-                )
-            }
-            1 -> {
-                val rank = (result[1] as Long) + 1
-                logger.info("Queue re-entered (idempotent): userId={}, scheduleId={}, rank={}", userId, scheduleId, rank)
+            0, 1 -> {
+                val rank = safeRank(result)
+                val logMsg = if (code == 0) "Queue entered" else "Queue re-entered (idempotent)"
+                logger.info("$logMsg: userId={}, scheduleId={}, rank={}", userId, scheduleId, rank)
                 QueueDto.EnterResponse(
                     status = QueueStatus.WAITING,
                     scheduleId = scheduleId,
@@ -105,11 +96,21 @@ class QueueService(
      * 예상 대기 시간 계산 (초)
      *
      * 배치 처리 단위: batchSize명 / interval ms마다 승인
-     * 공식: ceil(rank / batchSize) * (interval / 1000)
+     * 밀리초 단위로 먼저 계산한 후 올림(ceiling)하여 초로 변환
+     * interval < 1000ms인 경우(예: 500ms)에도 0초 반환 버그 방지
      */
     private fun calculateWaitTime(rank: Long): Long {
         val batchSize = queueProperties.batch.size.toLong()
-        val intervalSeconds = queueProperties.batch.interval / 1000L
-        return ((rank + batchSize - 1) / batchSize) * intervalSeconds
+        val intervalMs = queueProperties.batch.interval
+        val batchCount = (rank + batchSize - 1) / batchSize
+        val waitMs = batchCount * intervalMs
+        return (waitMs + 999) / 1000
     }
+
+    /**
+     * Lua 결과 리스트에서 rank를 안전하게 추출한다.
+     * result[1]이 없거나 Long이 아닌 경우 0으로 폴백 (0-based index → 1-based rank)
+     */
+    private fun safeRank(result: List<*>): Long =
+        ((result.getOrNull(1) as? Long) ?: 0L) + 1
 }

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
@@ -5,6 +5,7 @@ import com.ticketqueue.queue.config.QueueProperties
 import com.ticketqueue.queue.dto.QueueDto
 import com.ticketqueue.queue.dto.QueueStatus
 import com.ticketqueue.queue.exception.QueueException
+import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.data.redis.core.script.DefaultRedisScript
 import org.springframework.stereotype.Service
@@ -23,6 +24,8 @@ class QueueService(
     private val queueProperties: QueueProperties
 ) {
 
+    private val logger = LoggerFactory.getLogger(QueueService::class.java)
+
     /**
      * 대기열 진입 처리 (REQ-QUEUE-001)
      *
@@ -31,6 +34,10 @@ class QueueService(
      * - 1: 동일 회차 중복 진입 (멱등성 — 기존 순위 반환)
      * - 2: 다른 회차 대기 중 → ALREADY_IN_QUEUE
      * - 3: 대기열 가득 참 → QUEUE_FULL
+     * - 4: 이미 배치 승인 완료 → ALREADY_APPROVED
+     *
+     * TODO: scheduleId 유효성 검증 미구현 — 존재하지 않거나 판매 상태가 아닌 회차에 대한 대기열 생성 가능
+     *       Event Service 내부 API 호출 또는 Gateway 레벨 검증 필요 (GitHub Issue #163)
      */
     fun enterQueue(userId: UUID, scheduleId: UUID): QueueDto.EnterResponse {
         val queueKey = "queue:$scheduleId"
@@ -46,15 +53,19 @@ class QueueService(
         )
 
         @Suppress("UNCHECKED_CAST")
-        val result = stringRedisTemplate.execute(queueEnterScript, keys, *args) as List<*>
+        val result = try {
+            stringRedisTemplate.execute(queueEnterScript, keys, *args) as List<*>
+        } catch (e: Exception) {
+            logger.error("Redis execute failed: scheduleId={}, userId={}", scheduleId, userId, e)
+            throw QueueException(ErrorCode.INTERNAL_SERVER_ERROR, "대기열 서비스에 일시적인 오류가 발생했습니다.", e)
+        }
 
         val code = (result[0] as Long).toInt()
 
         return when (code) {
-            0, 1 -> {
-                // 0: 신규 진입, 1: 동일 회차 중복 (멱등성)
-                val zeroBasedRank = result[1] as Long
-                val rank = zeroBasedRank + 1 // 0-based → 1-based 변환
+            0 -> {
+                val rank = (result[1] as Long) + 1
+                logger.info("Queue entered: userId={}, scheduleId={}, rank={}", userId, scheduleId, rank)
                 QueueDto.EnterResponse(
                     status = QueueStatus.WAITING,
                     scheduleId = scheduleId,
@@ -63,8 +74,29 @@ class QueueService(
                     token = null
                 )
             }
-            2 -> throw QueueException(ErrorCode.ALREADY_IN_QUEUE)
-            3 -> throw QueueException(ErrorCode.QUEUE_FULL)
+            1 -> {
+                val rank = (result[1] as Long) + 1
+                logger.info("Queue re-entered (idempotent): userId={}, scheduleId={}, rank={}", userId, scheduleId, rank)
+                QueueDto.EnterResponse(
+                    status = QueueStatus.WAITING,
+                    scheduleId = scheduleId,
+                    rank = rank,
+                    estimatedWaitTime = calculateWaitTime(rank),
+                    token = null
+                )
+            }
+            2 -> {
+                logger.warn("Queue enter rejected (already in another queue): userId={}, scheduleId={}", userId, scheduleId)
+                throw QueueException(ErrorCode.ALREADY_IN_QUEUE)
+            }
+            3 -> {
+                logger.warn("Queue enter rejected (queue full): scheduleId={}, capacity={}", scheduleId, queueProperties.maxCapacity)
+                throw QueueException(ErrorCode.QUEUE_FULL)
+            }
+            4 -> {
+                logger.info("Queue enter rejected (already approved): userId={}, scheduleId={}", userId, scheduleId)
+                throw QueueException(ErrorCode.ALREADY_APPROVED)
+            }
             else -> throw QueueException(ErrorCode.INTERNAL_SERVER_ERROR)
         }
     }

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
@@ -1,0 +1,83 @@
+package com.ticketqueue.queue.service
+
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.queue.config.QueueProperties
+import com.ticketqueue.queue.dto.QueueDto
+import com.ticketqueue.queue.dto.QueueStatus
+import com.ticketqueue.queue.exception.QueueException
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.script.DefaultRedisScript
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+/**
+ * 대기열 비즈니스 로직 서비스
+ *
+ * Lua 스크립트를 통해 원자적으로 대기열 진입을 처리하며,
+ * Lua 반환 코드를 도메인 응답 또는 QueueException으로 변환한다.
+ */
+@Service
+class QueueService(
+    private val stringRedisTemplate: StringRedisTemplate,
+    private val queueEnterScript: DefaultRedisScript<List<*>>,
+    private val queueProperties: QueueProperties
+) {
+
+    /**
+     * 대기열 진입 처리 (REQ-QUEUE-001)
+     *
+     * Lua 스크립트 반환 코드:
+     * - 0: 신규 진입 성공
+     * - 1: 동일 회차 중복 진입 (멱등성 — 기존 순위 반환)
+     * - 2: 다른 회차 대기 중 → ALREADY_IN_QUEUE
+     * - 3: 대기열 가득 참 → QUEUE_FULL
+     */
+    fun enterQueue(userId: UUID, scheduleId: UUID): QueueDto.EnterResponse {
+        val queueKey = "queue:$scheduleId"
+        val activeKey = "queue:active:$userId"
+        val keys = listOf(queueKey, activeKey)
+
+        val args = arrayOf(
+            userId.toString(),
+            System.currentTimeMillis().toString(),
+            queueProperties.maxCapacity.toString(),
+            queueProperties.activeUser.ttl.toString(),
+            scheduleId.toString()
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val result = stringRedisTemplate.execute(queueEnterScript, keys, *args) as List<*>
+
+        val code = (result[0] as Long).toInt()
+
+        return when (code) {
+            0, 1 -> {
+                // 0: 신규 진입, 1: 동일 회차 중복 (멱등성)
+                val zeroBasedRank = result[1] as Long
+                val rank = zeroBasedRank + 1 // 0-based → 1-based 변환
+                QueueDto.EnterResponse(
+                    status = QueueStatus.WAITING,
+                    scheduleId = scheduleId,
+                    rank = rank,
+                    estimatedWaitTime = calculateWaitTime(rank),
+                    token = null
+                )
+            }
+            2 -> throw QueueException(ErrorCode.ALREADY_IN_QUEUE)
+            3 -> throw QueueException(ErrorCode.QUEUE_FULL)
+            else -> throw QueueException(ErrorCode.INTERNAL_SERVER_ERROR)
+        }
+    }
+
+    /**
+     * 예상 대기 시간 계산 (초)
+     *
+     * 배치 처리 단위: batchSize명 / interval ms마다 승인
+     * 공식: ceil(rank / batchSize) * (interval / 1000)
+     */
+    private fun calculateWaitTime(rank: Long): Long {
+        val batchSize = queueProperties.batch.size.toLong()
+        val intervalSeconds = queueProperties.batch.interval / 1000L
+        return ((rank + batchSize - 1) / batchSize) * intervalSeconds
+    }
+}

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
@@ -98,10 +98,20 @@ class QueueService(
      * 배치 처리 단위: batchSize명 / interval ms마다 승인
      * 밀리초 단위로 먼저 계산한 후 올림(ceiling)하여 초로 변환
      * interval < 1000ms인 경우(예: 500ms)에도 0초 반환 버그 방지
+     *
+     * 설정값 방어:
+     * - batchSize <= 0 → 1로 보정 (divide-by-zero 방지)
+     * - intervalMs < 0 → 0으로 보정 (음수 대기시간 방지, interval=0은 "즉시 처리"로 허용)
      */
     private fun calculateWaitTime(rank: Long): Long {
-        val batchSize = queueProperties.batch.size.toLong()
-        val intervalMs = queueProperties.batch.interval
+        val batchSize = queueProperties.batch.size.toLong().coerceAtLeast(1)
+        val intervalMs = queueProperties.batch.interval.coerceAtLeast(0)
+        if (batchSize != queueProperties.batch.size.toLong() || intervalMs != queueProperties.batch.interval) {
+            logger.warn(
+                "Invalid queue batch config detected — batchSize={}, intervalMs={}. Using safe fallback values.",
+                queueProperties.batch.size, queueProperties.batch.interval
+            )
+        }
         val batchCount = (rank + batchSize - 1) / batchSize
         val waitMs = batchCount * intervalMs
         return (waitMs + 999) / 1000
@@ -109,8 +119,11 @@ class QueueService(
 
     /**
      * Lua 결과 리스트에서 rank를 안전하게 추출한다.
-     * result[1]이 없거나 Long이 아닌 경우 0으로 폴백 (0-based index → 1-based rank)
+     * result[1]이 없거나 Long이 아닌 경우 예외를 던져 Lua 스크립트 버그를 즉시 노출한다.
      */
-    private fun safeRank(result: List<*>): Long =
-        ((result.getOrNull(1) as? Long) ?: 0L) + 1
+    private fun safeRank(result: List<*>): Long {
+        val rawRank = result.getOrNull(1) as? Long
+            ?: throw QueueException(ErrorCode.INTERNAL_SERVER_ERROR, "대기열 순위 정보를 읽을 수 없습니다.")
+        return rawRank + 1
+    }
 }

--- a/backend/queue-service/src/main/resources/lua/queue-enter.lua
+++ b/backend/queue-service/src/main/resources/lua/queue-enter.lua
@@ -1,0 +1,59 @@
+--[[
+  대기열 진입 Lua 스크립트 (REQ-QUEUE-001, REQ-QUEUE-006, REQ-QUEUE-011)
+
+  ZCARD, ZADD, SET 간의 Race Condition을 단일 원자적 실행으로 해결한다.
+
+  KEYS[1] = queue:{scheduleId}      -- 대기열 Sorted Set
+  KEYS[2] = queue:active:{userId}   -- 중복 대기 방지 키
+
+  ARGV[1] = userId                  -- 대기열에 추가할 사용자 ID
+  ARGV[2] = timestamp               -- score (진입 시각, Unix ms)
+  ARGV[3] = maxCapacity             -- 대기열 최대 수용 인원 (기본 50000)
+  ARGV[4] = activeUserTtl           -- queue:active 키 TTL (초, 기본 600)
+  ARGV[5] = scheduleId              -- 진입 요청한 회차 ID
+
+  Returns:
+    {0, rank} : 신규 진입 성공 (rank = ZRANK, 0-based)
+    {1, rank} : 동일 회차 중복 진입 — 멱등성 처리, 기존 rank 반환
+    {2, existingScheduleId} : 다른 회차 대기 중 (ALREADY_IN_QUEUE)
+    {3, -1}   : 대기열 가득 참 (QUEUE_FULL)
+]]
+
+local queueKey    = KEYS[1]
+local activeKey   = KEYS[2]
+
+local userId       = ARGV[1]
+local timestamp    = ARGV[2]
+local maxCapacity  = tonumber(ARGV[3])
+local activeUserTtl = tonumber(ARGV[4])
+local scheduleId   = ARGV[5]
+
+-- Step 1: 중복 대기 확인 (REQ-QUEUE-011)
+local existingScheduleId = redis.call('GET', activeKey)
+if existingScheduleId then
+    if existingScheduleId == scheduleId then
+        -- 같은 회차에 이미 대기 중 → 멱등성: 기존 순위 반환
+        local rank = redis.call('ZRANK', queueKey, userId)
+        return {1, rank}
+    else
+        -- 다른 회차에 대기 중 → 거부
+        return {2, existingScheduleId}
+    end
+end
+
+-- Step 2: 대기열 용량 확인 (REQ-QUEUE-006)
+local currentSize = redis.call('ZCARD', queueKey)
+if currentSize >= maxCapacity then
+    return {3, -1}
+end
+
+-- Step 3: 대기열 진입 (REQ-QUEUE-001)
+-- NX 옵션: 이미 존재하는 멤버는 score 변경 없이 무시
+redis.call('ZADD', queueKey, 'NX', timestamp, userId)
+
+-- Step 4: 중복 대기 방지 키 등록
+redis.call('SET', activeKey, scheduleId, 'EX', activeUserTtl)
+
+-- Step 5: 진입 순위 조회 (0-based, Service에서 1-based로 변환)
+local rank = redis.call('ZRANK', queueKey, userId)
+return {0, rank}

--- a/backend/queue-service/src/main/resources/lua/queue-enter.lua
+++ b/backend/queue-service/src/main/resources/lua/queue-enter.lua
@@ -17,6 +17,7 @@
     {1, rank} : 동일 회차 중복 진입 — 멱등성 처리, 기존 rank 반환
     {2, existingScheduleId} : 다른 회차 대기 중 (ALREADY_IN_QUEUE)
     {3, -1}   : 대기열 가득 참 (QUEUE_FULL)
+    {4, -1}   : 이미 배치 승인 완료 — Sorted Set에 존재하지 않음 (ALREADY_APPROVED)
 ]]
 
 local queueKey    = KEYS[1]
@@ -34,6 +35,12 @@ if existingScheduleId then
     if existingScheduleId == scheduleId then
         -- 같은 회차에 이미 대기 중 → 멱등성: 기존 순위 반환
         local rank = redis.call('ZRANK', queueKey, userId)
+        if rank == false then
+            -- ZRANK가 nil: 배치 승인으로 Sorted Set에서 이미 제거된 상태
+            return {4, -1}
+        end
+        -- 멱등성 경로에서 TTL 갱신: 반복 요청 시 active 키 만료 방지
+        redis.call('EXPIRE', activeKey, activeUserTtl)
         return {1, rank}
     else
         -- 다른 회차에 대기 중 → 거부


### PR DESCRIPTION
## Summary
- Queue Service에 대기열 진입 API(POST /queue/enter)를 구현합니다.
- Redis Lua 스크립트를 사용해 ZCARD, ZADD, SET 간의 Race Condition을 원자적으로 처리합니다.
- Spring Security를 도입하고, API Gateway 헤더(X-User-Id, X-User-Role) 기반 인증 필터를 구성합니다.

## Changes
- `common`: ALREADY_APPROVED 에러 코드 추가 (이미 배치 승인된 사용자 재진입 시 409 반환)
- `queue-service/build.gradle.kts`: Spring Security 의존성 추가
- `queue-service/config/GatewayAuthFilter`: API Gateway 전달 헤더를 SecurityContext에 설정하는 인증 필터 구현
- `queue-service/config/SecurityConfig`: Stateless 보안 정책, 커스텀 401/403 에러 핸들러 설정
- `queue-service/config/RedisConfig`: 대기열 진입용 Lua 스크립트 Bean 등록
- `queue-service/controller/QueueController`: POST /queue/enter 엔드포인트 구현
- `queue-service/dto/QueueDto`: EnterRequest(scheduleId), EnterResponse(status, rank, estimatedWaitTime, token) 정의
- `queue-service/service/QueueService`: Lua 스크립트 실행 및 반환 코드 기반 도메인 응답 처리
- `lua/queue-enter.lua`: 대기열 진입 원자적 처리 스크립트 (5가지 반환 코드)

## Test plan
- [ ] POST /queue/enter 정상 진입 시 status=WAITING, rank/estimatedWaitTime 반환 확인
- [ ] 동일 회차 중복 진입 시 멱등성 처리(기존 rank 반환) 확인
- [ ] 다른 회차 대기 중 진입 시 409 ALREADY_IN_QUEUE 반환 확인
- [ ] 대기열 만석(50,000명) 시 503 QUEUE_FULL 반환 확인
- [ ] 이미 배치 승인된 사용자 재진입 시 409 ALREADY_APPROVED 반환 확인
- [ ] 인증 헤더(X-User-Id, X-User-Role) 없이 요청 시 401 반환 확인

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can enter a queue and receive position, estimated wait time, and (when applicable) a fast-access token
  * Requests presenting identity headers are authenticated and protected endpoints now require authentication
  * Queue entry is executed atomically to prevent duplicate entries across schedules

* **Bug Fixes / UX**
  * Clear, user-facing error messages for already-approved entries, duplicate queue attempts, and full queues
<!-- end of auto-generated comment: release notes by coderabbit.ai -->