### PR TITLE
feat: [User] 토큰 재발급 API 구현 #26

### DIFF
--- a/backend/common-core/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
+++ b/backend/common-core/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
@@ -23,6 +23,7 @@ enum class ErrorCode(
     DUPLICATE_IDENTITY(HttpStatus.CONFLICT, "DUPLICATE_IDENTITY", "이미 본인인증이 완료된 다른 계정이 존재합니다."),
     RECAPTCHA_FAILED(HttpStatus.BAD_REQUEST, "RECAPTCHA_FAILED", "reCAPTCHA 검증에 실패했습니다."),
     JWT_CONFIGURATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "JWT_CONFIGURATION_ERROR", "서버 설정 오류로 로그인을 처리할 수 없습니다."),
+    REVOKED_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "REVOKED_REFRESH_TOKEN", "이미 사용된 토큰입니다. 보안을 위해 재로그인이 필요합니다."),
 
     // Queue
     QUEUE_FULL(HttpStatus.SERVICE_UNAVAILABLE, "QUEUE_FULL", "대기열이 가득 찼습니다. 잠시 후 다시 시도해주세요."),

--- a/backend/user-service/build.gradle.kts
+++ b/backend/user-service/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.kotlin.jpa)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.spring.dependency.management)
 }
@@ -11,6 +12,9 @@ dependencies {
     implementation(project(":common-core"))
     implementation(project(":common-jpa"))
     implementation(project(":common-web"))
+
+    // QueryDSL - Q클래스 생성 (querydsl-jpa는 common-jpa api()로 전파됨)
+    ksp(libs.querydsl.ksp.codegen)
 
     // Spring Boot & Security
     implementation(libs.spring.boot.starter.security)

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/AuthController.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/AuthController.kt
@@ -23,6 +23,7 @@ class AuthController(
 ) {
     private val logger = KotlinLogging.logger {}
 
+    // 회원가입
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
     fun signup(@Valid @RequestBody request: AuthDto.SignupRequest): AuthDto.SignupResponse {
@@ -30,6 +31,7 @@ class AuthController(
         return authService.signup(request)
     }
 
+    // 로그인
     @PostMapping("/login")
     fun login(
         @Valid @RequestBody request: AuthDto.LoginRequest,
@@ -39,6 +41,15 @@ class AuthController(
         val ipAddress = resolveClientIp(httpRequest)
         val userAgent = httpRequest.getHeader("User-Agent") ?: ""
         return ResponseEntity.ok(authService.login(request, ipAddress, userAgent))
+    }
+
+    // 토큰 재발급
+    @PostMapping("/refresh")
+    fun refresh(
+        @Valid @RequestBody request: AuthDto.RefreshRequest,
+    ): ResponseEntity<AuthDto.LoginResponse> {
+        logger.info { "Token refresh request received" }
+        return ResponseEntity.ok(authService.refresh(request))
     }
 
     private fun resolveClientIp(request: HttpServletRequest): String {

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/AuthController.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/AuthController.kt
@@ -3,11 +3,11 @@ package com.ticketqueue.user.controller
 import com.ticketqueue.user.dto.AuthDto
 import com.ticketqueue.user.service.AuthService
 import io.github.oshai.kotlinlogging.KotlinLogging
-import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -35,11 +35,11 @@ class AuthController(
     @PostMapping("/login")
     fun login(
         @Valid @RequestBody request: AuthDto.LoginRequest,
-        httpRequest: HttpServletRequest,
+        httpRequest: ServerHttpRequest,
     ): ResponseEntity<AuthDto.LoginResponse> {
         logger.info { "Login request received" }
         val ipAddress = resolveClientIp(httpRequest)
-        val userAgent = httpRequest.getHeader("User-Agent") ?: ""
+        val userAgent = httpRequest.headers.getFirst("User-Agent") ?: ""
         return ResponseEntity.ok(authService.login(request, ipAddress, userAgent))
     }
 
@@ -52,11 +52,11 @@ class AuthController(
         return ResponseEntity.ok(authService.refresh(request))
     }
 
-    private fun resolveClientIp(request: HttpServletRequest): String {
-        val remoteAddr = request.remoteAddr ?: ""
+    private fun resolveClientIp(request: ServerHttpRequest): String {
+        val remoteAddr = request.remoteAddress?.address?.hostAddress ?: ""
         val trustedIps = trustedProxyIps.split(",").map { it.trim() }
         return if (remoteAddr in trustedIps) {
-            request.getHeader("X-Forwarded-For")
+            request.headers.getFirst("X-Forwarded-For")
                 ?.split(",")?.firstOrNull()?.trim()
                 ?.takeIf { it.isNotBlank() }
                 ?: remoteAddr

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/AuthController.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/AuthController.kt
@@ -3,11 +3,11 @@ package com.ticketqueue.user.controller
 import com.ticketqueue.user.dto.AuthDto
 import com.ticketqueue.user.service.AuthService
 import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -35,11 +35,11 @@ class AuthController(
     @PostMapping("/login")
     fun login(
         @Valid @RequestBody request: AuthDto.LoginRequest,
-        httpRequest: ServerHttpRequest,
+        httpRequest: HttpServletRequest,
     ): ResponseEntity<AuthDto.LoginResponse> {
         logger.info { "Login request received" }
         val ipAddress = resolveClientIp(httpRequest)
-        val userAgent = httpRequest.headers.getFirst("User-Agent") ?: ""
+        val userAgent = httpRequest.getHeader("User-Agent") ?: ""
         return ResponseEntity.ok(authService.login(request, ipAddress, userAgent))
     }
 
@@ -52,11 +52,11 @@ class AuthController(
         return ResponseEntity.ok(authService.refresh(request))
     }
 
-    private fun resolveClientIp(request: ServerHttpRequest): String {
-        val remoteAddr = request.remoteAddress?.address?.hostAddress ?: ""
+    private fun resolveClientIp(request: HttpServletRequest): String {
+        val remoteAddr = request.remoteAddr ?: ""
         val trustedIps = trustedProxyIps.split(",").map { it.trim() }
         return if (remoteAddr in trustedIps) {
-            request.headers.getFirst("X-Forwarded-For")
+            request.getHeader("X-Forwarded-For")
                 ?.split(",")?.firstOrNull()?.trim()
                 ?.takeIf { it.isNotBlank() }
                 ?: remoteAddr

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/dto/AuthDto.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/dto/AuthDto.kt
@@ -59,4 +59,9 @@ class AuthDto {
         val expiresIn: Long,
         val tokenType: String = "Bearer"
     )
+
+    data class RefreshRequest(
+        @field:NotBlank(message = "리프레시 토큰은 필수입니다.")
+        val refreshToken: String
+    )
 }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/entity/RefreshToken.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/entity/RefreshToken.kt
@@ -41,8 +41,13 @@ class RefreshToken(
     val expiresAt: LocalDateTime,
 
     @Column(nullable = false)
-    val revoked: Boolean = false,
+    var revoked: Boolean = false,
 
     @Column(name = "revoked_at")
-    val revokedAt: LocalDateTime? = null
-)
+    var revokedAt: LocalDateTime? = null
+) {
+    fun revoke(now: LocalDateTime) {
+        this.revoked = true
+        this.revokedAt = now
+    }
+}

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepository.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import java.util.UUID
 
-interface RefreshTokenRepository : JpaRepository<RefreshToken, UUID> {
+interface RefreshTokenRepository : JpaRepository<RefreshToken, UUID>, RefreshTokenRepositoryCustom {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     fun findByRefreshToken(token: String): RefreshToken?
     fun findAllByTokenFamilyAndRevokedFalse(tokenFamily: UUID): List<RefreshToken>

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepository.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepository.kt
@@ -1,10 +1,13 @@
 package com.ticketqueue.user.repository
 
 import com.ticketqueue.user.entity.RefreshToken
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import java.util.UUID
 
 interface RefreshTokenRepository : JpaRepository<RefreshToken, UUID> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     fun findByRefreshToken(token: String): RefreshToken?
     fun findAllByTokenFamilyAndRevokedFalse(tokenFamily: UUID): List<RefreshToken>
 }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepositoryCustom.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepositoryCustom.kt
@@ -1,0 +1,8 @@
+package com.ticketqueue.user.repository
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+interface RefreshTokenRepositoryCustom {
+    fun revokeAllActiveByTokenFamily(tokenFamily: UUID, now: LocalDateTime): Long
+}

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepositoryCustomImpl.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepositoryCustomImpl.kt
@@ -1,0 +1,24 @@
+package com.ticketqueue.user.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.ticketqueue.user.entity.QRefreshToken
+import java.time.LocalDateTime
+import java.util.UUID
+
+class RefreshTokenRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory
+) : RefreshTokenRepositoryCustom {
+
+    override fun revokeAllActiveByTokenFamily(tokenFamily: UUID, now: LocalDateTime): Long {
+        val token = QRefreshToken.refreshToken
+        return queryFactory
+            .update(token)
+            .set(token.revoked, true)
+            .set(token.revokedAt, now)
+            .where(
+                token.tokenFamily.eq(tokenFamily),
+                token.revoked.isFalse
+            )
+            .execute()
+    }
+}

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthService.kt
@@ -14,6 +14,7 @@ class AuthService(
     private val authTransactionalService: AuthTransactionalService,
     private val loginHistoryRecorder: LoginHistoryRecorder,
     private val encryptionService: EncryptionService,
+    private val jwtTokenProvider: JwtTokenProvider,
 ) {
     private val logger = KotlinLogging.logger {}
 
@@ -51,6 +52,12 @@ class AuthService(
         // 2. DB 처리 위임 (사용자 조회 + 검증 + 토큰 발급)
         val emailHash = encryptionService.hash(request.email)
         return authTransactionalService.processLogin(emailHash, request.password, ipAddress, userAgent)
+    }
+
+    fun refresh(request: AuthDto.RefreshRequest): AuthDto.LoginResponse {
+        // JWT 서명 검증 (DB 조회 전 빠른 실패)
+        jwtTokenProvider.validateAndParseRefreshToken(request.refreshToken)
+        return authTransactionalService.processRefresh(request.refreshToken)
     }
 
     private fun verifyRecaptcha(token: String) {

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthTransactionalService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthTransactionalService.kt
@@ -155,9 +155,7 @@ class AuthTransactionalService(
 
         // 2. 탈취 감지: revoked 토큰 재사용 시도 → token_family 전체 무효화 (만료 체크 전 수행)
         if (storedToken.revoked) {
-            refreshTokenRepository
-                .findAllByTokenFamilyAndRevokedFalse(storedToken.tokenFamily)
-                .forEach { it.revoke(now) }
+            refreshTokenRepository.revokeAllActiveByTokenFamily(storedToken.tokenFamily, now)
             logger.error { "Token reuse detected! Family ${storedToken.tokenFamily} fully revoked." }
             throw UserException(ErrorCode.REVOKED_REFRESH_TOKEN)
         }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthTransactionalService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthTransactionalService.kt
@@ -145,18 +145,63 @@ class AuthTransactionalService(
         )
     }
 
-    private fun issueTokens(user: User, email: String): Pair<String, String> {
+    @Transactional(noRollbackFor = [UserException::class])
+    fun processRefresh(rawToken: String): AuthDto.LoginResponse {
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+
+        // 1. DB에서 토큰 조회
+        val storedToken = refreshTokenRepository.findByRefreshToken(rawToken)
+            ?: throw UserException(ErrorCode.INVALID_TOKEN)
+
+        // 2. 탈취 감지: revoked 토큰 재사용 시도 → token_family 전체 무효화 (만료 체크 전 수행)
+        if (storedToken.revoked) {
+            refreshTokenRepository
+                .findAllByTokenFamilyAndRevokedFalse(storedToken.tokenFamily)
+                .forEach { it.revoke(now) }
+            logger.error { "Token reuse detected! Family ${storedToken.tokenFamily} fully revoked." }
+            throw UserException(ErrorCode.REVOKED_REFRESH_TOKEN)
+        }
+
+        // 3. DB 기준 만료 체크
+        if (storedToken.expiresAt.isBefore(now))
+            throw UserException(ErrorCode.EXPIRED_TOKEN)
+
+        // 4. 사용자 상태 검증 (삭제/휴면 계정은 토큰 즉시 폐기)
+        val user = storedToken.user
+        if (user.status == UserStatus.DELETED || user.status == UserStatus.DORMANT) {
+            storedToken.revoke(now)
+            throw UserException(ErrorCode.INVALID_CREDENTIALS)
+        }
+
+        // 5. 기존 토큰 폐기 (RTR: 1회용)
+        storedToken.revoke(now)
+
+        // 6. 신규 Access + Refresh Token 발급 (같은 tokenFamily 유지)
+        val email = encryptionService.decrypt(user.email)
+        val (accessToken, refreshToken) = issueTokens(user, email, storedToken.tokenFamily)
+
+        logger.info { "Token refreshed successfully: userId=${user.id}" }
+
+        return AuthDto.LoginResponse(
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+            expiresIn = Duration.ofMillis(jwtProperties.accessTokenExpiry).seconds,
+        )
+    }
+
+    private fun issueTokens(user: User, email: String, tokenFamily: UUID = UUID.randomUUID()): Pair<String, String> {
         val (accessToken, accessTokenJti) = jwtTokenProvider.generateAccessToken(user.id!!, user.role, email)
         val (refreshToken, _) = jwtTokenProvider.generateRefreshToken(user.id)
 
-        val refreshTokenEntity = RefreshToken(
-            user = user,
-            tokenFamily = UUID.randomUUID(),
-            refreshToken = refreshToken,
-            accessTokenJti = accessTokenJti,
-            expiresAt = LocalDateTime.now(ZoneOffset.UTC).plusSeconds(Duration.ofMillis(jwtProperties.refreshTokenExpiry).seconds),
+        refreshTokenRepository.save(
+            RefreshToken(
+                user = user,
+                tokenFamily = tokenFamily,
+                refreshToken = refreshToken,
+                accessTokenJti = accessTokenJti,
+                expiresAt = LocalDateTime.now(ZoneOffset.UTC).plusSeconds(Duration.ofMillis(jwtProperties.refreshTokenExpiry).seconds),
+            )
         )
-        refreshTokenRepository.save(refreshTokenEntity)
 
         return Pair(accessToken, refreshToken)
     }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthTransactionalService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthTransactionalService.kt
@@ -163,7 +163,7 @@ class AuthTransactionalService(
         }
 
         // 3. DB 기준 만료 체크
-        if (storedToken.expiresAt.isBefore(now))
+        if (!storedToken.expiresAt.isAfter(now))
             throw UserException(ErrorCode.EXPIRED_TOKEN)
 
         // 4. 사용자 상태 검증 (삭제/휴면 계정은 토큰 즉시 폐기)

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/JwtTokenProvider.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/JwtTokenProvider.kt
@@ -97,6 +97,7 @@ class JwtTokenProvider(private val jwtProperties: JwtProperties) {
                 .parseSignedClaims(token)
                 .payload
             if (claims["type"] != "refresh") throw UserException(ErrorCode.INVALID_TOKEN)
+            if (claims.subject.isNullOrBlank()) throw UserException(ErrorCode.INVALID_TOKEN)
             UUID.fromString(claims.subject) // subject가 유효한 UUID인지 검증
         } catch (e: ExpiredJwtException) {
             logger.error { "JWT token expired: ${e.javaClass.simpleName}" }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/JwtTokenProvider.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/JwtTokenProvider.kt
@@ -1,7 +1,12 @@
 package com.ticketqueue.user.service
 
+import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.user.config.JwtProperties
 import com.ticketqueue.user.entity.UserRole
+import com.ticketqueue.user.exception.UserException
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.JwtException
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -19,6 +24,8 @@ import java.util.UUID
 @Component
 @EnableConfigurationProperties(JwtProperties::class)
 class JwtTokenProvider(private val jwtProperties: JwtProperties) {
+
+    private val logger = KotlinLogging.logger {}
 
     private val secretKey by lazy {
         val decoded = try {
@@ -75,5 +82,30 @@ class JwtTokenProvider(private val jwtProperties: JwtProperties) {
             .compact()
 
         return Pair(token, jti)
+    }
+
+    /**
+     * Refresh Token 서명 검증 및 userId 파싱
+     * - 서명 불일치 → INVALID_TOKEN
+     * - 만료 → EXPIRED_TOKEN (JWT 레벨; DB 레벨 만료는 별도 체크)
+     */
+    fun validateAndParseRefreshToken(token: String) {
+        try {
+            val claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .payload
+            if (claims["type"] != "refresh") throw UserException(ErrorCode.INVALID_TOKEN)
+            UUID.fromString(claims.subject) // subject가 유효한 UUID인지 검증
+        } catch (e: ExpiredJwtException) {
+            logger.error { "JWT token expired: ${e.javaClass.simpleName}" }
+            throw UserException(ErrorCode.EXPIRED_TOKEN)
+        } catch (e: UserException) {
+            throw e
+        } catch (e: JwtException) {
+            logger.error { "JWT token invalid: ${e.javaClass.simpleName}" }
+            throw UserException(ErrorCode.INVALID_TOKEN)
+        }
     }
 }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/JwtTokenProvider.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/JwtTokenProvider.kt
@@ -106,6 +106,9 @@ class JwtTokenProvider(private val jwtProperties: JwtProperties) {
         } catch (e: JwtException) {
             logger.error { "JWT token invalid: ${e.javaClass.simpleName}" }
             throw UserException(ErrorCode.INVALID_TOKEN)
+        } catch (e: IllegalArgumentException) {
+            logger.error { "JWT subject is not a valid UUID: ${e.javaClass.simpleName} - ${e.message}" }
+            throw UserException(ErrorCode.INVALID_TOKEN)
         }
     }
 }

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/controller/AuthControllerTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/controller/AuthControllerTest.kt
@@ -273,4 +273,87 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
         }
     }
+
+    @Nested
+    @DisplayName("POST /auth/refresh")
+    inner class RefreshTest {
+
+        private val refreshUrl = "/auth/refresh"
+        private val validRequest = AuthDto.RefreshRequest(refreshToken = "valid-refresh-token")
+        private val validResponse = AuthDto.LoginResponse(
+            accessToken = "new-access-token",
+            refreshToken = "new-refresh-token",
+            expiresIn = 3600L,
+            tokenType = "Bearer"
+        )
+
+        @Test
+        @DisplayName("유효한 요청 시 200 OK 응답")
+        fun `should return 200 when valid request`() {
+            every { authService.refresh(validRequest) } returns validResponse
+
+            performPost(refreshUrl, validRequest)
+                .andExpect(status().isOk)
+        }
+
+        @Test
+        @DisplayName("성공 응답에 accessToken, refreshToken, expiresIn, tokenType 포함")
+        fun `should return token fields in response`() {
+            every { authService.refresh(validRequest) } returns validResponse
+
+            performPost(refreshUrl, validRequest)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.accessToken").value("new-access-token"))
+                .andExpect(jsonPath("$.refreshToken").value("new-refresh-token"))
+                .andExpect(jsonPath("$.expiresIn").value(3600))
+                .andExpect(jsonPath("$.tokenType").value("Bearer"))
+        }
+
+        @Test
+        @DisplayName("빈 refreshToken 시 400 BAD REQUEST")
+        fun `should return 400 when refreshToken is blank`() {
+            performPost(refreshUrl, AuthDto.RefreshRequest(refreshToken = ""))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("리프레시 토큰")))
+        }
+
+        @Test
+        @DisplayName("요청 body 없을 시 400 BAD REQUEST")
+        fun `should return 400 when request body is missing`() {
+            performPost(refreshUrl, null)
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 토큰 시 401 UNAUTHORIZED")
+        fun `should return 401 when token is invalid`() {
+            every { authService.refresh(validRequest) } throws BusinessException(ErrorCode.INVALID_TOKEN)
+
+            performPost(refreshUrl, validRequest)
+                .andExpect(status().isUnauthorized)
+                .andExpect(jsonPath("$.code").value("INVALID_TOKEN"))
+        }
+
+        @Test
+        @DisplayName("만료된 토큰 시 401 UNAUTHORIZED")
+        fun `should return 401 when token is expired`() {
+            every { authService.refresh(validRequest) } throws BusinessException(ErrorCode.EXPIRED_TOKEN)
+
+            performPost(refreshUrl, validRequest)
+                .andExpect(status().isUnauthorized)
+                .andExpect(jsonPath("$.code").value("EXPIRED_TOKEN"))
+        }
+
+        @Test
+        @DisplayName("탈취된 토큰 사용 시 403 FORBIDDEN")
+        fun `should return 403 when token is revoked`() {
+            every { authService.refresh(validRequest) } throws BusinessException(ErrorCode.REVOKED_REFRESH_TOKEN)
+
+            performPost(refreshUrl, validRequest)
+                .andExpect(status().isForbidden)
+                .andExpect(jsonPath("$.code").value("REVOKED_REFRESH_TOKEN"))
+        }
+    }
 }

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/AuthServiceTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/AuthServiceTest.kt
@@ -6,7 +6,9 @@ import com.ticketqueue.common.external.portone.PortoneIdentityV2Response
 import com.ticketqueue.user.dto.AuthDto
 import com.ticketqueue.user.exception.UserException
 import io.kotest.matchers.shouldBe
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
@@ -22,6 +24,7 @@ class AuthServiceTest {
     private lateinit var portoneService: PortoneService
     private lateinit var authTransactionalService: AuthTransactionalService
     private lateinit var loginHistoryRecorder: LoginHistoryRecorder
+    private lateinit var jwtTokenProvider: JwtTokenProvider
     private lateinit var authService: AuthService
 
     @BeforeEach
@@ -31,7 +34,8 @@ class AuthServiceTest {
         portoneService = mockk()
         authTransactionalService = mockk()
         loginHistoryRecorder = mockk(relaxed = true)
-        authService = AuthService(recaptchaService, portoneService, authTransactionalService, loginHistoryRecorder, encryptionService)
+        jwtTokenProvider = mockk()
+        authService = AuthService(recaptchaService, portoneService, authTransactionalService, loginHistoryRecorder, encryptionService, jwtTokenProvider)
     }
 
     // ─── 공통 헬퍼 ────────────────────────────────────────────────────────────────
@@ -299,6 +303,77 @@ class AuthServiceTest {
             }
 
             exception.errorCode shouldBe ErrorCode.INVALID_CREDENTIALS
+        }
+    }
+
+    // ─── Refresh 테스트 ───────────────────────────────────────────────────────────
+
+    @Nested
+    inner class RefreshTest {
+
+        private val validRequest = AuthDto.RefreshRequest(refreshToken = "valid-refresh-token")
+        private val validResponse = AuthDto.LoginResponse(
+            accessToken = "new-access-token",
+            refreshToken = "new-refresh-token",
+            expiresIn = 3600L,
+        )
+
+        @Test
+        fun `정상 갱신 - JWT 검증 후 processRefresh 위임 및 LoginResponse 반환`() {
+            // given
+            every { jwtTokenProvider.validateAndParseRefreshToken(validRequest.refreshToken) } just Runs
+            every { authTransactionalService.processRefresh(validRequest.refreshToken) } returns validResponse
+
+            // when
+            val response = authService.refresh(validRequest)
+
+            // then
+            response.accessToken shouldBe "new-access-token"
+            response.refreshToken shouldBe "new-refresh-token"
+            verify(exactly = 1) { jwtTokenProvider.validateAndParseRefreshToken(validRequest.refreshToken) }
+            verify(exactly = 1) { authTransactionalService.processRefresh(validRequest.refreshToken) }
+        }
+
+        @Test
+        fun `JWT 서명 검증 실패 - INVALID_TOKEN 예외, processRefresh 미호출`() {
+            // given
+            every { jwtTokenProvider.validateAndParseRefreshToken(any()) } throws UserException(ErrorCode.INVALID_TOKEN)
+
+            // when & then
+            val exception = assertThrows<UserException> {
+                authService.refresh(validRequest)
+            }
+
+            exception.errorCode shouldBe ErrorCode.INVALID_TOKEN
+            verify(exactly = 0) { authTransactionalService.processRefresh(any()) }
+        }
+
+        @Test
+        fun `JWT 만료 - EXPIRED_TOKEN 예외, processRefresh 미호출`() {
+            // given
+            every { jwtTokenProvider.validateAndParseRefreshToken(any()) } throws UserException(ErrorCode.EXPIRED_TOKEN)
+
+            // when & then
+            val exception = assertThrows<UserException> {
+                authService.refresh(validRequest)
+            }
+
+            exception.errorCode shouldBe ErrorCode.EXPIRED_TOKEN
+            verify(exactly = 0) { authTransactionalService.processRefresh(any()) }
+        }
+
+        @Test
+        fun `processRefresh 예외 - 그대로 전파`() {
+            // given
+            every { jwtTokenProvider.validateAndParseRefreshToken(any()) } just Runs
+            every { authTransactionalService.processRefresh(any()) } throws UserException(ErrorCode.REVOKED_REFRESH_TOKEN)
+
+            // when & then
+            val exception = assertThrows<UserException> {
+                authService.refresh(validRequest)
+            }
+
+            exception.errorCode shouldBe ErrorCode.REVOKED_REFRESH_TOKEN
         }
     }
 }

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/AuthServiceTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/AuthServiceTest.kt
@@ -319,7 +319,7 @@ class AuthServiceTest {
         )
 
         @Test
-        fun `정상 갱신 - JWT 검증 후 processRefresh 위임 및 LoginResponse 반환`() {
+        fun refresh_shouldReturnLoginResponse_whenValid() {
             // given
             every { jwtTokenProvider.validateAndParseRefreshToken(validRequest.refreshToken) } just Runs
             every { authTransactionalService.processRefresh(validRequest.refreshToken) } returns validResponse
@@ -335,7 +335,7 @@ class AuthServiceTest {
         }
 
         @Test
-        fun `JWT 서명 검증 실패 - INVALID_TOKEN 예외, processRefresh 미호출`() {
+        fun refresh_shouldThrowInvalidToken_whenSignatureInvalid() {
             // given
             every { jwtTokenProvider.validateAndParseRefreshToken(any()) } throws UserException(ErrorCode.INVALID_TOKEN)
 
@@ -349,7 +349,7 @@ class AuthServiceTest {
         }
 
         @Test
-        fun `JWT 만료 - EXPIRED_TOKEN 예외, processRefresh 미호출`() {
+        fun refresh_shouldThrowExpiredToken_whenExpired() {
             // given
             every { jwtTokenProvider.validateAndParseRefreshToken(any()) } throws UserException(ErrorCode.EXPIRED_TOKEN)
 
@@ -363,7 +363,7 @@ class AuthServiceTest {
         }
 
         @Test
-        fun `processRefresh 예외 - 그대로 전파`() {
+        fun refresh_shouldPropagateException_whenProcessRefreshFails() {
             // given
             every { jwtTokenProvider.validateAndParseRefreshToken(any()) } just Runs
             every { authTransactionalService.processRefresh(any()) } throws UserException(ErrorCode.REVOKED_REFRESH_TOKEN)

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/AuthTransactionalServiceTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/AuthTransactionalServiceTest.kt
@@ -3,6 +3,7 @@ package com.ticketqueue.user.service
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.user.config.JwtProperties
 import com.ticketqueue.user.dto.AuthDto
+import com.ticketqueue.user.entity.RefreshToken
 import com.ticketqueue.user.entity.User
 import com.ticketqueue.user.entity.UserRole
 import com.ticketqueue.user.entity.UserStatus
@@ -10,6 +11,7 @@ import com.ticketqueue.user.exception.UserException
 import com.ticketqueue.user.repository.RefreshTokenRepository
 import com.ticketqueue.user.repository.UserRepository
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -21,6 +23,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.security.crypto.password.PasswordEncoder
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.Base64
 import java.util.UUID
 
@@ -350,7 +354,7 @@ class AuthTransactionalServiceTest {
         }
 
         @Test
-        fun `이메일 체크가 CI 체크보다 먼저 수행`() {
+        fun `이메일 체크가 CI 체크 보다 먼저 수행`() {
             // given
             val request = createSignupRequest()
             val callOrder = mutableListOf<String>()
@@ -372,6 +376,214 @@ class AuthTransactionalServiceTest {
 
             callOrder shouldBe listOf("emailCheck")
             verify(exactly = 0) { encryptionService.hash("test-ci-value") }
+        }
+    }
+
+    // ─── processRefresh 테스트 ────────────────────────────────────────────────────
+
+    @Nested
+    inner class ProcessRefreshTest {
+
+        private val tokenFamily: UUID = UUID.randomUUID()
+
+        private fun createStoredToken(
+            user: User,
+            tokenFamily: UUID = this.tokenFamily,
+            rawToken: String = "raw-refresh-token",
+            expiresAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC).plusDays(7),
+            revoked: Boolean = false,
+        ) = RefreshToken(
+            user = user,
+            tokenFamily = tokenFamily,
+            refreshToken = rawToken,
+            expiresAt = expiresAt,
+            revoked = revoked,
+        )
+
+        private fun mockSuccessfulRefresh(user: User, email: String = "test@example.com") {
+            every { encryptionService.decrypt(user.email) } returns email
+            every { jwtTokenProvider.generateAccessToken(user.id!!, user.role, email) } returns Pair("new-access-token", "new-access-jti")
+            every { jwtTokenProvider.generateRefreshToken(user.id!!) } returns Pair("new-refresh-token", "new-refresh-jti")
+            every { refreshTokenRepository.save(any()) } returns mockk()
+        }
+
+        @Test
+        fun `정상 갱신 - LoginResponse 반환`() {
+            // given
+            val user = createActiveUser()
+            val storedToken = createStoredToken(user)
+            every { refreshTokenRepository.findByRefreshToken("raw-refresh-token") } returns storedToken
+            mockSuccessfulRefresh(user)
+
+            // when
+            val response = authTransactionalService.processRefresh("raw-refresh-token")
+
+            // then
+            response.accessToken shouldBe "new-access-token"
+            response.refreshToken shouldBe "new-refresh-token"
+            response.expiresIn shouldBe 3600L
+            response.tokenType shouldBe "Bearer"
+        }
+
+        @Test
+        fun `정상 갱신 - 기존 토큰 폐기 (revoked=true, revokedAt 설정)`() {
+            // given
+            val user = createActiveUser()
+            val storedToken = createStoredToken(user)
+            every { refreshTokenRepository.findByRefreshToken("raw-refresh-token") } returns storedToken
+            mockSuccessfulRefresh(user)
+
+            // when
+            authTransactionalService.processRefresh("raw-refresh-token")
+
+            // then
+            storedToken.revoked shouldBe true
+            storedToken.revokedAt shouldNotBe null
+        }
+
+        @Test
+        fun `정상 갱신 - 새 RefreshToken 저장 시 동일 tokenFamily 유지`() {
+            // given
+            val user = createActiveUser()
+            val storedToken = createStoredToken(user, tokenFamily = tokenFamily)
+            val savedTokenSlot = slot<RefreshToken>()
+            every { refreshTokenRepository.findByRefreshToken("raw-refresh-token") } returns storedToken
+            every { encryptionService.decrypt(user.email) } returns "test@example.com"
+            every { jwtTokenProvider.generateAccessToken(any(), any(), any()) } returns Pair("new-access-token", "new-access-jti")
+            every { jwtTokenProvider.generateRefreshToken(any()) } returns Pair("new-refresh-token", "new-refresh-jti")
+            every { refreshTokenRepository.save(capture(savedTokenSlot)) } returns mockk()
+
+            // when
+            authTransactionalService.processRefresh("raw-refresh-token")
+
+            // then
+            savedTokenSlot.captured.tokenFamily shouldBe tokenFamily
+            savedTokenSlot.captured.refreshToken shouldBe "new-refresh-token"
+        }
+
+        @Test
+        fun `존재하지 않는 토큰 - INVALID_TOKEN 예외`() {
+            // given
+            every { refreshTokenRepository.findByRefreshToken("unknown-token") } returns null
+
+            // when & then
+            val exception = assertThrows<UserException> {
+                authTransactionalService.processRefresh("unknown-token")
+            }
+
+            exception.errorCode shouldBe ErrorCode.INVALID_TOKEN
+            verify(exactly = 0) { refreshTokenRepository.save(any()) }
+        }
+
+        @Test
+        fun `만료된 토큰 (DB 기준) - EXPIRED_TOKEN 예외`() {
+            // given
+            val user = createActiveUser()
+            val expiredToken = createStoredToken(
+                user = user,
+                expiresAt = LocalDateTime.now(ZoneOffset.UTC).minusSeconds(1),
+            )
+            every { refreshTokenRepository.findByRefreshToken("expired-token") } returns expiredToken
+
+            // when & then
+            val exception = assertThrows<UserException> {
+                authTransactionalService.processRefresh("expired-token")
+            }
+
+            exception.errorCode shouldBe ErrorCode.EXPIRED_TOKEN
+            verify(exactly = 0) { refreshTokenRepository.save(any()) }
+        }
+
+        @Test
+        fun `탈취 감지 - revoked 토큰 재사용 시 REVOKED_REFRESH_TOKEN 예외`() {
+            // given
+            val user = createActiveUser()
+            val revokedToken = createStoredToken(user, rawToken = "revoked-token", revoked = true)
+            every { refreshTokenRepository.findByRefreshToken("revoked-token") } returns revokedToken
+            every { refreshTokenRepository.findAllByTokenFamilyAndRevokedFalse(tokenFamily) } returns emptyList()
+
+            // when & then
+            val exception = assertThrows<UserException> {
+                authTransactionalService.processRefresh("revoked-token")
+            }
+
+            exception.errorCode shouldBe ErrorCode.REVOKED_REFRESH_TOKEN
+            verify(exactly = 0) { refreshTokenRepository.save(any()) }
+        }
+
+        @Test
+        fun `탈취 감지 - token_family 내 활성 토큰 전체 무효화`() {
+            // given
+            val user = createActiveUser()
+            val revokedToken = createStoredToken(user, rawToken = "revoked-token", revoked = true)
+            val activeToken1 = createStoredToken(user, rawToken = "active-token-1")
+            val activeToken2 = createStoredToken(user, rawToken = "active-token-2")
+            every { refreshTokenRepository.findByRefreshToken("revoked-token") } returns revokedToken
+            every { refreshTokenRepository.findAllByTokenFamilyAndRevokedFalse(tokenFamily) } returns listOf(activeToken1, activeToken2)
+
+            // when & then
+            assertThrows<UserException> {
+                authTransactionalService.processRefresh("revoked-token")
+            }
+
+            activeToken1.revoked shouldBe true
+            activeToken2.revoked shouldBe true
+        }
+
+        @Test
+        fun `탈취 감지 - 만료된 revoked 토큰도 감지 (revoked 체크가 만료 체크보다 우선)`() {
+            // given
+            val user = createActiveUser()
+            val expiredRevokedToken = createStoredToken(
+                user = user,
+                rawToken = "expired-revoked-token",
+                revoked = true,
+                expiresAt = LocalDateTime.now(ZoneOffset.UTC).minusDays(1),
+            )
+            every { refreshTokenRepository.findByRefreshToken("expired-revoked-token") } returns expiredRevokedToken
+            every { refreshTokenRepository.findAllByTokenFamilyAndRevokedFalse(tokenFamily) } returns emptyList()
+
+            // when & then
+            val exception = assertThrows<UserException> {
+                authTransactionalService.processRefresh("expired-revoked-token")
+            }
+
+            // EXPIRED_TOKEN이 아닌 REVOKED_REFRESH_TOKEN이어야 함 (탈취 우선 감지)
+            exception.errorCode shouldBe ErrorCode.REVOKED_REFRESH_TOKEN
+        }
+
+        @Test
+        fun `DELETED 계정 토큰 갱신 - INVALID_CREDENTIALS 예외 및 토큰 즉시 폐기`() {
+            // given
+            val user = createActiveUser(status = UserStatus.DELETED)
+            val storedToken = createStoredToken(user)
+            every { refreshTokenRepository.findByRefreshToken("raw-refresh-token") } returns storedToken
+
+            // when & then
+            val exception = assertThrows<UserException> {
+                authTransactionalService.processRefresh("raw-refresh-token")
+            }
+
+            exception.errorCode shouldBe ErrorCode.INVALID_CREDENTIALS
+            storedToken.revoked shouldBe true
+            verify(exactly = 0) { refreshTokenRepository.save(any()) }
+        }
+
+        @Test
+        fun `DORMANT 계정 토큰 갱신 - INVALID_CREDENTIALS 예외 및 토큰 즉시 폐기`() {
+            // given
+            val user = createActiveUser(status = UserStatus.DORMANT)
+            val storedToken = createStoredToken(user)
+            every { refreshTokenRepository.findByRefreshToken("raw-refresh-token") } returns storedToken
+
+            // when & then
+            val exception = assertThrows<UserException> {
+                authTransactionalService.processRefresh("raw-refresh-token")
+            }
+
+            exception.errorCode shouldBe ErrorCode.INVALID_CREDENTIALS
+            storedToken.revoked shouldBe true
+            verify(exactly = 0) { refreshTokenRepository.save(any()) }
         }
     }
 }

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/AuthTransactionalServiceTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/AuthTransactionalServiceTest.kt
@@ -354,7 +354,7 @@ class AuthTransactionalServiceTest {
         }
 
         @Test
-        fun `이메일 체크가 CI 체크 보다 먼저 수행`() {
+        fun processSignup_shouldPerformEmailCheckBeforeCICheck_whenEmailExists() {
             // given
             val request = createSignupRequest()
             val callOrder = mutableListOf<String>()
@@ -408,7 +408,7 @@ class AuthTransactionalServiceTest {
         }
 
         @Test
-        fun `정상 갱신 - LoginResponse 반환`() {
+        fun processRefresh_shouldReturnLoginResponse_whenValid() {
             // given
             val user = createActiveUser()
             val storedToken = createStoredToken(user)
@@ -426,7 +426,7 @@ class AuthTransactionalServiceTest {
         }
 
         @Test
-        fun `정상 갱신 - 기존 토큰 폐기 (revoked=true, revokedAt 설정)`() {
+        fun processRefresh_shouldRevokeExistingToken_whenValid() {
             // given
             val user = createActiveUser()
             val storedToken = createStoredToken(user)
@@ -442,7 +442,7 @@ class AuthTransactionalServiceTest {
         }
 
         @Test
-        fun `정상 갱신 - 새 RefreshToken 저장 시 동일 tokenFamily 유지`() {
+        fun processRefresh_shouldMaintainTokenFamily_whenValid() {
             // given
             val user = createActiveUser()
             val storedToken = createStoredToken(user, tokenFamily = tokenFamily)
@@ -462,7 +462,7 @@ class AuthTransactionalServiceTest {
         }
 
         @Test
-        fun `존재하지 않는 토큰 - INVALID_TOKEN 예외`() {
+        fun processRefresh_shouldThrowInvalidToken_whenTokenNotFound() {
             // given
             every { refreshTokenRepository.findByRefreshToken("unknown-token") } returns null
 
@@ -476,7 +476,7 @@ class AuthTransactionalServiceTest {
         }
 
         @Test
-        fun `만료된 토큰 (DB 기준) - EXPIRED_TOKEN 예외`() {
+        fun processRefresh_shouldThrowExpiredToken_whenTokenExpiredByDb() {
             // given
             val user = createActiveUser()
             val expiredToken = createStoredToken(
@@ -495,7 +495,7 @@ class AuthTransactionalServiceTest {
         }
 
         @Test
-        fun `탈취 감지 - revoked 토큰 재사용 시 REVOKED_REFRESH_TOKEN 예외`() {
+        fun processRefresh_shouldThrowRevokedRefreshToken_whenRevokedTokenReused() {
             // given
             val user = createActiveUser()
             val revokedToken = createStoredToken(user, rawToken = "revoked-token", revoked = true)
@@ -512,7 +512,7 @@ class AuthTransactionalServiceTest {
         }
 
         @Test
-        fun `탈취 감지 - token_family 내 활성 토큰 전체 무효화`() {
+        fun processRefresh_shouldRevokeAllTokensInFamily_whenRevokedTokenDetected() {
             // given
             val user = createActiveUser()
             val revokedToken = createStoredToken(user, rawToken = "revoked-token", revoked = true)
@@ -531,7 +531,7 @@ class AuthTransactionalServiceTest {
         }
 
         @Test
-        fun `탈취 감지 - 만료된 revoked 토큰도 감지 (revoked 체크가 만료 체크보다 우선)`() {
+        fun processRefresh_shouldThrowRevokedRefreshToken_whenExpiredAndRevoked() {
             // given
             val user = createActiveUser()
             val expiredRevokedToken = createStoredToken(
@@ -553,7 +553,7 @@ class AuthTransactionalServiceTest {
         }
 
         @Test
-        fun `DELETED 계정 토큰 갱신 - INVALID_CREDENTIALS 예외 및 토큰 즉시 폐기`() {
+        fun processRefresh_shouldThrowInvalidCredentials_whenDeletedAccount() {
             // given
             val user = createActiveUser(status = UserStatus.DELETED)
             val storedToken = createStoredToken(user)
@@ -570,7 +570,7 @@ class AuthTransactionalServiceTest {
         }
 
         @Test
-        fun `DORMANT 계정 토큰 갱신 - INVALID_CREDENTIALS 예외 및 토큰 즉시 폐기`() {
+        fun processRefresh_shouldThrowInvalidCredentials_whenDormantAccount() {
             // given
             val user = createActiveUser(status = UserStatus.DORMANT)
             val storedToken = createStoredToken(user)

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/AuthTransactionalServiceTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/AuthTransactionalServiceTest.kt
@@ -500,7 +500,7 @@ class AuthTransactionalServiceTest {
             val user = createActiveUser()
             val revokedToken = createStoredToken(user, rawToken = "revoked-token", revoked = true)
             every { refreshTokenRepository.findByRefreshToken("revoked-token") } returns revokedToken
-            every { refreshTokenRepository.findAllByTokenFamilyAndRevokedFalse(tokenFamily) } returns emptyList()
+            every { refreshTokenRepository.revokeAllActiveByTokenFamily(tokenFamily, any()) } returns 0L
 
             // when & then
             val exception = assertThrows<UserException> {
@@ -516,18 +516,15 @@ class AuthTransactionalServiceTest {
             // given
             val user = createActiveUser()
             val revokedToken = createStoredToken(user, rawToken = "revoked-token", revoked = true)
-            val activeToken1 = createStoredToken(user, rawToken = "active-token-1")
-            val activeToken2 = createStoredToken(user, rawToken = "active-token-2")
             every { refreshTokenRepository.findByRefreshToken("revoked-token") } returns revokedToken
-            every { refreshTokenRepository.findAllByTokenFamilyAndRevokedFalse(tokenFamily) } returns listOf(activeToken1, activeToken2)
+            every { refreshTokenRepository.revokeAllActiveByTokenFamily(tokenFamily, any()) } returns 2L
 
             // when & then
             assertThrows<UserException> {
                 authTransactionalService.processRefresh("revoked-token")
             }
 
-            activeToken1.revoked shouldBe true
-            activeToken2.revoked shouldBe true
+            verify(exactly = 1) { refreshTokenRepository.revokeAllActiveByTokenFamily(tokenFamily, any()) }
         }
 
         @Test
@@ -541,7 +538,7 @@ class AuthTransactionalServiceTest {
                 expiresAt = LocalDateTime.now(ZoneOffset.UTC).minusDays(1),
             )
             every { refreshTokenRepository.findByRefreshToken("expired-revoked-token") } returns expiredRevokedToken
-            every { refreshTokenRepository.findAllByTokenFamilyAndRevokedFalse(tokenFamily) } returns emptyList()
+            every { refreshTokenRepository.revokeAllActiveByTokenFamily(tokenFamily, any()) } returns 0L
 
             // when & then
             val exception = assertThrows<UserException> {

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/PortoneServiceTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/PortoneServiceTest.kt
@@ -2,6 +2,7 @@ package com.ticketqueue.user.service
 
 import com.ticketqueue.common.exception.BusinessException
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.exception.ExternalSystemException
 import com.ticketqueue.common.external.portone.*
 import com.ticketqueue.user.exception.UserException
 import feign.Request
@@ -124,7 +125,7 @@ class PortoneServiceTest {
         } throws retryableException
 
         // when & then
-        val exception = shouldThrow<UserException> {
+        val exception = shouldThrow<ExternalSystemException> {
             portoneService.verifyIdentity(identityVerificationId)
         }
         exception.errorCode shouldBe ErrorCode.PORTONE_API_ERROR

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/RecaptchaServiceTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/RecaptchaServiceTest.kt
@@ -3,6 +3,8 @@ package com.ticketqueue.user.service
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.common.exception.ExternalSystemException
 import com.ticketqueue.user.exception.UserException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 import io.mockk.*
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
@@ -127,10 +129,10 @@ class RecaptchaServiceTest {
         every { mockRequestBodySpec.retrieve() } throws expectedException
 
         // When & Then
-        val exception = assertThrows(ExternalSystemException::class.java) {
+        val exception = shouldThrow<ExternalSystemException> {
             recaptchaService.verify(testToken)
         }
 
-        assertEquals(ErrorCode.RECAPTCHA_SERVICE_ERROR, exception.errorCode)
+        exception.errorCode shouldBe ErrorCode.RECAPTCHA_SERVICE_ERROR
     }
 }

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/RecaptchaServiceTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/RecaptchaServiceTest.kt
@@ -1,6 +1,7 @@
 package com.ticketqueue.user.service
 
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.exception.ExternalSystemException
 import com.ticketqueue.user.exception.UserException
 import io.mockk.*
 import org.junit.jupiter.api.AfterEach
@@ -126,10 +127,10 @@ class RecaptchaServiceTest {
         every { mockRequestBodySpec.retrieve() } throws expectedException
 
         // When & Then
-        val exception = assertThrows(UserException::class.java) {
+        val exception = assertThrows(ExternalSystemException::class.java) {
             recaptchaService.verify(testToken)
         }
 
-        assertEquals(ErrorCode.RECAPTCHA_FAILED, exception.errorCode)
+        assertEquals(ErrorCode.RECAPTCHA_SERVICE_ERROR, exception.errorCode)
     }
 }


### PR DESCRIPTION
## Summary
- `POST /auth/refresh` 토큰 재발급 엔드포인트 추가
- Refresh Token Rotation(RTR) + 탈취 감지 구현
- `REVOKED_REFRESH_TOKEN` 에러 코드 추가 (403 Forbidden)
- PortoneServiceTest, RecaptchaServiceTest 예외 타입 수정 (5xx → ExternalSystemException)

## Changes
- **AuthController**: `POST /auth/refresh` 엔드포인트 추가
- **AuthDto**: `RefreshRequest` DTO 추가
- **JwtTokenProvider**: `validateAndParseRefreshToken()` 추가 (서명/만료 검증)
- **AuthTransactionalService**: `processRefresh()` 구현
  - revoked 토큰 재사용 시 token_family 전체 무효화 (탈취 감지)
  - DB 기준 만료 체크
  - 삭제/휴면 계정 토큰 즉시 폐기
  - 기존 토큰 폐기 후 신규 Access + Refresh Token 발급 (동일 tokenFamily 유지)
- **RefreshToken**: `revoke()` 메서드 추가, 비관적 락(@Lock) 적용
- **ErrorCode**: `REVOKED_REFRESH_TOKEN` 추가

## Test plan
- [ ] AuthControllerTest: 6개 케이스 (정상/빈 토큰/body 없음/invalid/expired/revoked)
- [ ] AuthServiceTest: 4개 케이스 (정상 갱신/JWT 검증 실패/만료/processRefresh 예외 전파)
- [ ] AuthTransactionalServiceTest: 9개 케이스 (정상/기존 토큰 폐기/tokenFamily 유지/존재하지 않는 토큰/만료/탈취 감지 등)

Closes #26 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a token refresh endpoint to obtain new access and refresh tokens.

* **Security Improvements**
  * Enforced single-use refresh tokens with token-family continuity and family-wide revocation on compromise.
  * New explicit error for revoked refresh attempts to guide re-login.

* **Bug Fixes**
  * Stricter refresh-token validation, expiry handling, and account-status checks.

* **Tests**
  * Extensive tests covering refresh success, validation errors, revoked/expired cases, and revocation cascades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->