### PR TITLE
test: [Event] Security/RBAC 테스트 커버리지 강화

### DIFF
--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
@@ -1,10 +1,10 @@
 package com.ticketqueue.event.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ninjasquad.springmockk.MockkBean
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.common.exception.GlobalExceptionHandler
+import com.ticketqueue.event.config.SecurityConfig
 import com.ticketqueue.event.dto.EventDto
 import com.ticketqueue.event.dto.SeatDto
 import com.ticketqueue.event.entity.EventStatus
@@ -13,16 +13,25 @@ import com.ticketqueue.event.entity.SeatStatus
 import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.service.EventService
 import com.ticketqueue.event.service.SeatService
+import io.awspring.cloud.autoconfigure.config.parameterstore.ParameterStoreAutoConfiguration
+import io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerAutoConfiguration
 import io.mockk.every
-import io.mockk.mockk
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.MediaType
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -30,19 +39,48 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.util.UUID
 
+@WebMvcTest(
+    controllers = [EventController::class],
+    useDefaultFilters = false,
+    includeFilters = [
+        ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = [EventController::class, GlobalExceptionHandler::class, SecurityConfig::class]
+        )
+    ],
+    excludeAutoConfiguration = [
+        DataSourceAutoConfiguration::class,
+        HibernateJpaAutoConfiguration::class,
+        RedisAutoConfiguration::class,
+        SecretsManagerAutoConfiguration::class,
+        ParameterStoreAutoConfiguration::class
+    ]
+)
+@ContextConfiguration(classes = [EventController::class, GlobalExceptionHandler::class, SecurityConfig::class])
+@ActiveProfiles("test")
+@TestPropertySource(properties = [
+    "spring.cloud.aws.region.static=us-east-1",
+    "spring.cloud.aws.credentials.access-key=test",
+    "spring.cloud.aws.credentials.secret-key=test"
+])
+@DisplayName("EventController 단위 테스트")
 class EventControllerTest {
 
+    @Autowired
     private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockkBean
     private lateinit var eventService: EventService
+
+    @MockkBean
     private lateinit var seatService: SeatService
-    private val objectMapper: ObjectMapper = jacksonObjectMapper().apply {
-        registerModule(JavaTimeModule())
-    }
 
     private val eventId = UUID.randomUUID()
     private val now = LocalDateTime.now()
@@ -106,17 +144,6 @@ class EventControllerTest {
         )
     )
 
-    @BeforeEach
-    fun setUp() {
-        eventService = mockk()
-        seatService = mockk()
-        val controller = EventController(eventService, seatService)
-        mockMvc = MockMvcBuilders.standaloneSetup(controller)
-            .setControllerAdvice(GlobalExceptionHandler())
-            .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
-            .build()
-    }
-
     @Nested
     @DisplayName("POST /events")
     inner class CreateEvent {
@@ -128,6 +155,8 @@ class EventControllerTest {
 
             mockMvc.perform(
                 post("/events")
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(validCreateRequest()))
             )
@@ -144,6 +173,8 @@ class EventControllerTest {
 
             mockMvc.perform(
                 post("/events")
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(invalidRequest))
             )
@@ -218,6 +249,8 @@ class EventControllerTest {
 
             mockMvc.perform(
                 patch("/events/{eventId}", eventId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(EventDto.UpdateRequest(title = "BTS World Tour 2026")))
             )
@@ -232,6 +265,8 @@ class EventControllerTest {
 
             mockMvc.perform(
                 patch("/events/{eventId}", eventId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(EventDto.UpdateRequest(artist = "변경된 아티스트")))
             )
@@ -245,6 +280,8 @@ class EventControllerTest {
 
             mockMvc.perform(
                 patch("/events/{eventId}", eventId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(EventDto.UpdateRequest(title = "새 제목")))
             )
@@ -256,6 +293,8 @@ class EventControllerTest {
         fun titleEmpty() {
             mockMvc.perform(
                 patch("/events/{eventId}", eventId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(EventDto.UpdateRequest(title = "")))
             )
@@ -269,6 +308,8 @@ class EventControllerTest {
 
             mockMvc.perform(
                 patch("/events/{eventId}", eventId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("{}")
             )
@@ -285,7 +326,11 @@ class EventControllerTest {
         fun success() {
             every { eventService.deleteEvent(eventId) } returns EventDto.DeleteResponse("공연이 삭제되었습니다.")
 
-            mockMvc.perform(delete("/events/{eventId}", eventId))
+            mockMvc.perform(
+                delete("/events/{eventId}", eventId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
+            )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.message").value("공연이 삭제되었습니다."))
         }
@@ -295,7 +340,11 @@ class EventControllerTest {
         fun conflict() {
             every { eventService.deleteEvent(eventId) } throws EventException(ErrorCode.EVENT_HAS_RESERVATIONS)
 
-            mockMvc.perform(delete("/events/{eventId}", eventId))
+            mockMvc.perform(
+                delete("/events/{eventId}", eventId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
+            )
                 .andExpect(status().isConflict)
         }
 
@@ -304,7 +353,11 @@ class EventControllerTest {
         fun notFound() {
             every { eventService.deleteEvent(eventId) } throws EventException(ErrorCode.EVENT_NOT_FOUND)
 
-            mockMvc.perform(delete("/events/{eventId}", eventId))
+            mockMvc.perform(
+                delete("/events/{eventId}", eventId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
+            )
                 .andExpect(status().isNotFound)
         }
     }
@@ -351,6 +404,92 @@ class EventControllerTest {
 
             mockMvc.perform(get("/events/schedules/{scheduleId}/seats", scheduleId))
                 .andExpect(status().isNotFound)
+        }
+    }
+
+    @Nested
+    @DisplayName("Security")
+    inner class Security {
+
+        @Nested
+        @DisplayName("인증 없이 요청 시 401")
+        inner class Unauthenticated {
+
+            @Test
+            @DisplayName("POST /events → 401")
+            fun `post events without auth returns 401`() {
+                mockMvc.perform(
+                    post("/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isUnauthorized)
+                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            }
+
+            @Test
+            @DisplayName("PATCH /events/{id} → 401")
+            fun `patch event without auth returns 401`() {
+                mockMvc.perform(
+                    patch("/events/{eventId}", eventId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isUnauthorized)
+                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            }
+
+            @Test
+            @DisplayName("DELETE /events/{id} → 401")
+            fun `delete event without auth returns 401`() {
+                mockMvc.perform(delete("/events/{eventId}", eventId))
+                    .andExpect(status().isUnauthorized)
+                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            }
+        }
+
+        @Nested
+        @DisplayName("ROLE_USER 요청 시 403")
+        inner class Forbidden {
+
+            @Test
+            @DisplayName("POST /events with ROLE_USER → 403")
+            fun `post events with user role returns 403`() {
+                mockMvc.perform(
+                    post("/events")
+                        .header("X-User-Id", UUID.randomUUID().toString())
+                        .header("X-User-Role", "USER")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isForbidden)
+                    .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+            }
+        }
+
+        @Nested
+        @DisplayName("인증 없이 공개 엔드포인트 200")
+        inner class PublicAccess {
+
+            @Test
+            @DisplayName("GET /events → 200")
+            fun `get events without auth returns 200`() {
+                val pageable = PageRequest.of(0, 20)
+                val page = PageImpl(listOf(listResponse()), pageable, 1)
+                every { eventService.getEvents(0, 20, null, null, null) } returns page
+
+                mockMvc.perform(get("/events"))
+                    .andExpect(status().isOk)
+            }
+
+            @Test
+            @DisplayName("GET /events/{id} → 200")
+            fun `get event without auth returns 200`() {
+                every { eventService.getEvent(eventId) } returns detailResponse()
+
+                mockMvc.perform(get("/events/{eventId}", eventId))
+                    .andExpect(status().isOk)
+            }
         }
     }
 }

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
@@ -15,8 +15,10 @@ import com.ticketqueue.event.service.EventService
 import com.ticketqueue.event.service.SeatService
 import io.awspring.cloud.autoconfigure.config.parameterstore.ParameterStoreAutoConfiguration
 import io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerAutoConfiguration
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import org.junit.jupiter.api.DisplayName
+import org.springframework.http.HttpStatus
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -417,34 +419,34 @@ class EventControllerTest {
 
             @Test
             @DisplayName("POST /events → 401")
-            fun `post events without auth returns 401`() {
-                mockMvc.perform(
+            fun postEvents_shouldReturn401_whenNoAuth() {
+                val response = mockMvc.perform(
                     post("/events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}")
-                )
-                    .andExpect(status().isUnauthorized)
-                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                ).andReturn().response
+                response.status.shouldBe(HttpStatus.UNAUTHORIZED.value())
+                objectMapper.readTree(response.contentAsString)["code"].asText().shouldBe("UNAUTHORIZED")
             }
 
             @Test
             @DisplayName("PATCH /events/{id} → 401")
-            fun `patch event without auth returns 401`() {
-                mockMvc.perform(
+            fun patchEvent_shouldReturn401_whenNoAuth() {
+                val response = mockMvc.perform(
                     patch("/events/{eventId}", eventId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}")
-                )
-                    .andExpect(status().isUnauthorized)
-                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                ).andReturn().response
+                response.status.shouldBe(HttpStatus.UNAUTHORIZED.value())
+                objectMapper.readTree(response.contentAsString)["code"].asText().shouldBe("UNAUTHORIZED")
             }
 
             @Test
             @DisplayName("DELETE /events/{id} → 401")
-            fun `delete event without auth returns 401`() {
-                mockMvc.perform(delete("/events/{eventId}", eventId))
-                    .andExpect(status().isUnauthorized)
-                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            fun deleteEvent_shouldReturn401_whenNoAuth() {
+                val response = mockMvc.perform(delete("/events/{eventId}", eventId)).andReturn().response
+                response.status.shouldBe(HttpStatus.UNAUTHORIZED.value())
+                objectMapper.readTree(response.contentAsString)["code"].asText().shouldBe("UNAUTHORIZED")
             }
         }
 

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
@@ -456,7 +456,7 @@ class EventControllerTest {
 
             @Test
             @DisplayName("POST /events with ROLE_USER → 403")
-            fun `post events with user role returns 403`() {
+            fun postEvents_shouldReturnForbidden_whenUserRole() {
                 mockMvc.perform(
                     post("/events")
                         .header("X-User-Id", UUID.randomUUID().toString())
@@ -470,7 +470,7 @@ class EventControllerTest {
 
             @Test
             @DisplayName("PATCH /events/{id} with ROLE_USER → 403")
-            fun `patch event with user role returns 403`() {
+            fun patchEvent_shouldReturnForbidden_whenUserRole() {
                 mockMvc.perform(
                     patch("/events/{eventId}", eventId)
                         .header("X-User-Id", UUID.randomUUID().toString())
@@ -484,7 +484,7 @@ class EventControllerTest {
 
             @Test
             @DisplayName("DELETE /events/{id} with ROLE_USER → 403")
-            fun `delete event with user role returns 403`() {
+            fun deleteEvent_shouldReturnForbidden_whenUserRole() {
                 mockMvc.perform(
                     delete("/events/{eventId}", eventId)
                         .header("X-User-Id", UUID.randomUUID().toString())
@@ -501,7 +501,7 @@ class EventControllerTest {
 
             @Test
             @DisplayName("GET /events → 200")
-            fun `get events without auth returns 200`() {
+            fun getEvents_shouldReturnOk_whenNoAuth() {
                 val pageable = PageRequest.of(0, 20)
                 val page = PageImpl(listOf(listResponse()), pageable, 1)
                 every { eventService.getEvents(0, 20, null, null, null) } returns page
@@ -512,7 +512,7 @@ class EventControllerTest {
 
             @Test
             @DisplayName("GET /events/{id} → 200")
-            fun `get event without auth returns 200`() {
+            fun getEvent_shouldReturnOk_whenNoAuth() {
                 every { eventService.getEvent(eventId) } returns detailResponse()
 
                 mockMvc.perform(get("/events/{eventId}", eventId))

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
@@ -465,6 +465,32 @@ class EventControllerTest {
                     .andExpect(status().isForbidden)
                     .andExpect(jsonPath("$.code").value("FORBIDDEN"))
             }
+
+            @Test
+            @DisplayName("PATCH /events/{id} with ROLE_USER → 403")
+            fun `patch event with user role returns 403`() {
+                mockMvc.perform(
+                    patch("/events/{eventId}", eventId)
+                        .header("X-User-Id", UUID.randomUUID().toString())
+                        .header("X-User-Role", "USER")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isForbidden)
+                    .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+            }
+
+            @Test
+            @DisplayName("DELETE /events/{id} with ROLE_USER → 403")
+            fun `delete event with user role returns 403`() {
+                mockMvc.perform(
+                    delete("/events/{eventId}", eventId)
+                        .header("X-User-Id", UUID.randomUUID().toString())
+                        .header("X-User-Role", "USER")
+                )
+                    .andExpect(status().isForbidden)
+                    .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+            }
         }
 
         @Nested

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/HallControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/HallControllerTest.kt
@@ -370,6 +370,32 @@ class HallControllerTest {
                     .andExpect(status().isForbidden)
                     .andExpect(jsonPath("$.code").value("FORBIDDEN"))
             }
+
+            @Test
+            @DisplayName("PATCH /venues/{id}/halls/{id} with ROLE_USER → 403")
+            fun `patch hall with user role returns 403`() {
+                mockMvc.perform(
+                    patch("/venues/{venueId}/halls/{hallId}", venueId, hallId)
+                        .header("X-User-Id", UUID.randomUUID().toString())
+                        .header("X-User-Role", "USER")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isForbidden)
+                    .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+            }
+
+            @Test
+            @DisplayName("DELETE /venues/{id}/halls/{id} with ROLE_USER → 403")
+            fun `delete hall with user role returns 403`() {
+                mockMvc.perform(
+                    delete("/venues/{venueId}/halls/{hallId}", venueId, hallId)
+                        .header("X-User-Id", UUID.randomUUID().toString())
+                        .header("X-User-Role", "USER")
+                )
+                    .andExpect(status().isForbidden)
+                    .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+            }
         }
 
         @Nested

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/HallControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/HallControllerTest.kt
@@ -1,22 +1,31 @@
 package com.ticketqueue.event.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ninjasquad.springmockk.MockkBean
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.common.exception.GlobalExceptionHandler
+import com.ticketqueue.event.config.SecurityConfig
 import com.ticketqueue.event.dto.HallDto
 import com.ticketqueue.event.dto.SeatTemplateDto
 import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.service.HallService
+import io.awspring.cloud.autoconfigure.config.parameterstore.ParameterStoreAutoConfiguration
+import io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerAutoConfiguration
 import io.mockk.every
-import io.mockk.mockk
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
 import org.springframework.http.MediaType
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -24,17 +33,44 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import java.time.LocalDateTime
 import java.util.UUID
 
+@WebMvcTest(
+    controllers = [HallController::class],
+    useDefaultFilters = false,
+    includeFilters = [
+        ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = [HallController::class, GlobalExceptionHandler::class, SecurityConfig::class]
+        )
+    ],
+    excludeAutoConfiguration = [
+        DataSourceAutoConfiguration::class,
+        HibernateJpaAutoConfiguration::class,
+        RedisAutoConfiguration::class,
+        SecretsManagerAutoConfiguration::class,
+        ParameterStoreAutoConfiguration::class
+    ]
+)
+@ContextConfiguration(classes = [HallController::class, GlobalExceptionHandler::class, SecurityConfig::class])
+@ActiveProfiles("test")
+@TestPropertySource(properties = [
+    "spring.cloud.aws.region.static=us-east-1",
+    "spring.cloud.aws.credentials.access-key=test",
+    "spring.cloud.aws.credentials.secret-key=test"
+])
+@DisplayName("HallController 단위 테스트")
 class HallControllerTest {
 
+    @Autowired
     private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockkBean
     private lateinit var hallService: HallService
-    private val objectMapper: ObjectMapper = jacksonObjectMapper().apply {
-        registerModule(JavaTimeModule())
-    }
 
     private val venueId = UUID.randomUUID()
     private val hallId = UUID.randomUUID()
@@ -54,16 +90,6 @@ class HallControllerTest {
         createdAt = now
     )
 
-    @BeforeEach
-    fun setUp() {
-        hallService = mockk()
-        val controller = HallController(hallService)
-        mockMvc = MockMvcBuilders.standaloneSetup(controller)
-            .setControllerAdvice(GlobalExceptionHandler())
-            .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
-            .build()
-    }
-
     @Nested
     @DisplayName("POST /venues/{venueId}/halls")
     inner class CreateHall {
@@ -80,6 +106,8 @@ class HallControllerTest {
             )
             mockMvc.perform(
                 post("/venues/{venueId}/halls", venueId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -98,6 +126,8 @@ class HallControllerTest {
 
             mockMvc.perform(
                 post("/venues/{venueId}/halls", venueId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -115,6 +145,8 @@ class HallControllerTest {
 
             mockMvc.perform(
                 post("/venues/{venueId}/halls", venueId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -134,6 +166,8 @@ class HallControllerTest {
             )
             mockMvc.perform(
                 post("/venues/{venueId}/halls", venueId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -217,6 +251,8 @@ class HallControllerTest {
             val request = HallDto.UpdateRequest(name = "올림픽홀")
             mockMvc.perform(
                 patch("/venues/{venueId}/halls/{hallId}", venueId, hallId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -233,6 +269,8 @@ class HallControllerTest {
             val request = HallDto.UpdateRequest(name = "올림픽홀")
             mockMvc.perform(
                 patch("/venues/{venueId}/halls/{hallId}", venueId, hallId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -250,7 +288,11 @@ class HallControllerTest {
             every { hallService.deleteHall(venueId, hallId) } returns
                 HallDto.DeleteResponse("홀이 삭제되었습니다.")
 
-            mockMvc.perform(delete("/venues/{venueId}/halls/{hallId}", venueId, hallId))
+            mockMvc.perform(
+                delete("/venues/{venueId}/halls/{hallId}", venueId, hallId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
+            )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.message").value("홀이 삭제되었습니다."))
         }
@@ -261,8 +303,105 @@ class HallControllerTest {
             every { hallService.deleteHall(venueId, hallId) } throws
                 EventException(ErrorCode.HALL_HAS_EVENTS)
 
-            mockMvc.perform(delete("/venues/{venueId}/halls/{hallId}", venueId, hallId))
+            mockMvc.perform(
+                delete("/venues/{venueId}/halls/{hallId}", venueId, hallId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
+            )
                 .andExpect(status().isConflict)
+        }
+    }
+
+    @Nested
+    @DisplayName("Security")
+    inner class Security {
+
+        @Nested
+        @DisplayName("인증 없이 요청 시 401")
+        inner class Unauthenticated {
+
+            @Test
+            @DisplayName("POST /venues/{id}/halls → 401")
+            fun `post halls without auth returns 401`() {
+                mockMvc.perform(
+                    post("/venues/{venueId}/halls", venueId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isUnauthorized)
+                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            }
+
+            @Test
+            @DisplayName("PATCH /venues/{id}/halls/{id} → 401")
+            fun `patch hall without auth returns 401`() {
+                mockMvc.perform(
+                    patch("/venues/{venueId}/halls/{hallId}", venueId, hallId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isUnauthorized)
+                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            }
+
+            @Test
+            @DisplayName("DELETE /venues/{id}/halls/{id} → 401")
+            fun `delete hall without auth returns 401`() {
+                mockMvc.perform(delete("/venues/{venueId}/halls/{hallId}", venueId, hallId))
+                    .andExpect(status().isUnauthorized)
+                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            }
+        }
+
+        @Nested
+        @DisplayName("ROLE_USER 요청 시 403")
+        inner class Forbidden {
+
+            @Test
+            @DisplayName("POST /venues/{id}/halls with ROLE_USER → 403")
+            fun `post halls with user role returns 403`() {
+                mockMvc.perform(
+                    post("/venues/{venueId}/halls", venueId)
+                        .header("X-User-Id", UUID.randomUUID().toString())
+                        .header("X-User-Role", "USER")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isForbidden)
+                    .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+            }
+        }
+
+        @Nested
+        @DisplayName("인증 없이 공개 엔드포인트 200")
+        inner class PublicAccess {
+
+            @Test
+            @DisplayName("GET /venues/{id}/halls → 200")
+            fun `get halls without auth returns 200`() {
+                every { hallService.getHalls(venueId) } returns listOf(hallResponse())
+
+                mockMvc.perform(get("/venues/{venueId}/halls", venueId))
+                    .andExpect(status().isOk)
+            }
+
+            @Test
+            @DisplayName("GET /venues/{id}/halls/{id} → 200")
+            fun `get hall without auth returns 200`() {
+                val detail = HallDto.DetailResponse(
+                    id = hallId,
+                    venueId = venueId,
+                    name = "KSPO DOME",
+                    capacity = 15000,
+                    seatTemplate = seatTemplateDto,
+                    createdAt = now,
+                    updatedAt = now
+                )
+                every { hallService.getHall(venueId, hallId) } returns detail
+
+                mockMvc.perform(get("/venues/{venueId}/halls/{hallId}", venueId, hallId))
+                    .andExpect(status().isOk)
+            }
         }
     }
 }

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/HallControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/HallControllerTest.kt
@@ -11,8 +11,10 @@ import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.service.HallService
 import io.awspring.cloud.autoconfigure.config.parameterstore.ParameterStoreAutoConfiguration
 import io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerAutoConfiguration
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import org.junit.jupiter.api.DisplayName
+import org.springframework.http.HttpStatus
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -322,34 +324,34 @@ class HallControllerTest {
 
             @Test
             @DisplayName("POST /venues/{id}/halls → 401")
-            fun `post halls without auth returns 401`() {
-                mockMvc.perform(
+            fun postHall_shouldReturnUnauthorized_whenNoAuth() {
+                val response = mockMvc.perform(
                     post("/venues/{venueId}/halls", venueId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}")
-                )
-                    .andExpect(status().isUnauthorized)
-                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                ).andReturn().response
+                response.status.shouldBe(HttpStatus.UNAUTHORIZED.value())
+                objectMapper.readTree(response.contentAsString)["code"].asText().shouldBe("UNAUTHORIZED")
             }
 
             @Test
             @DisplayName("PATCH /venues/{id}/halls/{id} → 401")
-            fun `patch hall without auth returns 401`() {
-                mockMvc.perform(
+            fun patchHall_shouldReturnUnauthorized_whenNoAuth() {
+                val response = mockMvc.perform(
                     patch("/venues/{venueId}/halls/{hallId}", venueId, hallId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}")
-                )
-                    .andExpect(status().isUnauthorized)
-                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                ).andReturn().response
+                response.status.shouldBe(HttpStatus.UNAUTHORIZED.value())
+                objectMapper.readTree(response.contentAsString)["code"].asText().shouldBe("UNAUTHORIZED")
             }
 
             @Test
             @DisplayName("DELETE /venues/{id}/halls/{id} → 401")
-            fun `delete hall without auth returns 401`() {
-                mockMvc.perform(delete("/venues/{venueId}/halls/{hallId}", venueId, hallId))
-                    .andExpect(status().isUnauthorized)
-                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            fun deleteHall_shouldReturnUnauthorized_whenNoAuth() {
+                val response = mockMvc.perform(delete("/venues/{venueId}/halls/{hallId}", venueId, hallId)).andReturn().response
+                response.status.shouldBe(HttpStatus.UNAUTHORIZED.value())
+                objectMapper.readTree(response.contentAsString)["code"].asText().shouldBe("UNAUTHORIZED")
             }
         }
 

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/ScheduleControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/ScheduleControllerTest.kt
@@ -414,6 +414,20 @@ class ScheduleControllerTest {
                     .andExpect(status().isForbidden)
                     .andExpect(jsonPath("$.code").value("FORBIDDEN"))
             }
+
+            @Test
+            @DisplayName("PATCH /events/schedules/{id}/status with ROLE_USER → 403")
+            fun `patch schedule status with user role returns 403`() {
+                mockMvc.perform(
+                    patch("/events/schedules/{scheduleId}/status", scheduleId)
+                        .header("X-User-Id", UUID.randomUUID().toString())
+                        .header("X-User-Role", "USER")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isForbidden)
+                    .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+            }
         }
 
         @Nested

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/ScheduleControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/ScheduleControllerTest.kt
@@ -405,7 +405,7 @@ class ScheduleControllerTest {
 
             @Test
             @DisplayName("POST /events/{id}/schedules with ROLE_USER → 403")
-            fun `post schedules with user role returns 403`() {
+            fun postSchedule_shouldReturnForbidden_whenUserRole() {
                 mockMvc.perform(
                     post("/events/{eventId}/schedules", eventId)
                         .header("X-User-Id", UUID.randomUUID().toString())
@@ -419,7 +419,7 @@ class ScheduleControllerTest {
 
             @Test
             @DisplayName("PATCH /events/schedules/{id}/status with ROLE_USER → 403")
-            fun `patch schedule status with user role returns 403`() {
+            fun patchScheduleStatus_shouldReturnForbidden_whenUserRole() {
                 mockMvc.perform(
                     patch("/events/schedules/{scheduleId}/status", scheduleId)
                         .header("X-User-Id", UUID.randomUUID().toString())
@@ -438,7 +438,7 @@ class ScheduleControllerTest {
 
             @Test
             @DisplayName("GET /events/{id}/schedules → 200")
-            fun `get schedules without auth returns 200`() {
+            fun getSchedules_shouldReturnOk_whenNoAuth() {
                 every { scheduleService.getSchedules(eventId) } returns listOf(listResponse())
 
                 mockMvc.perform(get("/events/{eventId}/schedules", eventId))
@@ -447,7 +447,7 @@ class ScheduleControllerTest {
 
             @Test
             @DisplayName("GET /events/schedules/{id} → 200")
-            fun `get schedule without auth returns 200`() {
+            fun getSchedule_shouldReturnOk_whenNoAuth() {
                 every { scheduleService.getSchedule(scheduleId) } returns detailResponse()
 
                 mockMvc.perform(get("/events/schedules/{scheduleId}", scheduleId))

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/ScheduleControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/ScheduleControllerTest.kt
@@ -12,8 +12,10 @@ import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.service.ScheduleService
 import io.awspring.cloud.autoconfigure.config.parameterstore.ParameterStoreAutoConfiguration
 import io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerAutoConfiguration
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import org.junit.jupiter.api.DisplayName
+import org.springframework.http.HttpStatus
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -374,26 +376,26 @@ class ScheduleControllerTest {
 
             @Test
             @DisplayName("POST /events/{id}/schedules → 401")
-            fun `post schedules without auth returns 401`() {
-                mockMvc.perform(
+            fun postSchedule_shouldReturn401_whenUnauthenticated() {
+                val response = mockMvc.perform(
                     post("/events/{eventId}/schedules", eventId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}")
-                )
-                    .andExpect(status().isUnauthorized)
-                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                ).andReturn().response
+                response.status.shouldBe(HttpStatus.UNAUTHORIZED.value())
+                objectMapper.readTree(response.contentAsString)["code"].asText().shouldBe("UNAUTHORIZED")
             }
 
             @Test
             @DisplayName("PATCH /events/schedules/{id}/status → 401")
-            fun `patch schedule status without auth returns 401`() {
-                mockMvc.perform(
+            fun patchScheduleStatus_shouldReturn401_whenUnauthenticated() {
+                val response = mockMvc.perform(
                     patch("/events/schedules/{scheduleId}/status", scheduleId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}")
-                )
-                    .andExpect(status().isUnauthorized)
-                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                ).andReturn().response
+                response.status.shouldBe(HttpStatus.UNAUTHORIZED.value())
+                objectMapper.readTree(response.contentAsString)["code"].asText().shouldBe("UNAUTHORIZED")
             }
         }
 

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/ScheduleControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/ScheduleControllerTest.kt
@@ -1,41 +1,77 @@
 package com.ticketqueue.event.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ninjasquad.springmockk.MockkBean
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.common.exception.GlobalExceptionHandler
+import com.ticketqueue.event.config.SecurityConfig
 import com.ticketqueue.event.dto.ScheduleDto
 import com.ticketqueue.event.entity.ScheduleStatus
 import com.ticketqueue.event.entity.SeatGrade
 import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.service.ScheduleService
+import io.awspring.cloud.autoconfigure.config.parameterstore.ParameterStoreAutoConfiguration
+import io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerAutoConfiguration
 import io.mockk.every
-import io.mockk.mockk
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
 import org.springframework.http.MediaType
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.util.UUID
 
+@WebMvcTest(
+    controllers = [ScheduleController::class],
+    useDefaultFilters = false,
+    includeFilters = [
+        ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = [ScheduleController::class, GlobalExceptionHandler::class, SecurityConfig::class]
+        )
+    ],
+    excludeAutoConfiguration = [
+        DataSourceAutoConfiguration::class,
+        HibernateJpaAutoConfiguration::class,
+        RedisAutoConfiguration::class,
+        SecretsManagerAutoConfiguration::class,
+        ParameterStoreAutoConfiguration::class
+    ]
+)
+@ContextConfiguration(classes = [ScheduleController::class, GlobalExceptionHandler::class, SecurityConfig::class])
+@ActiveProfiles("test")
+@TestPropertySource(properties = [
+    "spring.cloud.aws.region.static=us-east-1",
+    "spring.cloud.aws.credentials.access-key=test",
+    "spring.cloud.aws.credentials.secret-key=test"
+])
+@DisplayName("ScheduleController 단위 테스트")
 class ScheduleControllerTest {
 
+    @Autowired
     private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockkBean
     private lateinit var scheduleService: ScheduleService
-    private val objectMapper: ObjectMapper = jacksonObjectMapper().apply {
-        registerModule(JavaTimeModule())
-    }
 
     private val eventId = UUID.randomUUID()
     private val scheduleId = UUID.randomUUID()
@@ -95,16 +131,6 @@ class ScheduleControllerTest {
         priceByGrade = mapOf(SeatGrade.VIP to BigDecimal("100000"))
     )
 
-    @BeforeEach
-    fun setUp() {
-        scheduleService = mockk()
-        val controller = ScheduleController(scheduleService)
-        mockMvc = MockMvcBuilders.standaloneSetup(controller)
-            .setControllerAdvice(GlobalExceptionHandler())
-            .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
-            .build()
-    }
-
     @Nested
     @DisplayName("POST /events/{eventId}/schedules")
     inner class CreateSchedule {
@@ -116,6 +142,8 @@ class ScheduleControllerTest {
 
             mockMvc.perform(
                 post("/events/{eventId}/schedules", eventId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(validCreateRequest()))
             )
@@ -135,6 +163,8 @@ class ScheduleControllerTest {
 
             mockMvc.perform(
                 post("/events/{eventId}/schedules", eventId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(invalidRequest))
             )
@@ -151,6 +181,8 @@ class ScheduleControllerTest {
 
             mockMvc.perform(
                 post("/events/{eventId}/schedules", eventId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(invalidRequest))
             )
@@ -164,6 +196,8 @@ class ScheduleControllerTest {
 
             mockMvc.perform(
                 post("/events/{eventId}/schedules", eventId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(validCreateRequest()))
             )
@@ -177,6 +211,8 @@ class ScheduleControllerTest {
 
             mockMvc.perform(
                 post("/events/{eventId}/schedules", eventId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(validCreateRequest()))
             )
@@ -190,6 +226,8 @@ class ScheduleControllerTest {
 
             mockMvc.perform(
                 post("/events/{eventId}/schedules", eventId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(validCreateRequest()))
             )
@@ -271,6 +309,8 @@ class ScheduleControllerTest {
 
             mockMvc.perform(
                 patch("/events/schedules/{scheduleId}/status", scheduleId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(ScheduleDto.ChangeStatusRequest(ScheduleStatus.ONGOING)))
             )
@@ -284,6 +324,8 @@ class ScheduleControllerTest {
         fun badRequestMissingStatus() {
             mockMvc.perform(
                 patch("/events/schedules/{scheduleId}/status", scheduleId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("{}")
             )
@@ -297,6 +339,8 @@ class ScheduleControllerTest {
 
             mockMvc.perform(
                 patch("/events/schedules/{scheduleId}/status", scheduleId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(ScheduleDto.ChangeStatusRequest(ScheduleStatus.UPCOMING)))
             )
@@ -311,10 +355,88 @@ class ScheduleControllerTest {
 
             mockMvc.perform(
                 patch("/events/schedules/{scheduleId}/status", scheduleId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(ScheduleDto.ChangeStatusRequest(ScheduleStatus.ONGOING)))
             )
                 .andExpect(status().isNotFound)
+        }
+    }
+
+    @Nested
+    @DisplayName("Security")
+    inner class Security {
+
+        @Nested
+        @DisplayName("인증 없이 요청 시 401")
+        inner class Unauthenticated {
+
+            @Test
+            @DisplayName("POST /events/{id}/schedules → 401")
+            fun `post schedules without auth returns 401`() {
+                mockMvc.perform(
+                    post("/events/{eventId}/schedules", eventId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isUnauthorized)
+                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            }
+
+            @Test
+            @DisplayName("PATCH /events/schedules/{id}/status → 401")
+            fun `patch schedule status without auth returns 401`() {
+                mockMvc.perform(
+                    patch("/events/schedules/{scheduleId}/status", scheduleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isUnauthorized)
+                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            }
+        }
+
+        @Nested
+        @DisplayName("ROLE_USER 요청 시 403")
+        inner class Forbidden {
+
+            @Test
+            @DisplayName("POST /events/{id}/schedules with ROLE_USER → 403")
+            fun `post schedules with user role returns 403`() {
+                mockMvc.perform(
+                    post("/events/{eventId}/schedules", eventId)
+                        .header("X-User-Id", UUID.randomUUID().toString())
+                        .header("X-User-Role", "USER")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isForbidden)
+                    .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+            }
+        }
+
+        @Nested
+        @DisplayName("인증 없이 공개 엔드포인트 200")
+        inner class PublicAccess {
+
+            @Test
+            @DisplayName("GET /events/{id}/schedules → 200")
+            fun `get schedules without auth returns 200`() {
+                every { scheduleService.getSchedules(eventId) } returns listOf(listResponse())
+
+                mockMvc.perform(get("/events/{eventId}/schedules", eventId))
+                    .andExpect(status().isOk)
+            }
+
+            @Test
+            @DisplayName("GET /events/schedules/{id} → 200")
+            fun `get schedule without auth returns 200`() {
+                every { scheduleService.getSchedule(scheduleId) } returns detailResponse()
+
+                mockMvc.perform(get("/events/schedules/{scheduleId}", scheduleId))
+                    .andExpect(status().isOk)
+            }
         }
     }
 }

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/VenueControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/VenueControllerTest.kt
@@ -328,7 +328,7 @@ class VenueControllerTest {
 
             @Test
             @DisplayName("POST /venues with ROLE_USER → 403")
-            fun `post venues with user role returns 403`() {
+            fun postVenues_shouldReturnForbidden_whenUserRole() {
                 mockMvc.perform(
                     post("/venues")
                         .header("X-User-Id", UUID.randomUUID().toString())
@@ -342,7 +342,7 @@ class VenueControllerTest {
 
             @Test
             @DisplayName("PATCH /venues/{id} with ROLE_USER → 403")
-            fun `patch venue with user role returns 403`() {
+            fun patchVenue_shouldReturnForbidden_whenUserRole() {
                 mockMvc.perform(
                     patch("/venues/{venueId}", venueId)
                         .header("X-User-Id", UUID.randomUUID().toString())
@@ -356,7 +356,7 @@ class VenueControllerTest {
 
             @Test
             @DisplayName("DELETE /venues/{id} with ROLE_USER → 403")
-            fun `delete venue with user role returns 403`() {
+            fun deleteVenue_shouldReturnForbidden_whenUserRole() {
                 mockMvc.perform(
                     delete("/venues/{venueId}", venueId)
                         .header("X-User-Id", UUID.randomUUID().toString())
@@ -373,7 +373,7 @@ class VenueControllerTest {
 
             @Test
             @DisplayName("GET /venues → 200")
-            fun `get venues without auth returns 200`() {
+            fun getVenues_shouldReturnOk_whenNoAuth() {
                 val pageable = PageRequest.of(0, 20)
                 val page = PageImpl(listOf(venueResponse()), pageable, 1)
                 every { venueService.getVenues(0, 20, null) } returns page
@@ -384,7 +384,7 @@ class VenueControllerTest {
 
             @Test
             @DisplayName("GET /venues/{id} → 200")
-            fun `get venue without auth returns 200`() {
+            fun getVenue_shouldReturnOk_whenNoAuth() {
                 val detail = VenueDto.DetailResponse(
                     id = venueId,
                     name = "올림픽공원",

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/VenueControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/VenueControllerTest.kt
@@ -10,8 +10,10 @@ import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.service.VenueService
 import io.awspring.cloud.autoconfigure.config.parameterstore.ParameterStoreAutoConfiguration
 import io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerAutoConfiguration
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import org.junit.jupiter.api.DisplayName
+import org.springframework.http.HttpStatus
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -289,34 +291,34 @@ class VenueControllerTest {
 
             @Test
             @DisplayName("POST /venues → 401")
-            fun `post venues without auth returns 401`() {
-                mockMvc.perform(
+            fun postVenue_shouldReturnUnauthorized_whenNoAuth() {
+                val response = mockMvc.perform(
                     post("/venues")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}")
-                )
-                    .andExpect(status().isUnauthorized)
-                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                ).andReturn().response
+                response.status.shouldBe(HttpStatus.UNAUTHORIZED.value())
+                objectMapper.readTree(response.contentAsString)["code"].asText().shouldBe("UNAUTHORIZED")
             }
 
             @Test
             @DisplayName("PATCH /venues/{id} → 401")
-            fun `patch venue without auth returns 401`() {
-                mockMvc.perform(
+            fun patchVenue_shouldReturnUnauthorized_whenNoAuth() {
+                val response = mockMvc.perform(
                     patch("/venues/{venueId}", venueId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}")
-                )
-                    .andExpect(status().isUnauthorized)
-                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                ).andReturn().response
+                response.status.shouldBe(HttpStatus.UNAUTHORIZED.value())
+                objectMapper.readTree(response.contentAsString)["code"].asText().shouldBe("UNAUTHORIZED")
             }
 
             @Test
             @DisplayName("DELETE /venues/{id} → 401")
-            fun `delete venue without auth returns 401`() {
-                mockMvc.perform(delete("/venues/{venueId}", venueId))
-                    .andExpect(status().isUnauthorized)
-                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            fun deleteVenue_shouldReturnUnauthorized_whenNoAuth() {
+                val response = mockMvc.perform(delete("/venues/{venueId}", venueId)).andReturn().response
+                response.status.shouldBe(HttpStatus.UNAUTHORIZED.value())
+                objectMapper.readTree(response.contentAsString)["code"].asText().shouldBe("UNAUTHORIZED")
             }
         }
 

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/VenueControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/VenueControllerTest.kt
@@ -1,23 +1,32 @@
 package com.ticketqueue.event.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ninjasquad.springmockk.MockkBean
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.common.exception.GlobalExceptionHandler
+import com.ticketqueue.event.config.SecurityConfig
 import com.ticketqueue.event.dto.VenueDto
 import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.service.VenueService
+import io.awspring.cloud.autoconfigure.config.parameterstore.ParameterStoreAutoConfiguration
+import io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerAutoConfiguration
 import io.mockk.every
-import io.mockk.mockk
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.MediaType
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -25,17 +34,44 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import java.time.LocalDateTime
 import java.util.UUID
 
+@WebMvcTest(
+    controllers = [VenueController::class],
+    useDefaultFilters = false,
+    includeFilters = [
+        ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = [VenueController::class, GlobalExceptionHandler::class, SecurityConfig::class]
+        )
+    ],
+    excludeAutoConfiguration = [
+        DataSourceAutoConfiguration::class,
+        HibernateJpaAutoConfiguration::class,
+        RedisAutoConfiguration::class,
+        SecretsManagerAutoConfiguration::class,
+        ParameterStoreAutoConfiguration::class
+    ]
+)
+@ContextConfiguration(classes = [VenueController::class, GlobalExceptionHandler::class, SecurityConfig::class])
+@ActiveProfiles("test")
+@TestPropertySource(properties = [
+    "spring.cloud.aws.region.static=us-east-1",
+    "spring.cloud.aws.credentials.access-key=test",
+    "spring.cloud.aws.credentials.secret-key=test"
+])
+@DisplayName("VenueController 단위 테스트")
 class VenueControllerTest {
 
+    @Autowired
     private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockkBean
     private lateinit var venueService: VenueService
-    private val objectMapper: ObjectMapper = jacksonObjectMapper().apply {
-        registerModule(JavaTimeModule())
-    }
 
     private val venueId = UUID.randomUUID()
     private val now = LocalDateTime.now()
@@ -47,16 +83,6 @@ class VenueControllerTest {
         city = "서울",
         createdAt = now
     )
-
-    @BeforeEach
-    fun setUp() {
-        venueService = mockk()
-        val controller = VenueController(venueService)
-        mockMvc = MockMvcBuilders.standaloneSetup(controller)
-            .setControllerAdvice(GlobalExceptionHandler())
-            .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
-            .build()
-    }
 
     @Nested
     @DisplayName("POST /venues")
@@ -74,6 +100,8 @@ class VenueControllerTest {
 
             mockMvc.perform(
                 post("/venues")
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -88,6 +116,8 @@ class VenueControllerTest {
 
             mockMvc.perform(
                 post("/venues")
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -178,6 +208,8 @@ class VenueControllerTest {
             val request = VenueDto.UpdateRequest(name = "고척스카이돔")
             mockMvc.perform(
                 patch("/venues/{venueId}", venueId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -193,6 +225,8 @@ class VenueControllerTest {
             val request = VenueDto.UpdateRequest(name = "고척스카이돔")
             mockMvc.perform(
                 patch("/venues/{venueId}", venueId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
             )
@@ -209,7 +243,11 @@ class VenueControllerTest {
         fun success() {
             every { venueService.deleteVenue(venueId) } returns VenueDto.DeleteResponse("공연장이 삭제되었습니다.")
 
-            mockMvc.perform(delete("/venues/{venueId}", venueId))
+            mockMvc.perform(
+                delete("/venues/{venueId}", venueId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
+            )
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.message").value("공연장이 삭제되었습니다."))
         }
@@ -219,7 +257,11 @@ class VenueControllerTest {
         fun conflict() {
             every { venueService.deleteVenue(venueId) } throws EventException(ErrorCode.VENUE_HAS_EVENTS)
 
-            mockMvc.perform(delete("/venues/{venueId}", venueId))
+            mockMvc.perform(
+                delete("/venues/{venueId}", venueId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
+            )
                 .andExpect(status().isConflict)
         }
 
@@ -228,8 +270,107 @@ class VenueControllerTest {
         fun conflictHalls() {
             every { venueService.deleteVenue(venueId) } throws EventException(ErrorCode.VENUE_HAS_HALLS)
 
-            mockMvc.perform(delete("/venues/{venueId}", venueId))
+            mockMvc.perform(
+                delete("/venues/{venueId}", venueId)
+                    .header("X-User-Id", UUID.randomUUID().toString())
+                    .header("X-User-Role", "ADMIN")
+            )
                 .andExpect(status().isConflict)
+        }
+    }
+
+    @Nested
+    @DisplayName("Security")
+    inner class Security {
+
+        @Nested
+        @DisplayName("인증 없이 요청 시 401")
+        inner class Unauthenticated {
+
+            @Test
+            @DisplayName("POST /venues → 401")
+            fun `post venues without auth returns 401`() {
+                mockMvc.perform(
+                    post("/venues")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isUnauthorized)
+                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            }
+
+            @Test
+            @DisplayName("PATCH /venues/{id} → 401")
+            fun `patch venue without auth returns 401`() {
+                mockMvc.perform(
+                    patch("/venues/{venueId}", venueId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isUnauthorized)
+                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            }
+
+            @Test
+            @DisplayName("DELETE /venues/{id} → 401")
+            fun `delete venue without auth returns 401`() {
+                mockMvc.perform(delete("/venues/{venueId}", venueId))
+                    .andExpect(status().isUnauthorized)
+                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            }
+        }
+
+        @Nested
+        @DisplayName("ROLE_USER 요청 시 403")
+        inner class Forbidden {
+
+            @Test
+            @DisplayName("POST /venues with ROLE_USER → 403")
+            fun `post venues with user role returns 403`() {
+                mockMvc.perform(
+                    post("/venues")
+                        .header("X-User-Id", UUID.randomUUID().toString())
+                        .header("X-User-Role", "USER")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isForbidden)
+                    .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+            }
+        }
+
+        @Nested
+        @DisplayName("인증 없이 공개 엔드포인트 200")
+        inner class PublicAccess {
+
+            @Test
+            @DisplayName("GET /venues → 200")
+            fun `get venues without auth returns 200`() {
+                val pageable = PageRequest.of(0, 20)
+                val page = PageImpl(listOf(venueResponse()), pageable, 1)
+                every { venueService.getVenues(0, 20, null) } returns page
+
+                mockMvc.perform(get("/venues"))
+                    .andExpect(status().isOk)
+            }
+
+            @Test
+            @DisplayName("GET /venues/{id} → 200")
+            fun `get venue without auth returns 200`() {
+                val detail = VenueDto.DetailResponse(
+                    id = venueId,
+                    name = "올림픽공원",
+                    address = "서울시 송파구",
+                    city = "서울",
+                    halls = emptyList(),
+                    createdAt = now,
+                    updatedAt = now
+                )
+                every { venueService.getVenue(venueId) } returns detail
+
+                mockMvc.perform(get("/venues/{venueId}", venueId))
+                    .andExpect(status().isOk)
+            }
         }
     }
 }

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/VenueControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/VenueControllerTest.kt
@@ -337,6 +337,32 @@ class VenueControllerTest {
                     .andExpect(status().isForbidden)
                     .andExpect(jsonPath("$.code").value("FORBIDDEN"))
             }
+
+            @Test
+            @DisplayName("PATCH /venues/{id} with ROLE_USER → 403")
+            fun `patch venue with user role returns 403`() {
+                mockMvc.perform(
+                    patch("/venues/{venueId}", venueId)
+                        .header("X-User-Id", UUID.randomUUID().toString())
+                        .header("X-User-Role", "USER")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                )
+                    .andExpect(status().isForbidden)
+                    .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+            }
+
+            @Test
+            @DisplayName("DELETE /venues/{id} with ROLE_USER → 403")
+            fun `delete venue with user role returns 403`() {
+                mockMvc.perform(
+                    delete("/venues/{venueId}", venueId)
+                        .header("X-User-Id", UUID.randomUUID().toString())
+                        .header("X-User-Role", "USER")
+                )
+                    .andExpect(status().isForbidden)
+                    .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+            }
         }
 
         @Nested


### PR DESCRIPTION
## Summary
- `standaloneSetup` → `@WebMvcTest` 전환으로 `SecurityConfig` + `GatewayAuthFilter` 필터 체인을 테스트에 적용
- ADMIN 전용 엔드포인트(POST/PATCH/DELETE) 기존 테스트에 `X-User-Id`, `X-User-Role: ADMIN` 헤더 추가
- 컨트롤러 4개에 Security `@Nested` 클래스 신규 추가 — 401(인증 없음), 403(ROLE_USER), 200(공개 GET) 검증

Closes #154

## Changes
- `EventControllerTest`: `@WebMvcTest` 전환 + Security @Nested (401x3, 403x1, 200x2)
- `VenueControllerTest`: `@WebMvcTest` 전환 + Security @Nested (401x3, 403x1, 200x2)
- `HallControllerTest`: `@WebMvcTest` 전환 + Security @Nested (401x3, 403x1, 200x2)
- `ScheduleControllerTest`: `@WebMvcTest` 전환 + Security @Nested (401x2, 403x1, 200x2)

## Test plan
- [x] `./gradlew :event-service:test` 전체 통과 확인 (BUILD SUCCESSFUL)
- [x] 기존 테스트 전부 ADMIN 헤더 추가 후 동일 동작 유지
- [x] 신규 Security 테스트 — 401/403/200 응답 코드 및 `$.code` 필드 검증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reworked controller tests to use framework-driven Web MVC slices with autowired test utilities and mock beans; removed manual setup.
  * Added test profile and test property configuration for isolated runs and excluded heavy infra auto-configurations.
  * Expanded security coverage (unauthenticated 401, forbidden 403, role-based checks, public access) and added authenticated-header scenarios for admin flows.
  * Broadened HTTP-status and error-case assertions and extended coverage across event, hall, schedule, and venue endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->