### PR TITLE
feat: [User] 로그아웃 API 구현

### DIFF
--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/config/SecurityConfig.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/config/SecurityConfig.kt
@@ -23,7 +23,7 @@ class SecurityConfig {
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests { auth ->
                 auth
-                    .requestMatchers("/auth/signup", "/auth/login", "/auth/refresh").permitAll()
+                    .requestMatchers("/auth/signup", "/auth/login", "/auth/refresh", "/auth/logout").permitAll()
                     .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                     .anyRequest().authenticated()
             }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/config/SecurityConfig.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/config/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package com.ticketqueue.user.config
 
+import com.ticketqueue.common.security.GatewayAuthFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -8,6 +9,7 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
@@ -21,9 +23,10 @@ class SecurityConfig {
         return http
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .addFilterBefore(GatewayAuthFilter(), UsernamePasswordAuthenticationFilter::class.java)
             .authorizeHttpRequests { auth ->
                 auth
-                    .requestMatchers("/auth/signup", "/auth/login", "/auth/refresh", "/auth/logout").permitAll()
+                    .requestMatchers("/auth/signup", "/auth/login", "/auth/refresh").permitAll()
                     .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                     .anyRequest().authenticated()
             }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/AuthController.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/AuthController.kt
@@ -1,6 +1,8 @@
 package com.ticketqueue.user.controller
 
+import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.user.dto.AuthDto
+import com.ticketqueue.user.exception.UserException
 import com.ticketqueue.user.service.AuthService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.HttpServletRequest
@@ -41,6 +43,16 @@ class AuthController(
         val ipAddress = resolveClientIp(httpRequest)
         val userAgent = httpRequest.getHeader("User-Agent") ?: ""
         return ResponseEntity.ok(authService.login(request, ipAddress, userAgent))
+    }
+
+    // 로그아웃
+    @PostMapping("/logout")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun logout(httpRequest: HttpServletRequest) {
+        logger.info { "Logout request received" }
+        val authHeader = httpRequest.getHeader("Authorization")
+            ?: throw UserException(ErrorCode.UNAUTHORIZED)
+        authService.logout(authHeader)
     }
 
     // 토큰 재발급

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepository.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepository.kt
@@ -9,5 +9,5 @@ import java.util.UUID
 interface RefreshTokenRepository : JpaRepository<RefreshToken, UUID>, RefreshTokenRepositoryCustom {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     fun findByRefreshToken(token: String): RefreshToken?
-    fun findAllByTokenFamilyAndRevokedFalse(tokenFamily: UUID): List<RefreshToken>
+    fun findByAccessTokenJti(jti: String): RefreshToken?
 }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthService.kt
@@ -62,8 +62,8 @@ class AuthService(
             throw UserException(ErrorCode.UNAUTHORIZED)
         val accessToken = authorizationHeader.removePrefix("Bearer ")
         val jti = jwtTokenProvider.parseAccessTokenJti(accessToken)
-        tokenBlacklistService.addToBlacklist(jti, jwtProperties.accessTokenExpiry)
         authTransactionalService.processLogout(jti)
+        tokenBlacklistService.addToBlacklist(jti, jwtProperties.accessTokenExpiry)
     }
 
     fun refresh(request: AuthDto.RefreshRequest): AuthDto.LoginResponse {

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthService.kt
@@ -2,6 +2,7 @@ package com.ticketqueue.user.service
 
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.common.exception.ExternalSystemException
+import com.ticketqueue.user.config.JwtProperties
 import com.ticketqueue.user.dto.AuthDto
 import com.ticketqueue.user.exception.UserException
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -15,6 +16,8 @@ class AuthService(
     private val loginHistoryRecorder: LoginHistoryRecorder,
     private val encryptionService: EncryptionService,
     private val jwtTokenProvider: JwtTokenProvider,
+    private val tokenBlacklistService: TokenBlacklistService,
+    private val jwtProperties: JwtProperties,
 ) {
     private val logger = KotlinLogging.logger {}
 
@@ -52,6 +55,15 @@ class AuthService(
         // 2. DB 처리 위임 (사용자 조회 + 검증 + 토큰 발급)
         val emailHash = encryptionService.hash(request.email)
         return authTransactionalService.processLogin(emailHash, request.password, ipAddress, userAgent)
+    }
+
+    fun logout(authorizationHeader: String) {
+        if (!authorizationHeader.startsWith("Bearer "))
+            throw UserException(ErrorCode.UNAUTHORIZED)
+        val accessToken = authorizationHeader.removePrefix("Bearer ")
+        val jti = jwtTokenProvider.parseAccessTokenJti(accessToken)
+        tokenBlacklistService.addToBlacklist(jti, jwtProperties.accessTokenExpiry)
+        authTransactionalService.processLogout(jti)
     }
 
     fun refresh(request: AuthDto.RefreshRequest): AuthDto.LoginResponse {

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthTransactionalService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/AuthTransactionalService.kt
@@ -145,6 +145,13 @@ class AuthTransactionalService(
         )
     }
 
+    fun processLogout(jti: String) {
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        refreshTokenRepository.findByAccessTokenJti(jti)?.let { token ->
+            if (!token.revoked) token.revoke(now)
+        }
+    }
+
     @Transactional(noRollbackFor = [UserException::class])
     fun processRefresh(rawToken: String): AuthDto.LoginResponse {
         val now = LocalDateTime.now(ZoneOffset.UTC)

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/JwtTokenProvider.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/JwtTokenProvider.kt
@@ -85,6 +85,29 @@ class JwtTokenProvider(private val jwtProperties: JwtProperties) {
     }
 
     /**
+     * Access Token에서 jti 추출
+     * - 만료된 토큰에서도 jti 추출 가능 (로그아웃 시 필요)
+     * - 서명 불일치 → INVALID_TOKEN
+     */
+    fun parseAccessTokenJti(token: String): String {
+        return try {
+            Jwts.parser().verifyWith(secretKey).build()
+                .parseSignedClaims(token).payload
+                .id ?: throw UserException(ErrorCode.INVALID_TOKEN)
+        } catch (e: ExpiredJwtException) {
+            e.claims.id ?: throw UserException(ErrorCode.INVALID_TOKEN)
+        } catch (e: UserException) {
+            throw e
+        } catch (e: JwtException) {
+            logger.error { "JWT token invalid: ${e.javaClass.simpleName} - ${e.message}" }
+            throw UserException(ErrorCode.INVALID_TOKEN)
+        } catch (e: IllegalArgumentException) {
+            logger.error { "JWT subject is not a valid UUID: ${e.javaClass.simpleName} - ${e.message}" }
+            throw UserException(ErrorCode.INVALID_TOKEN)
+        }
+    }
+
+    /**
      * Refresh Token 서명 검증 및 userId 파싱
      * - 서명 불일치 → INVALID_TOKEN
      * - 만료 → EXPIRED_TOKEN (JWT 레벨; DB 레벨 만료는 별도 체크)
@@ -100,12 +123,12 @@ class JwtTokenProvider(private val jwtProperties: JwtProperties) {
             if (claims.subject.isNullOrBlank()) throw UserException(ErrorCode.INVALID_TOKEN)
             UUID.fromString(claims.subject) // subject가 유효한 UUID인지 검증
         } catch (e: ExpiredJwtException) {
-            logger.error { "JWT token expired: ${e.javaClass.simpleName}" }
+            logger.error { "JWT token expired: ${e.javaClass.simpleName} - ${e.message}" }
             throw UserException(ErrorCode.EXPIRED_TOKEN)
         } catch (e: UserException) {
             throw e
         } catch (e: JwtException) {
-            logger.error { "JWT token invalid: ${e.javaClass.simpleName}" }
+            logger.error { "JWT token invalid: ${e.javaClass.simpleName} - ${e.message}" }
             throw UserException(ErrorCode.INVALID_TOKEN)
         } catch (e: IllegalArgumentException) {
             logger.error { "JWT subject is not a valid UUID: ${e.javaClass.simpleName} - ${e.message}" }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/JwtTokenProvider.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/JwtTokenProvider.kt
@@ -99,10 +99,10 @@ class JwtTokenProvider(private val jwtProperties: JwtProperties) {
         } catch (e: UserException) {
             throw e
         } catch (e: JwtException) {
-            logger.error { "JWT token invalid: ${e.javaClass.simpleName} - ${e.message}" }
+            logger.error { "JWT token invalid" }
             throw UserException(ErrorCode.INVALID_TOKEN)
         } catch (e: IllegalArgumentException) {
-            logger.error { "JWT subject is not a valid UUID: ${e.javaClass.simpleName} - ${e.message}" }
+            logger.error { "JWT subject is not a valid UUID" }
             throw UserException(ErrorCode.INVALID_TOKEN)
         }
     }
@@ -123,15 +123,15 @@ class JwtTokenProvider(private val jwtProperties: JwtProperties) {
             if (claims.subject.isNullOrBlank()) throw UserException(ErrorCode.INVALID_TOKEN)
             UUID.fromString(claims.subject) // subject가 유효한 UUID인지 검증
         } catch (e: ExpiredJwtException) {
-            logger.error { "JWT token expired: ${e.javaClass.simpleName} - ${e.message}" }
+            logger.error { "JWT token expired" }
             throw UserException(ErrorCode.EXPIRED_TOKEN)
         } catch (e: UserException) {
             throw e
         } catch (e: JwtException) {
-            logger.error { "JWT token invalid: ${e.javaClass.simpleName} - ${e.message}" }
+            logger.error { "JWT token invalid" }
             throw UserException(ErrorCode.INVALID_TOKEN)
         } catch (e: IllegalArgumentException) {
-            logger.error { "JWT subject is not a valid UUID: ${e.javaClass.simpleName} - ${e.message}" }
+            logger.error { "JWT subject is not a valid UUID" }
             throw UserException(ErrorCode.INVALID_TOKEN)
         }
     }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/JwtTokenProvider.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/JwtTokenProvider.kt
@@ -91,10 +91,12 @@ class JwtTokenProvider(private val jwtProperties: JwtProperties) {
      */
     fun parseAccessTokenJti(token: String): String {
         return try {
-            Jwts.parser().verifyWith(secretKey).build()
+            val claims = Jwts.parser().verifyWith(secretKey).build()
                 .parseSignedClaims(token).payload
-                .id ?: throw UserException(ErrorCode.INVALID_TOKEN)
+            if (claims["type"] == "refresh") throw UserException(ErrorCode.INVALID_TOKEN)
+            claims.id ?: throw UserException(ErrorCode.INVALID_TOKEN)
         } catch (e: ExpiredJwtException) {
+            if (e.claims["type"] == "refresh") throw UserException(ErrorCode.INVALID_TOKEN)
             e.claims.id ?: throw UserException(ErrorCode.INVALID_TOKEN)
         } catch (e: UserException) {
             throw e

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/JwtTokenProvider.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/JwtTokenProvider.kt
@@ -102,7 +102,7 @@ class JwtTokenProvider(private val jwtProperties: JwtProperties) {
             logger.error { "JWT token invalid" }
             throw UserException(ErrorCode.INVALID_TOKEN)
         } catch (e: IllegalArgumentException) {
-            logger.error { "JWT subject is not a valid UUID" }
+            logger.error { "JWT token malformed" }
             throw UserException(ErrorCode.INVALID_TOKEN)
         }
     }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/TokenBlacklistService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/TokenBlacklistService.kt
@@ -1,0 +1,15 @@
+package com.ticketqueue.user.service
+
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Service
+import java.time.Duration
+
+@Service
+class TokenBlacklistService(private val stringRedisTemplate: StringRedisTemplate) {
+
+    fun addToBlacklist(jti: String, ttlMillis: Long) {
+        stringRedisTemplate.opsForValue().set(
+            "token:blacklist:$jti", "1", Duration.ofMillis(ttlMillis)
+        )
+    }
+}

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/AuthServiceTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/AuthServiceTest.kt
@@ -3,6 +3,7 @@ package com.ticketqueue.user.service
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.common.exception.ExternalSystemException
 import com.ticketqueue.common.external.portone.PortoneIdentityV2Response
+import com.ticketqueue.user.config.JwtProperties
 import com.ticketqueue.user.dto.AuthDto
 import com.ticketqueue.user.exception.UserException
 import io.kotest.matchers.shouldBe
@@ -25,6 +26,8 @@ class AuthServiceTest {
     private lateinit var authTransactionalService: AuthTransactionalService
     private lateinit var loginHistoryRecorder: LoginHistoryRecorder
     private lateinit var jwtTokenProvider: JwtTokenProvider
+    private lateinit var tokenBlacklistService: TokenBlacklistService
+    private lateinit var jwtProperties: JwtProperties
     private lateinit var authService: AuthService
 
     @BeforeEach
@@ -35,7 +38,9 @@ class AuthServiceTest {
         authTransactionalService = mockk()
         loginHistoryRecorder = mockk(relaxed = true)
         jwtTokenProvider = mockk()
-        authService = AuthService(recaptchaService, portoneService, authTransactionalService, loginHistoryRecorder, encryptionService, jwtTokenProvider)
+        tokenBlacklistService = mockk(relaxed = true)
+        jwtProperties = mockk()
+        authService = AuthService(recaptchaService, portoneService, authTransactionalService, loginHistoryRecorder, encryptionService, jwtTokenProvider, tokenBlacklistService, jwtProperties)
     }
 
     // ─── 공통 헬퍼 ────────────────────────────────────────────────────────────────

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/AuthServiceTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/AuthServiceTest.kt
@@ -12,6 +12,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.verifyOrder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -379,6 +380,75 @@ class AuthServiceTest {
             }
 
             exception.errorCode shouldBe ErrorCode.REVOKED_REFRESH_TOKEN
+        }
+    }
+
+    // ─── Logout 테스트 ────────────────────────────────────────────────────────────
+
+    @Nested
+    inner class LogoutTest {
+
+        private val jti = "test-jti-value"
+        private val accessToken = "valid.access.token"
+        private val validHeader = "Bearer $accessToken"
+
+        @Test
+        fun `정상 로그아웃 - DB revoke 먼저, Redis 블랙리스트 나중 순서 검증`() {
+            // given
+            every { jwtTokenProvider.parseAccessTokenJti(accessToken) } returns jti
+            every { authTransactionalService.processLogout(jti) } just Runs
+            every { jwtProperties.accessTokenExpiry } returns 3600000L
+            every { tokenBlacklistService.addToBlacklist(jti, 3600000L) } just Runs
+
+            // when
+            authService.logout(validHeader)
+
+            // then
+            verifyOrder {
+                authTransactionalService.processLogout(jti)
+                tokenBlacklistService.addToBlacklist(jti, 3600000L)
+            }
+        }
+
+        @Test
+        fun `Authorization 헤더 없음 - UNAUTHORIZED 예외, DB revoke 및 블랙리스트 미호출`() {
+            // when & then
+            val exception = assertThrows<UserException> {
+                authService.logout("")
+            }
+
+            exception.errorCode shouldBe ErrorCode.UNAUTHORIZED
+            verify(exactly = 0) { jwtTokenProvider.parseAccessTokenJti(any()) }
+            verify(exactly = 0) { authTransactionalService.processLogout(any()) }
+            verify(exactly = 0) { tokenBlacklistService.addToBlacklist(any(), any()) }
+        }
+
+        @Test
+        fun `Bearer 접두사 없음 - UNAUTHORIZED 예외, DB revoke 및 블랙리스트 미호출`() {
+            // when & then
+            val exception = assertThrows<UserException> {
+                authService.logout(accessToken)
+            }
+
+            exception.errorCode shouldBe ErrorCode.UNAUTHORIZED
+            verify(exactly = 0) { jwtTokenProvider.parseAccessTokenJti(any()) }
+            verify(exactly = 0) { authTransactionalService.processLogout(any()) }
+            verify(exactly = 0) { tokenBlacklistService.addToBlacklist(any(), any()) }
+        }
+
+        @Test
+        fun `유효하지 않은 토큰 - INVALID_TOKEN 전파, DB revoke 및 블랙리스트 미호출`() {
+            // given
+            every { jwtTokenProvider.parseAccessTokenJti(accessToken) } throws UserException(ErrorCode.INVALID_TOKEN)
+
+            // when & then
+            val exception = assertThrows<UserException> {
+                authService.logout(validHeader)
+            }
+
+            exception.errorCode shouldBe ErrorCode.INVALID_TOKEN
+            verify(exactly = 0) { authTransactionalService.processLogout(any()) }
+            verify(exactly = 0) { tokenBlacklistService.addToBlacklist(any(), any()) }
         }
     }
 }


### PR DESCRIPTION
## Summary
- `POST /auth/logout` 엔드포인트 구현 (REQ-AUTH-008, REQ-AUTH-010)
- Access Token jti를 Redis 블랙리스트에 등록하여 토큰 무효화
- 연결된 Refresh Token DB revoke 처리 (멱등성 보장)

## Changes
- `TokenBlacklistService` 신규 추가 — Redis `token:blacklist:{jti}` 등록 (TTL 1시간)
- `JwtTokenProvider.parseAccessTokenJti()` 추가 — 만료 토큰에서도 jti 추출 가능
- `RefreshTokenRepository.findByAccessTokenJti()` 쿼리 메서드 추가
- `AuthTransactionalService.processLogout()` 추가 — jti 기반 Refresh Token revoke
- `AuthService.logout()` 추가 — jti 추출 → Redis 블랙리스트 → DB revoke 오케스트레이션
- `AuthController` — `POST /auth/logout` 엔드포인트 (204 No Content)

Closes #25

## Test plan
- [x] `POST /auth/logout` 요청 시 204 No Content 반환
- [x] Redis `token:blacklist:{jti}` 키 등록 확인 (TTL 1시간)
- [x] DB `refresh_tokens.revoked = true` 확인
- [x] Authorization 헤더 누락 시 401 반환
- [x] 동일 토큰으로 재요청 시 멱등성 보장 (204 반환)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a logout endpoint (POST /auth/logout) that revokes refresh tokens and blacklists access tokens to prevent reuse.
* **Security**
  * Authorization rules updated to allow unauthenticated access to /actuator/health and /actuator/info.
* **Tests**
  * Expanded authentication tests to cover logout flows, token invalidation, error cases, and operation ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->