### PR TITLE
feat: [Queue] 대기열 이탈 API 구현 (#43)

### DIFF
--- a/backend/queue-service/build.gradle.kts
+++ b/backend/queue-service/build.gradle.kts
@@ -17,4 +17,7 @@ dependencies {
     // Test
     testImplementation(libs.bundles.test.base)
     testImplementation(libs.spring.security.test)
+    testImplementation(platform(libs.testcontainers.bom))
+    testImplementation(libs.testcontainers.junit.jupiter)
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
 }

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/QueueRedisKeys.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/QueueRedisKeys.kt
@@ -16,4 +16,5 @@ object QueueRedisKeys {
     fun userToken(userId: Any, scheduleId: Any): String = "queue:user-token:$userId:$scheduleId"
     fun active(userId: Any): String = "queue:active:$userId"
     fun rateLimit(userId: Any): String = "rate:queue-status:$userId"
+    fun token(token: Any): String = "queue:token:$token"
 }

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/RedisConfig.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/RedisConfig.kt
@@ -87,6 +87,27 @@ class RedisConfig {
     }
 
     /**
+     * 대기열 이탈 Lua 스크립트 (REQ-QUEUE-003)
+     *
+     * WAITING/ACTIVE 상태를 모두 처리하며, 관련 Redis 키를 원자적으로 삭제한다.
+     *
+     * KEYS[1]: queue:{scheduleId}
+     * KEYS[2]: queue:active:{userId}
+     * KEYS[3]: queue:user-token:{userId}:{scheduleId}
+     * ARGV[1]: userId, ARGV[2]: scheduleId
+     * @return [resultCode]
+     *   {0} — NOT_IN_QUEUE (대기열에 없거나 다른 회차 대기 중)
+     *   {1} — 이탈 성공
+     */
+    @Bean
+    fun queueLeaveScript(): DefaultRedisScript<List<*>> {
+        return DefaultRedisScript<List<*>>().apply {
+            setLocation(ClassPathResource("lua/queue-leave.lua"))
+            setResultType(List::class.java)
+        }
+    }
+
+    /**
      * Rate Limit 검사 Lua 스크립트 (REQ-QUEUE-008)
      *
      * 고정 윈도우 방식으로 사용자별 요청 횟수를 원자적으로 카운트한다.

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/controller/QueueController.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/controller/QueueController.kt
@@ -8,6 +8,7 @@ import jakarta.validation.Valid
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -49,6 +50,15 @@ class QueueController(private val queueService: QueueService) {
         return ResponseEntity.ok()
             .header(HttpHeaders.CACHE_CONTROL, "no-store")
             .body(response)
+    }
+
+    @DeleteMapping("/leave")
+    fun leave(
+        @RequestParam scheduleId: UUID,
+        authentication: Authentication
+    ): QueueDto.LeaveResponse {
+        val userId = authentication.extractUserId()
+        return queueService.leaveQueue(userId, scheduleId)
     }
 
     /**

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/dto/QueueDto.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/dto/QueueDto.kt
@@ -29,4 +29,8 @@ class QueueDto {
         val estimatedWaitTime: Long, // 예상 대기 시간 (초, ACTIVE 상태에서는 0)
         val token: String?           // WAITING 상태에서는 null
     )
+
+    data class LeaveResponse(
+        val message: String
+    )
 }

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
@@ -25,6 +25,7 @@ class QueueService(
     private val stringRedisTemplate: StringRedisTemplate,
     private val queueEnterScript: DefaultRedisScript<List<*>>,
     private val queueStatusScript: DefaultRedisScript<List<*>>,
+    private val queueLeaveScript: DefaultRedisScript<List<*>>,
     private val rateLimitScript: DefaultRedisScript<Long>,
     private val queueProperties: QueueProperties,
     private val meterRegistry: MeterRegistry
@@ -142,6 +143,39 @@ class QueueService(
             2 -> {
                 logger.debug { "Queue status NOT_IN_QUEUE: userId=$userId, scheduleId=$scheduleId" }
                 throw QueueException(ErrorCode.NOT_IN_QUEUE)
+            }
+            else -> throw QueueException(ErrorCode.INTERNAL_SERVER_ERROR)
+        }
+    }
+
+    /**
+     * 대기열 이탈 처리 (REQ-QUEUE-003)
+     *
+     * Lua 스크립트 반환 코드:
+     * - 0: NOT_IN_QUEUE — 대기열에 없거나 다른 회차에 대기 중
+     * - 1: 이탈 성공
+     */
+    fun leaveQueue(userId: UUID, scheduleId: UUID): QueueDto.LeaveResponse {
+        val keys = listOf(
+            QueueRedisKeys.queue(scheduleId),
+            QueueRedisKeys.active(userId),
+            QueueRedisKeys.userToken(userId, scheduleId)
+        )
+        val args = arrayOf(userId.toString(), scheduleId.toString())
+
+        val result = executeLuaOrThrow(
+            queueLeaveScript, keys, *args,
+            logContext = "leave: scheduleId=$scheduleId, userId=$userId"
+        )
+
+        val code = (result.getOrNull(0) as? Long)?.toInt()
+            ?: throw QueueException(ErrorCode.INTERNAL_SERVER_ERROR, "대기열 처리 결과를 읽을 수 없습니다.")
+
+        return when (code) {
+            0 -> throw QueueException(ErrorCode.NOT_IN_QUEUE)
+            1 -> {
+                logger.info { "Queue left: userId=$userId, scheduleId=$scheduleId" }
+                QueueDto.LeaveResponse(message = "Removed from queue")
             }
             else -> throw QueueException(ErrorCode.INTERNAL_SERVER_ERROR)
         }

--- a/backend/queue-service/src/main/resources/lua/queue-leave.lua
+++ b/backend/queue-service/src/main/resources/lua/queue-leave.lua
@@ -1,0 +1,50 @@
+--[[
+  대기열 이탈 Lua 스크립트 (REQ-QUEUE-003)
+
+  WAITING 상태(Sorted Set 대기)와 ACTIVE 상태(토큰 발급)를 모두 원자적으로 처리한다.
+
+  KEYS[1] = queue:{scheduleId}                     -- 대기열 Sorted Set
+  KEYS[2] = queue:active:{userId}                  -- 중복 대기 방지 키
+  KEYS[3] = queue:user-token:{userId}:{scheduleId} -- 역방향 토큰 조회 키
+
+  ARGV[1] = userId
+  ARGV[2] = scheduleId
+
+  Returns:
+    {0} : NOT_IN_QUEUE — 대기열에 없거나 다른 회차에 대기 중
+    {1} : 이탈 성공
+]]
+
+local queueKey     = KEYS[1]
+local activeKey    = KEYS[2]
+local userTokenKey = KEYS[3]
+
+local userId     = ARGV[1]
+local scheduleId = ARGV[2]
+
+-- Step 1: active 키 확인 (Single Source of Truth)
+local existingScheduleId = redis.call('GET', activeKey)
+if not existingScheduleId then
+    -- active 키 없음 → 대기열에 없음
+    return {0}
+end
+if existingScheduleId ~= scheduleId then
+    -- 다른 회차에 대기 중 → 이 회차에서는 이탈 불가
+    return {0}
+end
+
+-- Step 2: Sorted Set에서 제거 (WAITING 상태 처리)
+-- ACTIVE 상태(배치 승인 후)에서는 이미 제거되어 있으므로 0 반환 — 정상
+redis.call('ZREM', queueKey, userId)
+
+-- Step 3: active 키 삭제
+redis.call('DEL', activeKey)
+
+-- Step 4: 토큰 정리 (ACTIVE 상태 처리)
+local token = redis.call('GET', userTokenKey)
+if token then
+    redis.call('DEL', 'queue:token:' .. token)
+    redis.call('DEL', userTokenKey)
+end
+
+return {1}

--- a/backend/queue-service/src/main/resources/lua/queue-leave.lua
+++ b/backend/queue-service/src/main/resources/lua/queue-leave.lua
@@ -25,8 +25,24 @@ local scheduleId = ARGV[2]
 -- Step 1: active 키 확인 (Single Source of Truth)
 local existingScheduleId = redis.call('GET', activeKey)
 if not existingScheduleId then
-    -- active 키 없음 → 대기열에 없음
-    return {0}
+    -- active 키 만료 → ZSET 멤버십과 토큰 존재 여부로 fallback 판단
+    local inQueue = redis.call('ZRANK', queueKey, userId)
+    local hasToken = redis.call('GET', userTokenKey)
+
+    if inQueue == false and not hasToken then
+        -- 진짜 대기열에 없음
+        return {0}
+    end
+
+    -- ZSET 또는 토큰이 존재 → 정리 후 이탈 처리
+    if inQueue ~= false then
+        redis.call('ZREM', queueKey, userId)
+    end
+    if hasToken then
+        redis.call('DEL', 'queue:token:' .. hasToken)
+        redis.call('DEL', userTokenKey)
+    end
+    return {1}
 end
 if existingScheduleId ~= scheduleId then
     -- 다른 회차에 대기 중 → 이 회차에서는 이탈 불가

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/controller/QueueControllerTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/controller/QueueControllerTest.kt
@@ -28,6 +28,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -187,6 +188,81 @@ class QueueControllerTest {
             fun returnsUnauthorizedWhenNoAuthHeader() {
                 val response = mockMvc.perform(
                     get("/queue/status")
+                        .param("scheduleId", scheduleId.toString())
+                ).andReturn().response
+
+                response.status.shouldBe(HttpStatus.UNAUTHORIZED.value())
+                objectMapper.readTree(response.contentAsString)["code"].asText().shouldBe("UNAUTHORIZED")
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /queue/leave")
+    inner class DeleteQueueLeave {
+
+        @Test
+        @DisplayName("200 OK - 대기열 이탈 성공")
+        fun returnsOkOnLeaveSuccess() {
+            every { queueService.leaveQueue(any(), scheduleId) } returns QueueDto.LeaveResponse("Removed from queue")
+
+            mockMvc.perform(
+                delete("/queue/leave")
+                    .header("X-User-Id", userId.toString())
+                    .header("X-User-Role", "USER")
+                    .param("scheduleId", scheduleId.toString())
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.message").value("Removed from queue"))
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 대기열에 없는 사용자")
+        fun returnsNotFoundWhenNotInQueue() {
+            every { queueService.leaveQueue(any(), scheduleId) } throws QueueException(ErrorCode.NOT_IN_QUEUE)
+
+            mockMvc.perform(
+                delete("/queue/leave")
+                    .header("X-User-Id", userId.toString())
+                    .header("X-User-Role", "USER")
+                    .param("scheduleId", scheduleId.toString())
+            )
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.code").value("NOT_IN_QUEUE"))
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - scheduleId 파라미터 누락")
+        fun returnsBadRequestWhenScheduleIdMissing() {
+            mockMvc.perform(
+                delete("/queue/leave")
+                    .header("X-User-Id", userId.toString())
+                    .header("X-User-Role", "USER")
+            )
+                .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - 유효하지 않은 UUID 형식")
+        fun returnsBadRequestWhenScheduleIdInvalidUuid() {
+            mockMvc.perform(
+                delete("/queue/leave")
+                    .header("X-User-Id", userId.toString())
+                    .header("X-User-Role", "USER")
+                    .param("scheduleId", "not-a-uuid")
+            )
+                .andExpect(status().isBadRequest)
+        }
+
+        @Nested
+        @DisplayName("Security")
+        inner class Security {
+
+            @Test
+            @DisplayName("401 Unauthorized - 인증 헤더 없이 요청")
+            fun returnsUnauthorizedWhenNoAuthHeader() {
+                val response = mockMvc.perform(
+                    delete("/queue/leave")
                         .param("scheduleId", scheduleId.toString())
                 ).andReturn().response
 

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/integration/QueueLeaveIntegrationTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/integration/QueueLeaveIntegrationTest.kt
@@ -1,0 +1,176 @@
+package com.ticketqueue.queue.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Testcontainers
+@TestPropertySource(properties = [
+    "spring.cloud.aws.region.static=us-east-1",
+    "spring.cloud.aws.credentials.access-key=test",
+    "spring.cloud.aws.credentials.secret-key=test"
+])
+@DisplayName("Queue 대기열 이탈 통합 테스트")
+class QueueLeaveIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val valkey = GenericContainer("valkey/valkey:8.1-alpine")
+            .withExposedPorts(6379)
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun redisProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.data.redis.host") { valkey.host }
+            registry.add("spring.data.redis.port") { valkey.getMappedPort(6379) }
+        }
+    }
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var stringRedisTemplate: StringRedisTemplate
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun flushRedis() {
+        stringRedisTemplate.connectionFactory!!.connection.use { it.serverCommands().flushAll() }
+    }
+
+    // ── 헬퍼 ──────────────────────────────────────────────────────────────────
+
+    private fun enterRequest(scheduleId: UUID) = post("/queue/enter")
+        .header("X-User-Id", userId.toString())
+        .header("X-User-Role", "USER")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(mapOf("scheduleId" to scheduleId.toString())))
+
+    private fun leaveRequest(scheduleId: UUID) = delete("/queue/leave")
+        .header("X-User-Id", userId.toString())
+        .header("X-User-Role", "USER")
+        .param("scheduleId", scheduleId.toString())
+
+    private val userId = UUID.randomUUID()
+    private val scheduleId = UUID.randomUUID()
+
+    // ── 테스트 1: enter → leave → 200 OK ─────────────────────────────────────
+
+    @Test
+    @DisplayName("대기열 진입 후 이탈 시 200 OK와 메시지를 반환한다")
+    fun enterThenLeave_returns200() {
+        mockMvc.perform(enterRequest(scheduleId))
+            .andExpect(status().isOk)
+
+        mockMvc.perform(leaveRequest(scheduleId))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("Removed from queue"))
+    }
+
+    // ── 테스트 2: leave → leave → 404 NOT_IN_QUEUE ───────────────────────────
+
+    @Test
+    @DisplayName("이탈 후 재호출 시 404 NOT_IN_QUEUE를 반환한다")
+    fun leaveAfterLeave_returns404() {
+        mockMvc.perform(enterRequest(scheduleId)).andExpect(status().isOk)
+        mockMvc.perform(leaveRequest(scheduleId)).andExpect(status().isOk)
+
+        mockMvc.perform(leaveRequest(scheduleId))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.code").value("NOT_IN_QUEUE"))
+    }
+
+    // ── 테스트 3: enter → leave → enter → 재진입 성공 ────────────────────────
+
+    @Test
+    @DisplayName("이탈 후 재진입 시 WAITING 상태로 성공한다")
+    fun leaveAndReenter_succeeds() {
+        mockMvc.perform(enterRequest(scheduleId)).andExpect(status().isOk)
+        mockMvc.perform(leaveRequest(scheduleId)).andExpect(status().isOk)
+
+        mockMvc.perform(enterRequest(scheduleId))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("WAITING"))
+            .andExpect(jsonPath("$.rank").value(1))
+    }
+
+    // ── 테스트 4: WAITING 상태 Redis 키 정리 검증 ────────────────────────────
+
+    @Nested
+    @DisplayName("Redis 키 정리 검증")
+    inner class RedisKeyCleanup {
+
+        @Test
+        @DisplayName("WAITING 상태 이탈 후 queue:active와 Sorted Set 멤버가 삭제된다")
+        fun leaveQueue_cleansUpRedisKeys_waitingState() {
+            val activeKey = "queue:active:$userId"
+            val queueKey = "queue:$scheduleId"
+
+            // enter 후 키 존재 확인
+            mockMvc.perform(enterRequest(scheduleId)).andExpect(status().isOk)
+
+            stringRedisTemplate.hasKey(activeKey) shouldBe true
+            stringRedisTemplate.opsForZSet().rank(queueKey, userId.toString()) shouldBe 0L
+
+            // leave 후 키 삭제 확인
+            mockMvc.perform(leaveRequest(scheduleId)).andExpect(status().isOk)
+
+            stringRedisTemplate.hasKey(activeKey) shouldBe false
+            stringRedisTemplate.opsForZSet().rank(queueKey, userId.toString()) shouldBe null
+        }
+
+        @Test
+        @DisplayName("ACTIVE 상태(토큰 발급 후) 이탈 시 queue:active, queue:user-token, queue:token 키가 삭제된다")
+        fun leaveQueue_cleansUpRedisKeys_activeState() {
+            val activeKey = "queue:active:$userId"
+            val userTokenKey = "queue:user-token:$userId:$scheduleId"
+            val token = UUID.randomUUID().toString()
+            val tokenKey = "queue:token:$token"
+
+            // ACTIVE 상태 시뮬레이션: Redis에 직접 키 세팅 (배치 승인 후 상태)
+            stringRedisTemplate.opsForValue().set(activeKey, scheduleId.toString())
+            stringRedisTemplate.opsForValue().set(userTokenKey, token)
+            stringRedisTemplate.opsForValue().set(tokenKey, """{"userId":"$userId","scheduleId":"$scheduleId"}""")
+
+            // 키 존재 확인
+            stringRedisTemplate.hasKey(activeKey) shouldBe true
+            stringRedisTemplate.hasKey(userTokenKey) shouldBe true
+            stringRedisTemplate.hasKey(tokenKey) shouldBe true
+
+            // leave 호출
+            mockMvc.perform(leaveRequest(scheduleId)).andExpect(status().isOk)
+
+            // 모든 토큰 관련 키 삭제 확인
+            stringRedisTemplate.hasKey(activeKey) shouldBe false
+            stringRedisTemplate.hasKey(userTokenKey) shouldBe false
+            stringRedisTemplate.hasKey(tokenKey) shouldBe false
+        }
+    }
+}

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/QueueServiceTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/QueueServiceTest.kt
@@ -25,6 +25,7 @@ class QueueServiceTest {
     private lateinit var stringRedisTemplate: StringRedisTemplate
     private lateinit var queueEnterScript: DefaultRedisScript<List<*>>
     private lateinit var queueStatusScript: DefaultRedisScript<List<*>>
+    private lateinit var queueLeaveScript: DefaultRedisScript<List<*>>
     private lateinit var rateLimitScript: DefaultRedisScript<Long>
     private lateinit var queueProperties: QueueProperties
     private lateinit var meterRegistry: SimpleMeterRegistry
@@ -38,6 +39,7 @@ class QueueServiceTest {
         stringRedisTemplate = mockk()
         queueEnterScript = mockk()
         queueStatusScript = mockk()
+        queueLeaveScript = mockk()
         rateLimitScript = mockk()
         queueProperties = QueueProperties(
             batch = QueueProperties.BatchProperties(size = 10, interval = 1000),
@@ -48,6 +50,7 @@ class QueueServiceTest {
             stringRedisTemplate,
             queueEnterScript,
             queueStatusScript,
+            queueLeaveScript,
             rateLimitScript,
             queueProperties,
             meterRegistry
@@ -238,6 +241,62 @@ class QueueServiceTest {
                 }
                 assertEquals(ErrorCode.INTERNAL_SERVER_ERROR, exception.errorCode)
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("leaveQueue")
+    inner class LeaveQueue {
+
+        @Test
+        @DisplayName("대기열 이탈 성공 시 LeaveResponse를 반환한다")
+        fun returnsLeaveResponseOnSuccess() {
+            every {
+                stringRedisTemplate.execute(queueLeaveScript, any(), *anyVararg<String>())
+            } returns listOf(1L)
+
+            val result = queueService.leaveQueue(userId, scheduleId)
+
+            assertEquals("Removed from queue", result.message)
+        }
+
+        @Test
+        @DisplayName("대기열에 없으면 NOT_IN_QUEUE 예외를 던진다")
+        fun throwsNotInQueueWhenNotInQueue() {
+            every {
+                stringRedisTemplate.execute(queueLeaveScript, any(), *anyVararg<String>())
+            } returns listOf(0L)
+
+            val exception = assertThrows<QueueException> {
+                queueService.leaveQueue(userId, scheduleId)
+            }
+            assertEquals(ErrorCode.NOT_IN_QUEUE, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("Redis 실행 실패 시 INTERNAL_SERVER_ERROR를 던진다")
+        fun throwsInternalErrorWhenRedisFailure() {
+            every {
+                stringRedisTemplate.execute(queueLeaveScript, any(), *anyVararg<String>())
+            } throws RuntimeException("Redis connection refused")
+
+            val exception = assertThrows<QueueException> {
+                queueService.leaveQueue(userId, scheduleId)
+            }
+            assertEquals(ErrorCode.INTERNAL_SERVER_ERROR, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("예상치 못한 반환 코드 시 INTERNAL_SERVER_ERROR를 던진다")
+        fun throwsInternalErrorOnUnexpectedCode() {
+            every {
+                stringRedisTemplate.execute(queueLeaveScript, any(), *anyVararg<String>())
+            } returns listOf(99L)
+
+            val exception = assertThrows<QueueException> {
+                queueService.leaveQueue(userId, scheduleId)
+            }
+            assertEquals(ErrorCode.INTERNAL_SERVER_ERROR, exception.errorCode)
         }
     }
 

--- a/backend/queue-service/src/test/resources/application-test.yml
+++ b/backend/queue-service/src/test/resources/application-test.yml
@@ -1,0 +1,24 @@
+spring:
+  config:
+    import: ""  # base application.yml의 aws-secretsmanager import 비활성화
+  cloud:
+    aws:
+      secretsmanager:
+        enabled: false
+
+internal:
+  api:
+    key: test-internal-api-key
+
+queue:
+  batch:
+    size: 10
+    interval: 1000
+  token:
+    ttl: 600
+  max-capacity: 50000
+  active-user:
+    ttl: 600
+  rate-limit:
+    max-requests: 15
+    window-seconds: 60


### PR DESCRIPTION
## Summary
- `DELETE /queue/leave` 엔드포인트 구현 (Issue #43)
- 사용자가 대기열에서 즉시 이탈하여 다른 회차로 재진입 가능

## Changes
- `queue-leave.lua` 신규 작성 — WAITING/ACTIVE 상태를 원자적으로 처리
  - WAITING: Sorted Set 제거 + active 키 삭제
  - ACTIVE: Sorted Set 제거(no-op) + active 키 삭제 + 토큰 키 2개 삭제
  - 다른 회차 대기 중이거나 대기열에 없는 경우 `{0}` 반환
- `RedisConfig.kt` — `queueLeaveScript` Bean 추가
- `QueueRedisKeys.kt` — `token()` 키 패턴 추가
- `QueueDto.kt` — `LeaveResponse` DTO 추가
- `QueueService.kt` — `leaveQueue()` 메서드 추가
- `QueueController.kt` — `DELETE /queue/leave` 엔드포인트 추가
- `QueueServiceTest.kt` — leaveQueue 단위 테스트 4개 추가
- `QueueControllerTest.kt` — DELETE /queue/leave 테스트 5개 추가

## Test plan
- [x] 단위 테스트 통과 (`./gradlew :queue-service:test`)
- [x] 수동 검증: `POST /queue/enter` → `DELETE /queue/leave` → 200 OK (통합 테스트로 자동화)
- [x] 수동 검증: 이탈 후 재호출 → 404 NOT_IN_QUEUE (통합 테스트로 자동화)
- [x] 수동 검증: 이탈 후 `POST /queue/enter` 재진입 → 성공 (통합 테스트로 자동화)
- [x] Redis 키 검증: 이탈 후 `queue:active:{userId}`, `queue:user-token:*` 키 삭제 확인 (통합 테스트로 자동화)

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now leave a queue via a new DELETE endpoint; the system returns a confirmation message.

* **Behavioral**
  * Leave operation is handled atomically and cleans up associated queue state and tokens to prevent duplication and stale entries.
  * Returns clear not-in-queue and error responses when applicable.

* **Tests**
  * Added unit, controller, and integration tests covering success, repeated leave, re-enter, invalid input, auth, and Redis state cleanup.

* **Chores**
  * Test dependencies and test configuration updated to support integration testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->