### PR TITLE
feat: [Reservation] Reservation Entity 및 Repository 생성

### DIFF
--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/entity/Reservation.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/entity/Reservation.kt
@@ -1,0 +1,74 @@
+package com.ticketqueue.reservation.entity
+
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class ReservationStatus {
+    PENDING, CONFIRMED, CANCELLED
+}
+
+@Entity
+@Table(
+    name = "reservations",
+    schema = "reservation_service"
+)
+class Reservation(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: UUID,
+
+    @Column(name = "schedule_id", nullable = false)
+    val scheduleId: UUID,
+
+    @Column(name = "event_id", nullable = false)
+    val eventId: UUID,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    var status: ReservationStatus = ReservationStatus.PENDING,
+
+    @Column(name = "total_amount", nullable = false, precision = 10, scale = 0)
+    val totalAmount: BigDecimal,
+
+    @Column(name = "hold_expires_at", nullable = false)
+    val holdExpiresAt: LocalDateTime,
+
+    @Column(name = "ticket_number", length = 50)
+    var ticketNumber: String? = null,
+
+    @Column(name = "payment_id")
+    var paymentId: UUID? = null,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime? = null,
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime? = null
+) {
+    fun confirm(paymentId: UUID, ticketNumber: String) {
+        this.status = ReservationStatus.CONFIRMED
+        this.paymentId = paymentId
+        this.ticketNumber = ticketNumber
+    }
+
+    fun cancel() {
+        this.status = ReservationStatus.CANCELLED
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Reservation) return false
+        return id != null && id == other.id
+    }
+
+    override fun hashCode(): Int = id?.hashCode() ?: 0
+}

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/entity/ReservationSeat.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/entity/ReservationSeat.kt
@@ -1,0 +1,45 @@
+package com.ticketqueue.reservation.entity
+
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(
+    name = "reservation_seats",
+    schema = "reservation_service"
+)
+class ReservationSeat(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @Column(name = "reservation_id", nullable = false)
+    val reservationId: UUID,
+
+    @Column(name = "seat_id", nullable = false)
+    val seatId: UUID,
+
+    @Column(name = "seat_number", nullable = false, length = 20)
+    val seatNumber: String,
+
+    @Column(name = "grade", nullable = false, length = 10)
+    val grade: String,
+
+    @Column(name = "price", nullable = false, precision = 10, scale = 0)
+    val price: BigDecimal,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime? = null
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ReservationSeat) return false
+        return id != null && id == other.id
+    }
+
+    override fun hashCode(): Int = id?.hashCode() ?: 0
+}

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/repository/ReservationRepository.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/repository/ReservationRepository.kt
@@ -1,0 +1,14 @@
+package com.ticketqueue.reservation.repository
+
+import com.ticketqueue.reservation.entity.Reservation
+import com.ticketqueue.reservation.entity.ReservationStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
+import java.util.UUID
+
+interface ReservationRepository : JpaRepository<Reservation, UUID> {
+    fun findByUserIdOrderByCreatedAtDesc(userId: UUID): List<Reservation>
+    fun findByIdAndUserId(id: UUID, userId: UUID): Reservation?
+    fun existsByUserIdAndScheduleIdAndStatusIn(userId: UUID, scheduleId: UUID, statuses: List<ReservationStatus>): Boolean
+    fun findAllByStatusAndHoldExpiresAtBefore(status: ReservationStatus, now: LocalDateTime): List<Reservation>
+}

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/repository/ReservationSeatRepository.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/repository/ReservationSeatRepository.kt
@@ -1,0 +1,9 @@
+package com.ticketqueue.reservation.repository
+
+import com.ticketqueue.reservation.entity.ReservationSeat
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface ReservationSeatRepository : JpaRepository<ReservationSeat, UUID> {
+    fun findByReservationId(reservationId: UUID): List<ReservationSeat>
+}


### PR DESCRIPTION
## Summary
- `Reservation`, `ReservationSeat` JPA Entity 구현
- `ReservationRepository`, `ReservationSeatRepository` 구현

## Changes
- `Reservation` Entity: 예매 상태(PENDING/CONFIRMED/CANCELLED), 좌석 선점 만료 시각(`holdExpiresAt`), userId/scheduleId 등 핵심 필드 포함
- `ReservationSeat` Entity: 예매-좌석 연관 엔티티, 다대일 관계로 `Reservation`에 연결
- `ReservationRepository`: JPA Repository 인터페이스
- `ReservationSeatRepository`: JPA Repository 인터페이스

## Test plan
- [x] 해당 없음 (Entity/Repository 구현 단계, 이후 서비스 레이어 테스트에서 검증 예정)

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added backend infrastructure supporting reservation management with status tracking and seat allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->