### PR TITLE
test: [Event] 좌석 조회 API 테스트 보강 및 API 스펙 수정 (#35)

### DIFF
--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
@@ -518,6 +518,19 @@ class EventControllerTest {
                 mockMvc.perform(get("/events/{eventId}", eventId))
                     .andExpect(status().isOk)
             }
+
+            @Test
+            @DisplayName("GET /events/schedules/{scheduleId}/seats → 200")
+            fun getSeats_shouldReturnOk_whenNoAuth() {
+                val scheduleId = UUID.randomUUID()
+                every { seatService.getSeats(scheduleId) } returns SeatDto.SeatsResponse(
+                    scheduleId = scheduleId,
+                    grades = emptyList()
+                )
+
+                mockMvc.perform(get("/events/schedules/{scheduleId}/seats", scheduleId))
+                    .andExpect(status().isOk)
+            }
         }
     }
 }

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
@@ -305,6 +305,33 @@ class EventServiceTest {
         }
 
         @Test
+        @DisplayName("gradeMapping 값이 유효하지 않은 등급 문자열이면 INVALID_SEAT_TEMPLATE_MAPPING 예외가 발생한다")
+        fun invalidGradeStringInSeatTemplateMapping() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+            val templateWithInvalidGrade = SeatTemplateDto(
+                rows = listOf("A"),
+                seatsPerRow = 1,
+                gradeMapping = mapOf("A" to "PLATINUM")
+            )
+            val request = EventDto.CreateRequest(
+                title = "BTS World Tour", artist = "BTS",
+                venueId = venueId, hallId = hallId,
+                priceByGrade = priceByGrade, schedules = listOf(scheduleRequest)
+            )
+            every { venueRepository.findById(venueId) } returns Optional.of(venue)
+            every { hallRepository.findById(hallId) } returns Optional.of(hall)
+            every { objectMapper.readValue(any<String>(), SeatTemplateDto::class.java) } returns templateWithInvalidGrade
+            every { eventRepository.save(any()) } returns event
+            every { eventScheduleRepository.save(any()) } returns schedule
+
+            val exception = assertThrows<EventException> { eventService.createEvent(request) }
+            assertEquals(ErrorCode.INVALID_SEAT_TEMPLATE_MAPPING, exception.errorCode)
+        }
+
+        @Test
         @DisplayName("행-등급 매핑이 누락되면 INVALID_SEAT_TEMPLATE_MAPPING 예외가 발생한다")
         fun invalidSeatTemplateMapping() {
             val venue = createVenue()

--- a/docs/specification/02_event_service.md
+++ b/docs/specification/02_event_service.md
@@ -144,7 +144,7 @@ Event Service는 공연, 공연장, 좌석 정보를 관리하며 조회 성능�
 
 ### 1.4 회차별 좌석 정보 조회
 - **URL:** `GET /events/schedules/{scheduleId}/seats`
-- **Auth:** Bearer Token
+- **Auth:** None
 
 **Response (200 OK)**
 ```json


### PR DESCRIPTION
## Summary
- `GET /events/schedules/{scheduleId}/seats` 엔드포인트의 공개 접근(인증 없음) Security 테스트 추가
- `initializeSeats()` 내 `SeatGrade.valueOf()` catch 분기를 커버하는 엣지케이스 테스트 추가 (유효하지 않은 등급 문자열)
- API 스펙 문서에서 좌석 조회 Auth 요구사항을 실제 구현과 일치하도록 수정

## Changes
- `EventControllerTest.kt`: `Security > PublicAccess`에 `getSeats_shouldReturnOk_whenNoAuth` 테스트 추가
- `EventServiceTest.kt`: `CreateEvent`에 `invalidGradeStringInSeatTemplateMapping` 테스트 추가 (`gradeMapping` 값이 `PLATINUM` 등 존재하지 않는 등급일 때 `INVALID_SEAT_TEMPLATE_MAPPING` 예외 검증)
- `docs/specification/02_event_service.md`: section 1.4 `Auth: Bearer Token` → `Auth: None` (Event Service `SecurityConfig`의 `permitAll()` 실제 동작과 일치)

## Test plan
- [x] `./gradlew :event-service:test` 전체 통과 확인

Closes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event schedule seat information endpoints are now publicly accessible without authentication. Guests can browse available seats and seating information without logging in, providing better pre-purchase exploration.

* **Documentation**
  * API specification updated to reflect authentication changes for seat information endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->