### PR TITLE
feat: [Monitoring] Prometheus + Grafana 모니터링 스택 도입

### DIFF
--- a/backend/api-gateway/build.gradle.kts
+++ b/backend/api-gateway/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
 
     // Actuator
     implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.micrometer.registry.prometheus)
 
     // Logging
     implementation(libs.kotlin.logging)

--- a/backend/api-gateway/src/main/resources/application.yml
+++ b/backend/api-gateway/src/main/resources/application.yml
@@ -167,7 +167,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,gateway
+        include: health,info,gateway,prometheus
   endpoint:
     health:
       show-details: when-authorized

--- a/backend/api-gateway/src/main/resources/application.yml
+++ b/backend/api-gateway/src/main/resources/application.yml
@@ -164,6 +164,8 @@ resilience4j:
         timeoutDuration: 60s     # Payment 60초
 
 management:
+  server:
+    port: 9080
   endpoints:
     web:
       exposure:

--- a/backend/api-gateway/src/main/resources/application.yml
+++ b/backend/api-gateway/src/main/resources/application.yml
@@ -175,3 +175,7 @@ management:
       show-details: when-authorized
     gateway:
       access: read_only
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true

--- a/backend/common-core/build.gradle.kts
+++ b/backend/common-core/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     api(libs.spring.boot.starter.web)
     api(libs.spring.boot.starter.validation)
     api(libs.spring.boot.starter.actuator)
+    api(libs.micrometer.registry.prometheus)
 
     // Spring Cloud
     api(platform(libs.spring.cloud.dependencies))

--- a/backend/event-service/src/main/resources/application.yml
+++ b/backend/event-service/src/main/resources/application.yml
@@ -41,10 +41,12 @@ internal:
     key: ${INTERNAL_API_KEY:internal-api-key-for-dev}
 
 management:
+  server:
+    port: 9082
   endpoints:
     web:
       exposure:
         include: health,info,prometheus
   endpoint:
     health:
-      show-details: always
+      show-details: when-authorized

--- a/backend/event-service/src/main/resources/application.yml
+++ b/backend/event-service/src/main/resources/application.yml
@@ -44,7 +44,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info
+        include: health,info,prometheus
   endpoint:
     health:
       show-details: always

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -109,6 +109,7 @@ kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.
 kotest-extensions-spring = { module = "io.kotest.extensions:kotest-extensions-spring", version = "1.3.0" }
 spring-security-test = { module = "org.springframework.security:spring-security-test" }
 reactor-test = { module = "io.projectreactor:reactor-test" }
+micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus" }
 
 [bundles]
 kotlin = ["kotlin-reflect", "kotlin-stdlib", "jackson-module-kotlin"]

--- a/backend/payment-service/src/main/resources/application.yml
+++ b/backend/payment-service/src/main/resources/application.yml
@@ -90,7 +90,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info, circuitbreakers
+        include: health,info,circuitbreakers,prometheus
   endpoint:
     health:
       show-details: always

--- a/backend/payment-service/src/main/resources/application.yml
+++ b/backend/payment-service/src/main/resources/application.yml
@@ -87,10 +87,12 @@ internal:
     key: ${INTERNAL_API_KEY:internal-api-key-for-dev}
 
 management:
+  server:
+    port: 9085
   endpoints:
     web:
       exposure:
         include: health,info,circuitbreakers,prometheus
   endpoint:
     health:
-      show-details: always
+      show-details: when-authorized

--- a/backend/queue-service/src/main/resources/application.yml
+++ b/backend/queue-service/src/main/resources/application.yml
@@ -23,7 +23,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info
+        include: health,info,prometheus
   endpoint:
     health:
       show-details: always

--- a/backend/queue-service/src/main/resources/application.yml
+++ b/backend/queue-service/src/main/resources/application.yml
@@ -20,10 +20,12 @@ queue:
     ttl: 600
 
 management:
+  server:
+    port: 9083
   endpoints:
     web:
       exposure:
         include: health,info,prometheus
   endpoint:
     health:
-      show-details: always
+      show-details: when-authorized

--- a/backend/reservation-service/src/main/resources/application.yml
+++ b/backend/reservation-service/src/main/resources/application.yml
@@ -84,10 +84,12 @@ internal:
     key: ${INTERNAL_API_KEY:internal-api-key-for-dev}
 
 management:
+  server:
+    port: 9084
   endpoints:
     web:
       exposure:
         include: health,info,prometheus
   endpoint:
     health:
-      show-details: always
+      show-details: when-authorized

--- a/backend/reservation-service/src/main/resources/application.yml
+++ b/backend/reservation-service/src/main/resources/application.yml
@@ -87,7 +87,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info
+        include: health,info,prometheus
   endpoint:
     health:
       show-details: always

--- a/backend/user-service/src/main/resources/application.yml
+++ b/backend/user-service/src/main/resources/application.yml
@@ -30,13 +30,15 @@ internal:
     key: ${internal_api_key}
 
 management:
+  server:
+    port: 9081
   endpoints:
     web:
       exposure:
         include: health,info,prometheus
   endpoint:
     health:
-      show-details: always
+      show-details: when-authorized
 
 recaptcha:
   url: https://www.google.com/recaptcha/api/siteverify

--- a/backend/user-service/src/main/resources/application.yml
+++ b/backend/user-service/src/main/resources/application.yml
@@ -33,7 +33,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info
+        include: health,info,prometheus
   endpoint:
     health:
       show-details: always

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -28,3 +28,11 @@ POSTGRES_USER=your_user_here
 # - portone_store_id.txt         (PortOne Store ID - Frontend/Backend 공유)
 # - portone_channel_key.txt      (PortOne Channel Key - Frontend/Backend 공유)
 # - recaptcha_secret.txt         (reCAPTCHA Secret Key - Backend 전용)
+#
+# [Grafana 모니터링]
+# - grafana_admin_pw.txt         (Grafana 관리자 비밀번호 — 공유/스테이징/운영 환경에서는 반드시 강력한 비밀번호로 변경)
+#
+# ===========================
+# Grafana 환경 변수
+# ===========================
+# GF_ADMIN_USER=admin            (Grafana 관리자 계정명, 기본값: admin)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -144,11 +144,55 @@ services:
       - enc_secret_key
       - enc_hash_salt
       
+  # Prometheus (메트릭 수집)
+  prometheus:
+    image: prom/prometheus:v3.2.1
+    container_name: ticket-prometheus
+    ports:
+      - "9090:9090"
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+      - '--storage.tsdb.retention.time=7d'
+    environment:
+      - TZ=Asia/Seoul
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - ticket-network
+
+  # Grafana (메트릭 시각화)
+  grafana:
+    image: grafana/grafana:11.4.0
+    container_name: ticket-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - TZ=Asia/Seoul
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus
+    networks:
+      - ticket-network
+
 volumes:
   postgres_data:
   valkey_data:
   kafka_data:
   localstack_data:
+  prometheus_data:
+  grafana_data:
 
 networks:
   ticket-network:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -174,8 +174,8 @@ services:
       - "3000:3000"
     environment:
       - TZ=Asia/Seoul
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_USER=${GF_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD__FILE=/run/secrets/grafana_admin_pw
       - GF_USERS_ALLOW_SIGN_UP=false
     volumes:
       - grafana_data:/var/lib/grafana
@@ -185,6 +185,8 @@ services:
       - prometheus
     networks:
       - ticket-network
+    secrets:
+      - grafana_admin_pw
 
 volumes:
   postgres_data:
@@ -227,3 +229,5 @@ secrets:
       file: ./secrets/enc_secret_key.txt
     enc_hash_salt:
       file: ./secrets/enc_hash_salt.txt
+    grafana_admin_pw:
+      file: ./secrets/grafana_admin_pw.txt

--- a/docker/grafana/dashboards/http-requests-overview.json
+++ b/docker/grafana/dashboards/http-requests-overview.json
@@ -1,0 +1,202 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (application) (rate(http_server_requests_seconds_count{application=~\"$service\"}[1m]))",
+          "legendFormat": "{{application}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Rate (QPS)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.50, sum by (application, le) (rate(http_server_requests_seconds_bucket{application=~\"$service\"}[1m])))",
+          "legendFormat": "{{application}} P50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum by (application, le) (rate(http_server_requests_seconds_bucket{application=~\"$service\"}[1m])))",
+          "legendFormat": "{{application}} P95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, sum by (application, le) (rate(http_server_requests_seconds_bucket{application=~\"$service\"}[1m])))",
+          "legendFormat": "{{application}} P99",
+          "refId": "C"
+        }
+      ],
+      "title": "HTTP Latency (P50 / P95 / P99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (application) (rate(http_server_requests_seconds_count{application=~\"$service\", status=~\"5..\"}[1m])) / sum by (application) (rate(http_server_requests_seconds_count{application=~\"$service\"}[1m]))",
+          "legendFormat": "{{application}} error rate",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP 5xx Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (application, status) (rate(http_server_requests_seconds_count{application=~\"$service\"}[1m]))",
+          "legendFormat": "{{application}} {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Requests by Status Code",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["http", "spring-boot", "ticket-queue"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(http_server_requests_seconds_count, application)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": false,
+        "name": "service",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_requests_seconds_count, application)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query",
+        "label": "Service"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "HTTP Requests Overview",
+  "uid": "http-requests-overview",
+  "version": 1
+}

--- a/docker/grafana/dashboards/infrastructure-overview.json
+++ b/docker/grafana/dashboards/infrastructure-overview.json
@@ -169,14 +169,14 @@
       {
         "current": { "selected": false, "text": "All", "value": "$__all" },
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "definition": "label_values(hikaricp_connections_active, application)",
+        "definition": "label_values({__name__=~\"hikaricp_connections_active|spring_kafka_consumer_fetch_manager_records_lag|spring_kafka_consumer_fetch_manager_records_consumed_total\"}, application)",
         "hide": 0,
         "includeAll": true,
         "multi": false,
         "name": "service",
         "options": [],
         "query": {
-          "query": "label_values(hikaricp_connections_active, application)",
+          "query": "label_values({__name__=~\"hikaricp_connections_active|spring_kafka_consumer_fetch_manager_records_lag|spring_kafka_consumer_fetch_manager_records_consumed_total\"}, application)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/docker/grafana/dashboards/infrastructure-overview.json
+++ b/docker/grafana/dashboards/infrastructure-overview.json
@@ -1,0 +1,196 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "hikaricp_connections_active{application=~\"$service\"}",
+          "legendFormat": "{{application}} active",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "hikaricp_connections_max{application=~\"$service\"}",
+          "legendFormat": "{{application}} max",
+          "refId": "B"
+        }
+      ],
+      "title": "HikariCP Connection Pool",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum by (application, le) (rate(hikaricp_connections_acquire_seconds_bucket{application=~\"$service\"}[1m])))",
+          "legendFormat": "{{application}} P95",
+          "refId": "A"
+        }
+      ],
+      "title": "HikariCP Connection Acquire Time P95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "spring_kafka_consumer_fetch_manager_records_lag{application=~\"$service\"}",
+          "legendFormat": "{{application}} {{topic}} {{partition}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Kafka Consumer Lag",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "recps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (application) (rate(spring_kafka_consumer_fetch_manager_records_consumed_total{application=~\"$service\"}[1m]))",
+          "legendFormat": "{{application}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Kafka Records Consumed Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["infrastructure", "hikari", "kafka", "ticket-queue"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(hikaricp_connections_active, application)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": false,
+        "name": "service",
+        "options": [],
+        "query": {
+          "query": "label_values(hikaricp_connections_active, application)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query",
+        "label": "Service"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Infrastructure Overview",
+  "uid": "infrastructure-overview",
+  "version": 1
+}

--- a/docker/grafana/dashboards/jvm-spring-boot-overview.json
+++ b/docker/grafana/dashboards/jvm-spring-boot-overview.json
@@ -1,0 +1,190 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "jvm_memory_used_bytes{application=~\"$service\", area=\"heap\"}",
+          "legendFormat": "{{application}} heap",
+          "refId": "A"
+        }
+      ],
+      "title": "JVM Heap Memory Used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "process_cpu_usage{application=~\"$service\"}",
+          "legendFormat": "{{application}}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(jvm_gc_pause_seconds_sum{application=~\"$service\"}[1m]) / rate(jvm_gc_pause_seconds_count{application=~\"$service\"}[1m])",
+          "legendFormat": "{{application}} {{action}}",
+          "refId": "A"
+        }
+      ],
+      "title": "GC Pause Duration (avg)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "jvm_threads_live_threads{application=~\"$service\"}",
+          "legendFormat": "{{application}} live",
+          "refId": "A"
+        }
+      ],
+      "title": "JVM Live Threads",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["jvm", "spring-boot", "ticket-queue"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(jvm_memory_used_bytes, application)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": false,
+        "name": "service",
+        "options": [],
+        "query": {
+          "query": "label_values(jvm_memory_used_bytes, application)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query",
+        "label": "Service"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "JVM & Spring Boot Overview",
+  "uid": "jvm-spring-boot-overview",
+  "version": 1
+}

--- a/docker/grafana/dashboards/resilience4j-circuit-breaker.json
+++ b/docker/grafana/dashboards/resilience4j-circuit-breaker.json
@@ -1,0 +1,161 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "CLOSED": { "color": "green", "index": 0, "text": "CLOSED" }, "HALF_OPEN": { "color": "yellow", "index": 1, "text": "HALF_OPEN" }, "OPEN": { "color": "red", "index": 2, "text": "OPEN" } }, "type": "value" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "text": {},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "resilience4j_circuitbreaker_state{application=~\"$service\"}",
+          "legendFormat": "{{application}} - {{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Circuit Breaker State",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "max": 100,
+          "min": 0,
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "resilience4j_circuitbreaker_failure_rate{application=~\"$service\"}",
+          "legendFormat": "{{application}} - {{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Circuit Breaker Failure Rate (%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (application, name, kind) (rate(resilience4j_circuitbreaker_calls_seconds_count{application=~\"$service\"}[1m]))",
+          "legendFormat": "{{application}} {{name}} {{kind}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Circuit Breaker Call Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["resilience4j", "circuit-breaker", "ticket-queue"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(resilience4j_circuitbreaker_state, application)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": false,
+        "name": "service",
+        "options": [],
+        "query": {
+          "query": "label_values(resilience4j_circuitbreaker_state, application)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query",
+        "label": "Service"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Resilience4j Circuit Breaker",
+  "uid": "resilience4j-circuit-breaker",
+  "version": 1
+}

--- a/docker/grafana/dashboards/resilience4j-circuit-breaker.json
+++ b/docker/grafana/dashboards/resilience4j-circuit-breaker.json
@@ -23,9 +23,7 @@
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "mappings": [
-            { "options": { "CLOSED": { "color": "green", "index": 0, "text": "CLOSED" }, "HALF_OPEN": { "color": "yellow", "index": 1, "text": "HALF_OPEN" }, "OPEN": { "color": "red", "index": 2, "text": "OPEN" } }, "type": "value" }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [{ "color": "green", "value": null }]
@@ -42,13 +40,13 @@
         "orientation": "auto",
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "text": {},
-        "textMode": "auto"
+        "textMode": "name"
       },
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "resilience4j_circuitbreaker_state{application=~\"$service\"}",
-          "legendFormat": "{{application}} - {{name}}",
+          "expr": "resilience4j_circuitbreaker_state{application=~\"$service\"} == 1",
+          "legendFormat": "{{application}} - {{name}} ({{state}})",
           "refId": "A"
         }
       ],

--- a/docker/grafana/provisioning/dashboards/dashboards.yml
+++ b/docker/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: Ticket Queue Dashboards
+    orgId: 1
+    folder: Ticket Queue
+    folderUid: ticket-queue
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://ticket-prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: 15s
+      httpMethod: POST

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,52 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'api-gateway'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+    relabel_configs:
+      - target_label: application
+        replacement: api-gateway
+
+  - job_name: 'user-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8081']
+    relabel_configs:
+      - target_label: application
+        replacement: user-service
+
+  - job_name: 'event-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8082']
+    relabel_configs:
+      - target_label: application
+        replacement: event-service
+
+  - job_name: 'queue-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8083']
+    relabel_configs:
+      - target_label: application
+        replacement: queue-service
+
+  - job_name: 'reservation-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8084']
+    relabel_configs:
+      - target_label: application
+        replacement: reservation-service
+
+  - job_name: 'payment-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8085']
+    relabel_configs:
+      - target_label: application
+        replacement: payment-service

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -6,7 +6,7 @@ scrape_configs:
   - job_name: 'api-gateway'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['host.docker.internal:8080']
+      - targets: ['host.docker.internal:9080']
     relabel_configs:
       - target_label: application
         replacement: api-gateway
@@ -14,7 +14,7 @@ scrape_configs:
   - job_name: 'user-service'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['host.docker.internal:8081']
+      - targets: ['host.docker.internal:9081']
     relabel_configs:
       - target_label: application
         replacement: user-service
@@ -22,7 +22,7 @@ scrape_configs:
   - job_name: 'event-service'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['host.docker.internal:8082']
+      - targets: ['host.docker.internal:9082']
     relabel_configs:
       - target_label: application
         replacement: event-service
@@ -30,7 +30,7 @@ scrape_configs:
   - job_name: 'queue-service'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['host.docker.internal:8083']
+      - targets: ['host.docker.internal:9083']
     relabel_configs:
       - target_label: application
         replacement: queue-service
@@ -38,7 +38,7 @@ scrape_configs:
   - job_name: 'reservation-service'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['host.docker.internal:8084']
+      - targets: ['host.docker.internal:9084']
     relabel_configs:
       - target_label: application
         replacement: reservation-service
@@ -46,7 +46,7 @@ scrape_configs:
   - job_name: 'payment-service'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['host.docker.internal:8085']
+      - targets: ['host.docker.internal:9085']
     relabel_configs:
       - target_label: application
         replacement: payment-service

--- a/docs/architecture/07_operations.md
+++ b/docs/architecture/07_operations.md
@@ -15,7 +15,57 @@
 - **Consumer Lag:** 메시지 처리 지연이 발생하고 있는지 시각적으로 확인.
 - **Message Flow:** Producer에서 Consumer로 데이터가 흐르는 과정을 데모 시연.
 
-### 1.2 시스템 리소스 모니터링
+### 1.2 애플리케이션 메트릭 모니터링 (Prometheus + Grafana)
+
+**도구:** `prom/prometheus:v3.2.1` + `grafana/grafana:11.4.0`
+**목적:** 6개 마이크로서비스의 QPS, 레이턴시(P50/P95/P99), 에러율, JVM 상태 실시간 관측
+
+**접근 URL:**
+- Prometheus: `http://localhost:9090` (메트릭 쿼리 및 타겟 상태 확인)
+- Grafana: `http://localhost:3000` (admin / admin)
+
+**메트릭 수집 방식:**
+- 각 서비스 `/actuator/prometheus` 엔드포인트에서 15초 간격 스크래핑
+- Micrometer Prometheus Registry를 통해 JVM, HTTP, DB, Kafka 메트릭 자동 노출
+- `host.docker.internal`을 통해 컨테이너 → 호스트 서비스 접근
+
+**자동 프로비저닝 대시보드 (4개):**
+
+| 대시보드 | 주요 메트릭 | 폴더 |
+|---------|-----------|------|
+| JVM & Spring Boot Overview | 힙 메모리, GC 일시정지, CPU, 스레드 수 | Ticket Queue |
+| HTTP Requests Overview | QPS, P50/P95/P99 레이턴시, 5xx 에러율, 상태코드별 분포 | Ticket Queue |
+| Resilience4j Circuit Breaker | CB 상태(CLOSED/OPEN/HALF_OPEN), 실패율, 호출 수 | Ticket Queue |
+| Infrastructure Overview | HikariCP 커넥션 풀, Kafka Consumer Lag, 처리량 | Ticket Queue |
+
+**서비스별 포트 매핑 (Prometheus 스크래핑 대상):**
+
+| 서비스 | 포트 | 메트릭 경로 |
+|--------|------|-----------|
+| api-gateway | 8080 | `/actuator/prometheus` |
+| user-service | 8081 | `/actuator/prometheus` |
+| event-service | 8082 | `/actuator/prometheus` |
+| queue-service | 8083 | `/actuator/prometheus` |
+| reservation-service | 8084 | `/actuator/prometheus` |
+| payment-service | 8085 | `/actuator/prometheus` |
+
+**실행 방법:**
+```bash
+# Prometheus + Grafana 시작
+docker-compose up -d prometheus grafana
+
+# 타겟 상태 확인 (서비스 기동 후)
+open http://localhost:9090/targets
+
+# Grafana 대시보드 확인
+open http://localhost:3000
+```
+
+**관련 요구사항:** REQ-GW-012 (라우트별 요청 수, 응답 시간, 에러율 메트릭)
+
+---
+
+### 1.3 시스템 리소스 모니터링
 
 **도구:** `ctop` 또는 `docker stats`
 **목적:** 컨테이너별 CPU/Memory 사용량 실시간 확인
@@ -25,7 +75,7 @@
 docker stats --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"
 ```
 
-### 1.3 애플리케이션 로그
+### 1.4 애플리케이션 로그
 
 **도구:** `docker-compose logs`
 **전략:** 중앙화된 로깅 시스템(ELK) 구축 대신, 컨테이너 로그를 직접 확인하거나 파일로 저장하여 분석.

--- a/docs/architecture/07_operations.md
+++ b/docs/architecture/07_operations.md
@@ -22,7 +22,9 @@
 
 **접근 URL:**
 - Prometheus: `http://localhost:9090` (메트릭 쿼리 및 타겟 상태 확인)
-- Grafana: `http://localhost:3000` (admin / admin)
+- Grafana: `http://localhost:3000` (로컬 전용 기본값: admin / admin — 공유/스테이징/운영 환경에서는 반드시 변경)
+  - 비밀번호 변경: Grafana UI → Server Admin → Users → admin → Change Password
+  - 또는 `docker/secrets/grafana_admin_pw.txt` 파일에 강력한 비밀번호 설정 후 컨테이너 재시작
 
 **메트릭 수집 방식:**
 - 각 서비스 `/actuator/prometheus` 엔드포인트에서 15초 간격 스크래핑
@@ -40,25 +42,28 @@
 
 **서비스별 포트 매핑 (Prometheus 스크래핑 대상):**
 
-| 서비스 | 포트 | 메트릭 경로 |
-|--------|------|-----------|
-| api-gateway | 8080 | `/actuator/prometheus` |
-| user-service | 8081 | `/actuator/prometheus` |
-| event-service | 8082 | `/actuator/prometheus` |
-| queue-service | 8083 | `/actuator/prometheus` |
-| reservation-service | 8084 | `/actuator/prometheus` |
-| payment-service | 8085 | `/actuator/prometheus` |
+| 서비스 | 서비스 포트 | Management 포트 | 메트릭 경로 |
+|--------|-----------|----------------|-----------|
+| api-gateway | 8080 | 9080 | `/actuator/prometheus` |
+| user-service | 8081 | 9081 | `/actuator/prometheus` |
+| event-service | 8082 | 9082 | `/actuator/prometheus` |
+| queue-service | 8083 | 9083 | `/actuator/prometheus` |
+| reservation-service | 8084 | 9084 | `/actuator/prometheus` |
+| payment-service | 8085 | 9085 | `/actuator/prometheus` |
+
+> **보안 참고:** Actuator 엔드포인트는 management 전용 포트(908X)에서만 노출됩니다. 서비스 메인 포트(808X)로는 `/actuator/**` 접근이 불가합니다.
 
 **실행 방법:**
+
 ```bash
 # Prometheus + Grafana 시작
 docker-compose up -d prometheus grafana
 
 # 타겟 상태 확인 (서비스 기동 후)
-open http://localhost:9090/targets
+echo "브라우저에서 접속: http://localhost:9090/targets"
 
 # Grafana 대시보드 확인
-open http://localhost:3000
+echo "브라우저에서 접속: http://localhost:3000"
 ```
 
 **관련 요구사항:** REQ-GW-012 (라우트별 요청 수, 응답 시간, 에러율 메트릭)


### PR DESCRIPTION
## Summary

- Prometheus + Grafana 기반 모니터링 스택을 도입하여 6개 마이크로서비스의 QPS, 레이턴시(P50/P95/P99), 에러율, JVM 상태를 실시간 관측 가능하게 함
- `docker-compose up -d` 한 번으로 Prometheus 수집 + Grafana 대시보드 4개가 자동 구성됨
- REQ-GW-012 (라우트별 요청 수, 응답 시간, 에러율 메트릭) 요구사항 구현

## Changes

- `backend/gradle/libs.versions.toml` — `micrometer-registry-prometheus` 라이브러리 추가 (Spring Boot BOM 버전 관리)
- `backend/common-core/build.gradle.kts` — `api(libs.micrometer.registry.prometheus)` 추가 (5개 MVC 서비스 자동 전파)
- `backend/api-gateway/build.gradle.kts` — `implementation(libs.micrometer.registry.prometheus)` 추가 (WebFlux 독립 선언)
- 6개 서비스 `application.yml` — `management.endpoints` include에 `prometheus` 추가
- `docker/prometheus/prometheus.yml` — 6개 서비스 스크래핑 설정, `relabel_configs`로 `application` 레이블 주입
- `docker/grafana/provisioning/datasources/prometheus.yml` — Prometheus 데이터소스 자동 설정
- `docker/grafana/provisioning/dashboards/dashboards.yml` — 대시보드 프로비저닝 설정
- `docker/grafana/dashboards/jvm-spring-boot-overview.json` — JVM 힙 메모리, CPU, GC, 스레드
- `docker/grafana/dashboards/http-requests-overview.json` — QPS, P50/P95/P99, 5xx 에러율, 상태코드별 분포
- `docker/grafana/dashboards/resilience4j-circuit-breaker.json` — CB 상태, 실패율, 호출 수
- `docker/grafana/dashboards/infrastructure-overview.json` — HikariCP 커넥션 풀, Kafka Consumer Lag
- `docker/docker-compose.yml` — `ticket-prometheus`(9090) + `ticket-grafana`(3000) 서비스 및 볼륨 추가
- `docs/architecture/07_operations.md` — 1.2 애플리케이션 메트릭 모니터링 섹션 신규 추가

## Test plan

- [ ] `docker-compose up -d prometheus grafana` 실행 후 `http://localhost:9090/targets` 에서 6개 타겟 확인
- [ ] 서비스 기동 후 각 타겟 상태 UP 확인
- [ ] `http://localhost:3000` (admin/admin) 접속 → "Ticket Queue" 폴더에 대시보드 4개 확인
- [ ] Prometheus 데이터소스 Test 성공 확인
- [ ] 서비스 기동 상태에서 대시보드 데이터 렌더링 확인
- [ ] `./gradlew build -x test` 빌드 성공 확인

Closes #171
Closes #172
Closes #173
Closes #174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full monitoring stack: Prometheus + Grafana with pre-provisioned dashboards (HTTP, Infrastructure, JVM/Spring Boot, Circuit Breaker) and a Prometheus datasource.

* **Chores**
  * Exposed Prometheus metrics and enabled dedicated management ports for backend services.
  * Added Docker Compose services and persistent volumes for Prometheus and Grafana.

* **Documentation**
  * Updated operations guide and example env with monitoring setup and access instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->