### PR TITLE
fix: [API Gateway] local 프로필 기동 시 Secrets Manager 의존성 및 config.import 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,25 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Docker & Docker Compose** 설치
 - **Gradle** (프로젝트 내 Wrapper 사용 가능)
 
+### 로컬 실행 프로필 및 환경 변수
+- **Active Profile**: `local` (모든 서비스 공통)
+- **필수 환경 변수** (IDE Run Configuration 또는 CLI에서 설정):
+  ```
+  SPRING_CLOUD_AWS_REGION_STATIC=ap-northeast-2
+  SPRING_CLOUD_AWS_CREDENTIALS_ACCESS_KEY=test
+  SPRING_CLOUD_AWS_CREDENTIALS_SECRET_KEY=test
+  SPRING_CLOUD_AWS_SECRETSMANAGER_ENDPOINT=http://192.168.50.111:4566
+  ```
+- Gradle로 실행 시 예시:
+  ```bash
+  SPRING_PROFILES_ACTIVE=local \
+  SPRING_CLOUD_AWS_REGION_STATIC=ap-northeast-2 \
+  SPRING_CLOUD_AWS_CREDENTIALS_ACCESS_KEY=test \
+  SPRING_CLOUD_AWS_CREDENTIALS_SECRET_KEY=test \
+  SPRING_CLOUD_AWS_SECRETSMANAGER_ENDPOINT=http://192.168.50.111:4566 \
+  ./gradlew :api-gateway:bootRun
+  ```
+
 ### 로컬 환경 실행 순서
 
 1. **인프라 컨테이너 실행**

--- a/backend/api-gateway/build.gradle.kts
+++ b/backend/api-gateway/build.gradle.kts
@@ -32,6 +32,9 @@ dependencies {
     // Redis Reactive (토큰 블랙리스트 조회)
     implementation(libs.spring.boot.starter.data.redis.reactive)
 
+    // Spring Cloud AWS (Secrets Manager - config property 해석용)
+    implementation(libs.spring.cloud.aws.starter.secrets.manager)
+
     // Test
     testImplementation(libs.bundles.test.base)
     testImplementation(libs.reactor.test)
@@ -40,5 +43,6 @@ dependencies {
 dependencyManagement {
     imports {
         mavenBom("org.springframework.cloud:spring-cloud-dependencies:${libs.versions.springCloud.get()}")
+        mavenBom(libs.spring.cloud.aws.dependencies.get().toString())
     }
 }

--- a/backend/api-gateway/src/main/resources/application.yml
+++ b/backend/api-gateway/src/main/resources/application.yml
@@ -9,8 +9,9 @@ spring:
     import:
       - "optional:aws-secretsmanager:common/secure-config"
 
-  codec:
-    max-in-memory-size: 1MB
+  http:
+    codecs:
+      max-in-memory-size: 1MB
 
   data:
     redis:
@@ -24,7 +25,7 @@ spring:
         webflux:
           httpclient:
             connect-timeout: 5000    # 5초 연결 타임아웃
-            response-timeout: 30s    # 30초 글로벌 응답 타임아웃 (REQ-GW-007)
+            response-timeout: 30s    # 30초 글로벌 응답 타임아웃
           globalcors:
             cors-configurations:
               '[/**]':
@@ -79,7 +80,7 @@ spring:
                     name: eventService
                     fallbackUri: forward:/fallback/event
 
-            - id: queue-service                          # REQ-GW-008: 10초 타임아웃
+            - id: queue-service                          # 10초 타임아웃
               uri: ${SERVICE_URI_QUEUE:http://192.168.50.111:8083}
               predicates:
                 - Path=/queue/**
@@ -101,7 +102,7 @@ spring:
                     name: reservationService
                     fallbackUri: forward:/fallback/reservation
 
-            - id: payment-service                        # REQ-GW-008: 60초 타임아웃
+            - id: payment-service                        # 60초 타임아웃
               uri: ${SERVICE_URI_PAYMENT:http://192.168.50.111:8085}
               predicates:
                 - Path=/payments/**
@@ -116,7 +117,7 @@ spring:
 jwt:
   secret: ${jwt_secret}
 
-# Resilience4j Circuit Breaker + TimeLimiter 설정 (REQ-GW-006)
+# Resilience4j Circuit Breaker + TimeLimiter 설정
 # TimeLimiter 필수 이유: ReactiveResilience4JCircuitBreakerFactory가 내부적으로 TimeLimiter를 함께 감싸며,
 # 미설정 시 기본 1초로 모든 요청이 타임아웃됨.
 resilience4j:
@@ -155,12 +156,12 @@ resilience4j:
         baseConfig: default
       queueService:
         baseConfig: default
-        timeoutDuration: 10s     # REQ-GW-008: Queue 10초
+        timeoutDuration: 10s     # Queue 10초
       reservationService:
         baseConfig: default
       paymentService:
         baseConfig: default
-        timeoutDuration: 60s     # REQ-GW-008: Payment 60초
+        timeoutDuration: 60s     # Payment 60초
 
 management:
   endpoints:

--- a/backend/api-gateway/src/main/resources/application.yml
+++ b/backend/api-gateway/src/main/resources/application.yml
@@ -5,6 +5,9 @@ server:
 spring:
   application:
     name: api-gateway
+  config:
+    import:
+      - "optional:aws-secretsmanager:common/secure-config"
 
   codec:
     max-in-memory-size: 1MB

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/ApiGatewayApplicationTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/ApiGatewayApplicationTest.kt
@@ -10,7 +10,8 @@ import org.springframework.test.context.ActiveProfiles
     properties = [
         "spring.cloud.discovery.enabled=false",
         "spring.cloud.config.enabled=false",
-        "spring.data.redis.repositories.enabled=false"
+        "spring.data.redis.repositories.enabled=false",
+        "spring.cloud.aws.secretsmanager.enabled=false"
     ]
 )
 @ActiveProfiles("test")

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/BaseIntegrationTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/BaseIntegrationTest.kt
@@ -6,6 +6,9 @@ import org.springframework.test.context.ActiveProfiles
 /**
  * 통합 테스트를 위한 기본 클래스.
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = ["spring.cloud.aws.secretsmanager.enabled=false"]
+)
 @ActiveProfiles("test")
 abstract class BaseIntegrationTest

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/config/GatewayBasicConfigTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/config/GatewayBasicConfigTest.kt
@@ -13,7 +13,7 @@ import org.springframework.test.context.ActiveProfiles
  * Issue #12: Spring Cloud Gateway 프로젝트 초기 설정
  * - 5개 서비스 라우트 등록 검증
  */
-@SpringBootTest
+@SpringBootTest(properties = ["spring.cloud.aws.secretsmanager.enabled=false"])
 @ActiveProfiles("test")
 class GatewayBasicConfigTest {
 

--- a/backend/api-gateway/src/test/resources/application-test.yml
+++ b/backend/api-gateway/src/test/resources/application-test.yml
@@ -6,10 +6,24 @@ spring:
   application:
     name: api-gateway-test
 
-  codec:
-    max-in-memory-size: 1MB
+  config:
+    import: []                    # main의 aws-secretsmanager config.import 무효화
+
+  autoconfigure:
+    exclude:
+      - io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerAutoConfiguration
+      - io.awspring.cloud.autoconfigure.config.parameterstore.ParameterStoreAutoConfiguration
+
+  http:
+    codecs:
+      max-in-memory-size: 1MB
 
   cloud:
+    aws:
+      secretsmanager:
+        enabled: false            # Secrets Manager AutoConfiguration 비활성화
+      region:
+        static: ap-northeast-2    # 더미 리전 (AWS SDK 초기화 방지)
     gateway:
       server:
         webflux:


### PR DESCRIPTION
## Summary
- API Gateway를 `local` 프로필로 실행 시 `valkey_password`, `jwt_secret` 플레이스홀더를 해석하지 못해 기동 실패하는 버그 수정
- Spring Cloud AWS Secrets Manager starter 의존성 추가 및 `config.import`로 `common/secure-config` 시크릿 참조

## Changes
- `backend/api-gateway/build.gradle.kts`: Spring Cloud AWS BOM 및 `spring-cloud-aws-starter-secrets-manager` 의존성 추가
- `backend/api-gateway/src/main/resources/application.yml`: `spring.config.import`에 `optional:aws-secretsmanager:common/secure-config` 추가

## Test plan
- [ ] 아래 환경변수 설정 후 local 프로필로 기동 시 `Could not resolve placeholder` 오류 없이 정상 기동 확인
  ```
  SPRING_CLOUD_AWS_REGION_STATIC=ap-northeast-2
  SPRING_CLOUD_AWS_CREDENTIALS_ACCESS_KEY=test
  SPRING_CLOUD_AWS_CREDENTIALS_SECRET_KEY=test
  SPRING_CLOUD_AWS_SECRETSMANAGER_ENDPOINT=http://192.168.50.111:4566
  ```
- [ ] `curl http://localhost:8080/actuator/health` → `{"status":"UP"}` 응답 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for optional AWS Secrets Manager integration and related configuration tweaks to enable secure secret loading.
* **Documentation**
  * Expanded local-run guidance with required environment variables and step-by-step startup commands.
* **Tests**
  * Adjusted test configurations to disable Secrets Manager during automated tests and updated test environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->