### PR TITLE
feat: [Frontend] 공연 목록 페이지 (SSR + 필터/페이지네이션) #115

### DIFF
--- a/frontend/src/app/(main)/events/loading.tsx
+++ b/frontend/src/app/(main)/events/loading.tsx
@@ -1,0 +1,9 @@
+import { EventListSkeleton } from '@/components/skeleton/event-list-skeleton'
+
+export default function EventsLoading() {
+  return (
+    <div className="max-w-7xl mx-auto px-6 py-12">
+      <EventListSkeleton />
+    </div>
+  )
+}

--- a/frontend/src/app/(main)/events/page.tsx
+++ b/frontend/src/app/(main)/events/page.tsx
@@ -1,10 +1,76 @@
-export default function EventsPage() {
+import type { Metadata } from 'next'
+import { getEventsServer } from '@/lib/api/server/events'
+import { EventList } from '@/components/domain/event/EventList'
+import { EventFilter } from '@/components/domain/event/EventFilter'
+import { Pagination } from '@/components/ui/Pagination'
+import type { EventSummary } from '@/types/event'
+
+const PAGE_SIZE = 12
+
+export const metadata: Metadata = {
+  title: '공연 목록 | Ticket Queue',
+  description: '진행 중인 공연 목록을 확인하고 예매를 시작하세요. 키워드 검색과 상태 필터로 원하는 공연을 찾아보세요.',
+  openGraph: {
+    title: '공연 목록 | Ticket Queue',
+    description: '진행 중인 공연 목록을 확인하고 예매를 시작하세요.',
+    type: 'website',
+    locale: 'ko_KR',
+    siteName: 'Ticket Queue',
+  },
+}
+
+interface EventsPageProps {
+  searchParams: Promise<{ page?: string; keyword?: string; status?: string }>
+}
+
+export default async function EventsPage({ searchParams }: EventsPageProps) {
+  const { page: pageParam, keyword, status } = await searchParams
+
+  const page = Math.max(1, parseInt(pageParam ?? '1', 10) || 1)
+
+  let events: EventSummary[] = []
+  let totalPages = 0
+
+  try {
+    const data = await getEventsServer({
+      page: page - 1,
+      size: PAGE_SIZE,
+      keyword: keyword || undefined,
+      status: status || undefined,
+    })
+    events = data.list
+    totalPages = Math.ceil(data.totalElements / PAGE_SIZE)
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('Failed to fetch events', error)
+    }
+    events = []
+  }
+
+  function createPageUrl(p: number) {
+    const params = new URLSearchParams()
+    if (keyword) params.set('keyword', keyword)
+    if (status) params.set('status', status)
+    params.set('page', String(p))
+    return '/events?' + params.toString()
+  }
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-spacing-xl">
-      <div className="max-w-2xl text-center">
-        <h1 className="mb-spacing-lg text-4xl font-bold text-gray-900">공연 목록</h1>
-        <p className="text-gray-600">진행 중인 공연 목록을 확인하고 예매를 시작하세요.</p>
+    <main className="max-w-7xl mx-auto px-6 py-12">
+      <div className="mb-8">
+        <h1 className="text-h1 text-foreground mb-2">공연 목록</h1>
+        <p className="text-muted-foreground">진행 중인 공연을 검색하고 예매하세요.</p>
       </div>
+
+      <EventFilter defaultKeyword={keyword} defaultStatus={status} />
+
+      <EventList events={events} />
+
+      <Pagination
+        currentPage={page}
+        totalPages={totalPages}
+        createPageUrl={createPageUrl}
+      />
     </main>
   )
 }

--- a/frontend/src/app/(main)/events/page.tsx
+++ b/frontend/src/app/(main)/events/page.tsx
@@ -40,6 +40,17 @@ export default async function EventsPage({ searchParams }: EventsPageProps) {
     })
     events = data.list
     totalPages = Math.ceil(data.totalElements / PAGE_SIZE)
+
+    if (page > totalPages && totalPages > 0) {
+      const corrected = await getEventsServer({
+        page: totalPages - 1,
+        size: PAGE_SIZE,
+        keyword: keyword || undefined,
+        status: status || undefined,
+      })
+      events = corrected.list
+      totalPages = Math.ceil(corrected.totalElements / PAGE_SIZE)
+    }
   } catch (error) {
     if (process.env.NODE_ENV !== 'production') {
       console.error('Failed to fetch events', error)

--- a/frontend/src/components/domain/event/EventFilter.tsx
+++ b/frontend/src/components/domain/event/EventFilter.tsx
@@ -10,8 +10,8 @@ import { cn } from '@/lib/utils'
 const STATUS_OPTIONS = [
   { value: '', label: '전체' },
   { value: 'OPEN', label: '예매중' },
-  { value: 'READY', label: '준비중' },
-  { value: 'CLOSED', label: '종료' },
+  { value: 'PREPARING', label: '준비중' },
+  { value: 'ENDED', label: '종료' },
   { value: 'CANCELLED', label: '취소' },
 ]
 

--- a/frontend/src/components/domain/event/EventFilter.tsx
+++ b/frontend/src/components/domain/event/EventFilter.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Search } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+const STATUS_OPTIONS = [
+  { value: '', label: '전체' },
+  { value: 'OPEN', label: '예매중' },
+  { value: 'READY', label: '준비중' },
+  { value: 'CLOSED', label: '종료' },
+  { value: 'CANCELLED', label: '취소' },
+]
+
+interface EventFilterProps {
+  defaultKeyword?: string
+  defaultStatus?: string
+}
+
+export function EventFilter({ defaultKeyword = '', defaultStatus = '' }: EventFilterProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [keyword, setKeyword] = useState(defaultKeyword)
+  const [status, setStatus] = useState(defaultStatus)
+
+  function handleSearch() {
+    const params = new URLSearchParams(searchParams.toString())
+    if (keyword.trim()) {
+      params.set('keyword', keyword.trim())
+    } else {
+      params.delete('keyword')
+    }
+    if (status) {
+      params.set('status', status)
+    } else {
+      params.delete('status')
+    }
+    params.delete('page')
+    router.push('/events?' + params.toString())
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') handleSearch()
+  }
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center mb-8">
+      <Input
+        type="text"
+        placeholder="공연명, 아티스트 검색"
+        value={keyword}
+        onChange={(e) => setKeyword(e.target.value)}
+        onKeyDown={handleKeyDown}
+        className="sm:w-72"
+      />
+
+      <select
+        value={status}
+        onChange={(e) => setStatus(e.target.value)}
+        className={cn(
+          'border-input h-9 rounded-md border bg-background px-3 py-1 text-sm shadow-xs transition-colors',
+          'focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+          'sm:w-36',
+        )}
+      >
+        {STATUS_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+
+      <Button onClick={handleSearch} size="md" className="sm:w-auto">
+        <Search className="size-4" />
+        검색
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/Pagination.tsx
+++ b/frontend/src/components/ui/Pagination.tsx
@@ -32,53 +32,61 @@ export function Pagination({ currentPage, totalPages, createPageUrl }: Paginatio
 
   return (
     <nav aria-label="페이지 네비게이션" className="flex items-center justify-center gap-1 mt-8">
-      <Link
-        href={createPageUrl(currentPage - 1)}
-        aria-disabled={currentPage === 1}
-        className={cn(
-          'inline-flex h-9 w-9 items-center justify-center rounded-md border text-sm transition-colors',
-          currentPage === 1
-            ? 'pointer-events-none border-border text-muted-foreground opacity-50'
-            : 'border-border bg-background hover:bg-accent hover:text-accent-foreground',
-        )}
-      >
-        ←
-      </Link>
+      {currentPage === 1 ? (
+        <span
+          aria-disabled="true"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md border text-sm transition-colors pointer-events-none border-border text-muted-foreground opacity-50"
+        >
+          ←
+        </span>
+      ) : (
+        <Link
+          href={createPageUrl(currentPage - 1)}
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md border text-sm transition-colors border-border bg-background hover:bg-accent hover:text-accent-foreground"
+        >
+          ←
+        </Link>
+      )}
 
       {pages.map((page, idx) =>
         page === 'ellipsis' ? (
           <span key={`ellipsis-${idx}`} className="inline-flex h-9 w-9 items-center justify-center text-sm text-muted-foreground">
             …
           </span>
+        ) : page === currentPage ? (
+          <span
+            key={page}
+            aria-current="page"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md border text-sm font-medium transition-colors border-primary bg-primary text-primary-foreground"
+          >
+            {page}
+          </span>
         ) : (
           <Link
             key={page}
             href={createPageUrl(page)}
-            aria-current={page === currentPage ? 'page' : undefined}
-            className={cn(
-              'inline-flex h-9 w-9 items-center justify-center rounded-md border text-sm font-medium transition-colors',
-              page === currentPage
-                ? 'border-primary bg-primary text-primary-foreground pointer-events-none'
-                : 'border-border bg-background hover:bg-accent hover:text-accent-foreground',
-            )}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md border text-sm font-medium transition-colors border-border bg-background hover:bg-accent hover:text-accent-foreground"
           >
             {page}
           </Link>
         ),
       )}
 
-      <Link
-        href={createPageUrl(currentPage + 1)}
-        aria-disabled={currentPage === totalPages}
-        className={cn(
-          'inline-flex h-9 w-9 items-center justify-center rounded-md border text-sm transition-colors',
-          currentPage === totalPages
-            ? 'pointer-events-none border-border text-muted-foreground opacity-50'
-            : 'border-border bg-background hover:bg-accent hover:text-accent-foreground',
-        )}
-      >
-        →
-      </Link>
+      {currentPage === totalPages ? (
+        <span
+          aria-disabled="true"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md border text-sm transition-colors pointer-events-none border-border text-muted-foreground opacity-50"
+        >
+          →
+        </span>
+      ) : (
+        <Link
+          href={createPageUrl(currentPage + 1)}
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md border text-sm transition-colors border-border bg-background hover:bg-accent hover:text-accent-foreground"
+        >
+          →
+        </Link>
+      )}
     </nav>
   )
 }

--- a/frontend/src/components/ui/Pagination.tsx
+++ b/frontend/src/components/ui/Pagination.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+
+interface PaginationProps {
+  currentPage: number
+  totalPages: number
+  createPageUrl: (page: number) => string
+}
+
+export function Pagination({ currentPage, totalPages, createPageUrl }: PaginationProps) {
+  if (totalPages <= 1) return null
+
+  const pages: (number | 'ellipsis')[] = []
+
+  // 페이지 윈도우 계산: 현재 페이지 ±2, 첫/마지막 페이지
+  const windowStart = Math.max(2, currentPage - 2)
+  const windowEnd = Math.min(totalPages - 1, currentPage + 2)
+
+  pages.push(1)
+
+  if (windowStart > 2) pages.push('ellipsis')
+
+  for (let i = windowStart; i <= windowEnd; i++) {
+    pages.push(i)
+  }
+
+  if (windowEnd < totalPages - 1) pages.push('ellipsis')
+
+  if (totalPages > 1) pages.push(totalPages)
+
+  return (
+    <nav aria-label="페이지 네비게이션" className="flex items-center justify-center gap-1 mt-8">
+      <Link
+        href={createPageUrl(currentPage - 1)}
+        aria-disabled={currentPage === 1}
+        className={cn(
+          'inline-flex h-9 w-9 items-center justify-center rounded-md border text-sm transition-colors',
+          currentPage === 1
+            ? 'pointer-events-none border-border text-muted-foreground opacity-50'
+            : 'border-border bg-background hover:bg-accent hover:text-accent-foreground',
+        )}
+      >
+        ←
+      </Link>
+
+      {pages.map((page, idx) =>
+        page === 'ellipsis' ? (
+          <span key={`ellipsis-${idx}`} className="inline-flex h-9 w-9 items-center justify-center text-sm text-muted-foreground">
+            …
+          </span>
+        ) : (
+          <Link
+            key={page}
+            href={createPageUrl(page)}
+            aria-current={page === currentPage ? 'page' : undefined}
+            className={cn(
+              'inline-flex h-9 w-9 items-center justify-center rounded-md border text-sm font-medium transition-colors',
+              page === currentPage
+                ? 'border-primary bg-primary text-primary-foreground pointer-events-none'
+                : 'border-border bg-background hover:bg-accent hover:text-accent-foreground',
+            )}
+          >
+            {page}
+          </Link>
+        ),
+      )}
+
+      <Link
+        href={createPageUrl(currentPage + 1)}
+        aria-disabled={currentPage === totalPages}
+        className={cn(
+          'inline-flex h-9 w-9 items-center justify-center rounded-md border text-sm transition-colors',
+          currentPage === totalPages
+            ? 'pointer-events-none border-border text-muted-foreground opacity-50'
+            : 'border-border bg-background hover:bg-accent hover:text-accent-foreground',
+        )}
+      >
+        →
+      </Link>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- 공연 목록 `/events` 페이지를 placeholder에서 완전한 SSR 페이지로 구현
- 키워드 검색 + 상태 필터 기능 추가 (URL 기반 상태 관리)
- 페이지네이션 UI 구현 (페이지 크기 12, 페이지 윈도우 ±2)

## Changes
- `src/app/(main)/events/page.tsx`: async Server Component, metadata, searchParams(Promise), getEventsServer SSR 페칭, 0-indexed 변환 (URL 1-indexed → API 0-indexed)
- `src/app/(main)/events/loading.tsx`: EventListSkeleton 기반 Next.js 로딩 UI
- `src/components/domain/event/EventFilter.tsx`: Client Component, 키워드 검색 입력 + 상태 필터 select, 검색 시 page 파라미터 초기화
- `src/components/ui/Pagination.tsx`: 재사용 가능한 페이지네이션 컴포넌트, aria-label/aria-current 접근성 적용, next/link 기반 클라이언트 네비게이션

## Test plan
- [ ] `npm run build` 성공 확인 (타입 에러 없음) — 로컬 빌드 통과 완료
- [ ] `http://localhost:3000/events` 접속 → SSR 렌더링된 공연 목록 확인
- [ ] 검색어 입력 후 검색 → URL `?keyword=xxx` 반영, 결과 필터링
- [ ] 상태 필터 변경 후 검색 → URL `?status=OPEN` 반영
- [ ] 페이지네이션 클릭 → URL `?page=2` 반영, 데이터 변경
- [ ] 빈 검색 결과 → "현재 진행 중인 공연이 없습니다." 표시
- [ ] 페이지 소스 보기 → SSR 렌더링된 이벤트 데이터 확인 (SEO)

Closes #115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Events list now supports server-side pagination and efficient data loading
* Users can search events by keyword and filter results by status
* Added loading state that displays while fetching event data
* Navigation controls enable seamless browsing through event pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->