### PR TITLE
feat: [Queue] 배치 승인 및 Token 발급 구현 (#44)

### DIFF
--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/QueueRedisKeys.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/QueueRedisKeys.kt
@@ -17,4 +17,13 @@ object QueueRedisKeys {
     fun active(userId: Any): String = "queue:active:$userId"
     fun rateLimit(userId: Any): String = "rate:queue-status:$userId"
     fun token(token: Any): String = "queue:token:$token"
+
+    /**
+     * 활성 대기열 scheduleId 추적 SET 키 (REQ-QUEUE-005)
+     *
+     * SCAN/KEYS 명령 대신 이 SET을 사용하여 배치 승인 대상 회차를 O(1)으로 조회한다.
+     * - 대기열 진입 시: SADD (queue-enter.lua)
+     * - 대기열 비워질 때: SREM (batch-approve.lua)
+     */
+    fun activeSchedules(): String = "queue:active-schedules"
 }

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/RedisConfig.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/config/RedisConfig.kt
@@ -32,17 +32,19 @@ class RedisConfig {
     /**
      * 배치 승인 Lua 스크립트 (REQ-QUEUE-005)
      *
-     * Sorted Set에서 상위 N명을 원자적으로 추출 및 제거한다.
+     * Sorted Set에서 상위 N명을 원자적으로 추출하고 Queue Token을 발급한다.
      *
      * KEYS[1]: queue:{scheduleId}
-     * ARGV[1]: batchSize (기본 10)
-     * @return 승인된 userId 목록
+     * KEYS[2]: queue:active-schedules
+     * ARGV[1]: batchSize, ARGV[2]: scheduleId, ARGV[3]: tokenTtl
+     * ARGV[4]: activeUserTtl, ARGV[5]: issuedAt, ARGV[6..]: 사전 생성된 token UUID
+     * @return 실제 승인된 사용자 수 (Long)
      */
     @Bean
-    fun batchApproveScript(): DefaultRedisScript<List<*>> {
-        return DefaultRedisScript<List<*>>().apply {
+    fun batchApproveScript(): DefaultRedisScript<Long> {
+        return DefaultRedisScript<Long>().apply {
             setLocation(ClassPathResource("lua/batch-approve.lua"))
-            setResultType(List::class.java)
+            setResultType(Long::class.java)
         }
     }
 

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/scheduler/BatchApproveScheduler.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/scheduler/BatchApproveScheduler.kt
@@ -1,0 +1,44 @@
+package com.ticketqueue.queue.scheduler
+
+import com.ticketqueue.queue.service.QueueService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * 대기열 배치 승인 스케줄러 (REQ-QUEUE-005)
+ *
+ * 1초마다 활성 대기열을 조회하고, 회차별로 상위 10명을 승인하여 Queue Token을 발급한다.
+ * fixedDelay: 이전 실행 완료 후 interval 대기 (fixedRate 아님 — 처리 지연 누적 방지)
+ *
+ * 처리량: 10명/초 × 3600초 = 36,000명/시간 (REQ-QUEUE-005)
+ */
+@Component
+class BatchApproveScheduler(
+    private val queueService: QueueService
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    @Scheduled(fixedDelayString = "\${queue.batch.interval}")
+    fun executeBatchApprove() {
+        val scheduleIds = queueService.getActiveScheduleIds()
+        if (scheduleIds.isEmpty()) return
+
+        for (rawId in scheduleIds) {
+            val scheduleId = try {
+                UUID.fromString(rawId)
+            } catch (e: IllegalArgumentException) {
+                logger.warn { "Invalid scheduleId format in active-schedules, skipping: $rawId" }
+                continue
+            }
+
+            try {
+                queueService.batchApprove(scheduleId)
+            } catch (e: Exception) {
+                logger.error(e) { "Batch approve failed for scheduleId=$scheduleId, continuing with remaining schedules" }
+            }
+        }
+    }
+}

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
@@ -27,6 +27,7 @@ class QueueService(
     private val queueStatusScript: DefaultRedisScript<List<*>>,
     private val queueLeaveScript: DefaultRedisScript<List<*>>,
     private val rateLimitScript: DefaultRedisScript<Long>,
+    private val batchApproveScript: DefaultRedisScript<Long>,
     private val queueProperties: QueueProperties,
     private val meterRegistry: MeterRegistry
 ) {
@@ -35,6 +36,9 @@ class QueueService(
 
     private val rateLimitFailOpenCounter: Counter =
         meterRegistry.counter("queue.ratelimit.failopen.total")
+
+    private val batchApproveCounter: Counter =
+        meterRegistry.counter("queue.batch.approved.total")
 
     /**
      * 대기열 진입 처리 (REQ-QUEUE-001)
@@ -50,7 +54,11 @@ class QueueService(
      *       Event Service 내부 API 호출 또는 Gateway 레벨 검증 필요 (GitHub Issue #163)
      */
     fun enterQueue(userId: UUID, scheduleId: UUID): QueueDto.EnterResponse {
-        val keys = listOf(QueueRedisKeys.queue(scheduleId), QueueRedisKeys.active(userId))
+        val keys = listOf(
+            QueueRedisKeys.queue(scheduleId),
+            QueueRedisKeys.active(userId),
+            QueueRedisKeys.activeSchedules()
+        )
         val args = arrayOf(
             userId.toString(),
             System.currentTimeMillis().toString(),
@@ -178,6 +186,59 @@ class QueueService(
                 QueueDto.LeaveResponse(message = "Removed from queue")
             }
             else -> throw QueueException(ErrorCode.INTERNAL_SERVER_ERROR)
+        }
+    }
+
+    /**
+     * 배치 승인 처리 (REQ-QUEUE-005)
+     *
+     * 대기열 Sorted Set에서 상위 batchSize명을 원자적으로 추출하고 Queue Token을 발급한다.
+     * Token UUID는 Lua 내부에서 생성 불가하므로 Kotlin에서 사전 생성하여 ARGV로 전달한다.
+     *
+     * @return 실제 승인된 사용자 수 (대기열이 비어 있으면 0)
+     */
+    fun batchApprove(scheduleId: UUID): Long {
+        val batchSize = queueProperties.batch.size
+        val tokens = (1..batchSize).map { UUID.randomUUID().toString() }
+
+        val keys = listOf(
+            QueueRedisKeys.queue(scheduleId),
+            QueueRedisKeys.activeSchedules()
+        )
+        val fixedArgs = arrayOf(
+            batchSize.toString(),
+            scheduleId.toString(),
+            queueProperties.token.ttl.toString(),
+            queueProperties.activeUser.ttl.toString(),
+            System.currentTimeMillis().toString()
+        )
+        val args = fixedArgs + tokens.toTypedArray()
+
+        return try {
+            val approved = stringRedisTemplate.execute(batchApproveScript, keys, *args) ?: 0L
+            if (approved > 0) {
+                logger.info { "Batch approve completed: scheduleId=$scheduleId, approved=$approved" }
+                batchApproveCounter.increment(approved.toDouble())
+            }
+            approved
+        } catch (e: Exception) {
+            logger.error(e) { "Batch approve failed: scheduleId=$scheduleId" }
+            throw QueueException(ErrorCode.INTERNAL_SERVER_ERROR, "배치 승인 처리 중 오류가 발생했습니다.", e)
+        }
+    }
+
+    /**
+     * 활성 대기열 scheduleId 목록 조회
+     *
+     * SMEMBERS queue:active-schedules 를 통해 현재 대기 중인 회차 ID를 반환한다.
+     * Redis 장애 시 빈 Set을 반환하여 배치 승인 스케줄러가 중단되지 않도록 한다.
+     */
+    fun getActiveScheduleIds(): Set<String> {
+        return try {
+            stringRedisTemplate.opsForSet().members(QueueRedisKeys.activeSchedules()) ?: emptySet()
+        } catch (e: Exception) {
+            logger.error(e) { "Failed to get active schedule IDs" }
+            emptySet()
         }
     }
 

--- a/backend/queue-service/src/main/resources/lua/batch-approve.lua
+++ b/backend/queue-service/src/main/resources/lua/batch-approve.lua
@@ -1,30 +1,61 @@
 --[[
   배치 승인 Lua 스크립트 (REQ-QUEUE-005)
 
-  대기열 Sorted Set에서 상위 N명을 원자적으로 추출하고 제거한다.
+  대기열 Sorted Set에서 상위 N명을 원자적으로 추출하고,
+  Queue Token을 발급하여 ACTIVE 상태로 전환한다.
 
-  KEYS[1] = queue:{scheduleId}
-  ARGV[1] = batchSize (기본 10)
+  KEYS[1] = queue:{scheduleId}          -- 대기열 Sorted Set
+  KEYS[2] = queue:active-schedules      -- 활성 회차 추적 SET
 
-  Returns: 승인된 userId 목록
+  ARGV[1] = batchSize                   -- 한 번에 승인할 최대 인원
+  ARGV[2] = scheduleId                  -- 회차 ID (토큰 데이터, SREM에 사용)
+  ARGV[3] = tokenTtl                    -- queue:token / queue:user-token TTL (초)
+  ARGV[4] = activeUserTtl              -- queue:active TTL 갱신 값 (초)
+  ARGV[5] = issuedAt                    -- 토큰 발급 시각 (Unix ms, 문자열)
+  ARGV[6..6+N-1] = 사전 생성된 token UUID 목록 (N = batchSize)
+
+  Returns: 실제 승인된 사용자 수 (Long)
 ]]
 
-local queueKey = KEYS[1]
-local batchSize = tonumber(ARGV[1]) or 10
+local queueKey         = KEYS[1]
+local activeSchedules  = KEYS[2]
 
+local batchSize    = tonumber(ARGV[1]) or 10
+local scheduleId   = ARGV[2]
+local tokenTtl     = tonumber(ARGV[3])
+local activeUserTtl = tonumber(ARGV[4])
+local issuedAt     = ARGV[5]
+
+-- Step 1: 대기열 상위 N명 조회
 local members = redis.call('ZRANGE', queueKey, 0, batchSize - 1)
 
-if #members > 0 then
-    redis.call('ZREM', queueKey, unpack(members))
+-- Step 2: 대기열이 비어 있으면 active-schedules에서 제거 후 즉시 반환
+if #members == 0 then
+    redis.call('SREM', activeSchedules, scheduleId)
+    return 0
 end
 
--- TODO(Issue #44): 배치 승인 완료 후 역방향 토큰 조회 키를 반드시 SET해야 함
--- queue-status.lua (KEYS[2])가 아래 키를 GET하여 ACTIVE 상태를 판단한다.
--- 미구현 시 배치 승인된 사용자가 NOT_IN_QUEUE로 표시됨 (ACTIVE 분기가 dead code)
--- 구현 예시 (scheduleId, token, tokenTtl을 ARGV로 추가 전달 필요):
---   for _, userId in ipairs(members) do
---     local token = generateToken(userId)  -- Token 생성 로직 별도 구현
---     redis.call('SET', 'queue:user-token:' .. userId .. ':' .. scheduleId, token, 'EX', tokenTtl)
---   end
+-- Step 3: Sorted Set에서 원자적 제거
+redis.call('ZREM', queueKey, unpack(members))
 
-return members
+-- Step 4: 각 사용자에 대해 Token 발급 및 ACTIVE 상태 전환
+for i, userId in ipairs(members) do
+    local token = ARGV[5 + i]  -- ARGV[6] = 첫 번째 토큰, ARGV[7] = 두 번째 토큰, ...
+
+    -- queue:token:{token} — 토큰 메타데이터 (다른 서비스에서 검증용)
+    local tokenData = '{"userId":"' .. userId .. '","scheduleId":"' .. scheduleId .. '","issuedAt":"' .. issuedAt .. '"}'
+    redis.call('SET', 'queue:token:' .. token, tokenData, 'EX', tokenTtl)
+
+    -- queue:user-token:{userId}:{scheduleId} — 역방향 토큰 조회 키 (queue-status.lua가 ACTIVE 판단에 사용)
+    redis.call('SET', 'queue:user-token:' .. userId .. ':' .. scheduleId, token, 'EX', tokenTtl)
+
+    -- queue:active:{userId} TTL 갱신 — 배치 승인 후에도 이탈 시 정리 가능하도록 유지
+    redis.call('EXPIRE', 'queue:active:' .. userId, activeUserTtl)
+end
+
+-- Step 5: 대기열이 비었으면 active-schedules에서 제거
+if redis.call('ZCARD', queueKey) == 0 then
+    redis.call('SREM', activeSchedules, scheduleId)
+end
+
+return #members

--- a/backend/queue-service/src/main/resources/lua/batch-approve.lua
+++ b/backend/queue-service/src/main/resources/lua/batch-approve.lua
@@ -48,7 +48,7 @@ for i, userId in ipairs(members) do
     local token = ARGV[5 + i]  -- ARGV[6] = 첫 번째 토큰, ARGV[7] = 두 번째 토큰, ...
 
     -- queue:token:{token} — 토큰 메타데이터 (다른 서비스에서 검증용)
-    local tokenData = '{"userId":"' .. userId .. '","scheduleId":"' .. scheduleId .. '","issuedAt":"' .. issuedAt .. '"}'
+    local tokenData = cjson.encode({ userId = userId, scheduleId = scheduleId, issuedAt = issuedAt })
     redis.call('SET', 'queue:token:' .. token, tokenData, 'EX', tokenTtl)
 
     -- queue:user-token:{userId}:{scheduleId} — 역방향 토큰 조회 키 (queue-status.lua가 ACTIVE 판단에 사용)

--- a/backend/queue-service/src/main/resources/lua/batch-approve.lua
+++ b/backend/queue-service/src/main/resources/lua/batch-approve.lua
@@ -26,6 +26,11 @@ local tokenTtl     = tonumber(ARGV[3])
 local activeUserTtl = tonumber(ARGV[4])
 local issuedAt     = ARGV[5]
 
+-- TTL 유효성 검증: ZREM 이전에 실패하여 데이터 유실 방지
+if not tokenTtl or tokenTtl <= 0 or not activeUserTtl or activeUserTtl <= 0 then
+    return redis.error_reply('INVALID_TTL: tokenTtl and activeUserTtl must be positive integers')
+end
+
 -- Step 1: 대기열 상위 N명 조회
 local members = redis.call('ZRANGE', queueKey, 0, batchSize - 1)
 
@@ -49,8 +54,8 @@ for i, userId in ipairs(members) do
     -- queue:user-token:{userId}:{scheduleId} — 역방향 토큰 조회 키 (queue-status.lua가 ACTIVE 판단에 사용)
     redis.call('SET', 'queue:user-token:' .. userId .. ':' .. scheduleId, token, 'EX', tokenTtl)
 
-    -- queue:active:{userId} TTL 갱신 — 배치 승인 후에도 이탈 시 정리 가능하도록 유지
-    redis.call('EXPIRE', 'queue:active:' .. userId, activeUserTtl)
+    -- queue:active:{userId} TTL 갱신 — EXPIRE는 키 부재 시 무시되므로 SET EX로 재설정
+    redis.call('SET', 'queue:active:' .. userId, scheduleId, 'EX', activeUserTtl)
 end
 
 -- Step 5: 대기열이 비었으면 active-schedules에서 제거

--- a/backend/queue-service/src/main/resources/lua/queue-enter.lua
+++ b/backend/queue-service/src/main/resources/lua/queue-enter.lua
@@ -3,8 +3,9 @@
 
   ZCARD, ZADD, SET 간의 Race Condition을 단일 원자적 실행으로 해결한다.
 
-  KEYS[1] = queue:{scheduleId}      -- 대기열 Sorted Set
-  KEYS[2] = queue:active:{userId}   -- 중복 대기 방지 키
+  KEYS[1] = queue:{scheduleId}          -- 대기열 Sorted Set
+  KEYS[2] = queue:active:{userId}       -- 중복 대기 방지 키
+  KEYS[3] = queue:active-schedules      -- 활성 회차 추적 SET (배치 승인 대상 탐색용)
 
   ARGV[1] = userId                  -- 대기열에 추가할 사용자 ID
   ARGV[2] = timestamp               -- score (진입 시각, Unix ms)
@@ -20,8 +21,9 @@
     {4, -1}   : 이미 배치 승인 완료 — Sorted Set에 존재하지 않음 (ALREADY_APPROVED)
 ]]
 
-local queueKey    = KEYS[1]
-local activeKey   = KEYS[2]
+local queueKey        = KEYS[1]
+local activeKey       = KEYS[2]
+local activeSchedules = KEYS[3]
 
 local userId       = ARGV[1]
 local timestamp    = ARGV[2]
@@ -57,6 +59,10 @@ end
 -- Step 3: 대기열 진입 (REQ-QUEUE-001)
 -- NX 옵션: 이미 존재하는 멤버는 score 변경 없이 무시
 redis.call('ZADD', queueKey, 'NX', timestamp, userId)
+
+-- Step 3-1: 활성 회차 목록에 등록 (배치 승인 스케줄러가 SMEMBERS로 조회)
+-- SADD는 멱등적이므로 동일 scheduleId 중복 등록 무해
+redis.call('SADD', activeSchedules, scheduleId)
 
 -- Step 4: 중복 대기 방지 키 등록
 redis.call('SET', activeKey, scheduleId, 'EX', activeUserTtl)

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/integration/BatchApproveIntegrationTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/integration/BatchApproveIntegrationTest.kt
@@ -3,7 +3,7 @@ package com.ticketqueue.queue.integration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.queue.scheduler.BatchApproveScheduler
 import com.ticketqueue.queue.service.QueueService
-import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.longs.shouldBeBetween
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.BeforeEach
@@ -77,7 +77,8 @@ class BatchApproveIntegrationTest {
 
     @BeforeEach
     fun flushRedis() {
-        stringRedisTemplate.connectionFactory!!.connection.use { it.serverCommands().flushAll() }
+        requireNotNull(stringRedisTemplate.connectionFactory) { "RedisConnectionFactory is not configured" }
+            .connection.use { it.serverCommands().flushAll() }
     }
 
     private fun enterRequest(uid: UUID = userId, sid: UUID = scheduleId) = post("/queue/enter")
@@ -106,7 +107,7 @@ class BatchApproveIntegrationTest {
         stringRedisTemplate.hasKey(tokenKey) shouldBe true
 
         val ttl = stringRedisTemplate.getExpire(tokenKey, TimeUnit.SECONDS)
-        ttl shouldBeGreaterThan 0L
+        ttl.shouldBeBetween(590L, 600L)
     }
 
     @Test
@@ -120,7 +121,7 @@ class BatchApproveIntegrationTest {
         stringRedisTemplate.hasKey(userTokenKey) shouldBe true
 
         val ttl = stringRedisTemplate.getExpire(userTokenKey, TimeUnit.SECONDS)
-        ttl shouldBeGreaterThan 0L
+        ttl.shouldBeBetween(590L, 600L)
     }
 
     @Test

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/integration/BatchApproveIntegrationTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/integration/BatchApproveIntegrationTest.kt
@@ -168,6 +168,11 @@ class BatchApproveIntegrationTest {
         userIds.forEach { uid ->
             val userTokenKey = "queue:user-token:$uid:$scheduleId"
             stringRedisTemplate.hasKey(userTokenKey) shouldBe true
+
+            // queue:active:{userId} 키 검증
+            val activeKey = "queue:active:$uid"
+            stringRedisTemplate.hasKey(activeKey) shouldBe true
+            stringRedisTemplate.opsForValue().get(activeKey) shouldBe scheduleId.toString()
         }
     }
 }

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/integration/BatchApproveIntegrationTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/integration/BatchApproveIntegrationTest.kt
@@ -1,0 +1,172 @@
+package com.ticketqueue.queue.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.queue.scheduler.BatchApproveScheduler
+import com.ticketqueue.queue.service.QueueService
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Testcontainers
+@TestPropertySource(properties = [
+    "spring.cloud.aws.region.static=us-east-1",
+    "spring.cloud.aws.credentials.access-key=test",
+    "spring.cloud.aws.credentials.secret-key=test"
+])
+@DisplayName("배치 승인 통합 테스트")
+class BatchApproveIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val valkey = GenericContainer("valkey/valkey:8.1-alpine")
+            .withExposedPorts(6379)
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun redisProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.data.redis.host") { valkey.host }
+            registry.add("spring.data.redis.port") { valkey.getMappedPort(6379) }
+        }
+    }
+
+    // 자동 스케줄링 비활성화 — 테스트에서 batchApprove를 직접 호출
+    @MockitoBean
+    private lateinit var batchApproveScheduler: BatchApproveScheduler
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var queueService: QueueService
+
+    @Autowired
+    private lateinit var stringRedisTemplate: StringRedisTemplate
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    private val userId = UUID.randomUUID()
+    private val scheduleId = UUID.randomUUID()
+
+    @BeforeEach
+    fun flushRedis() {
+        stringRedisTemplate.connectionFactory!!.connection.use { it.serverCommands().flushAll() }
+    }
+
+    private fun enterRequest(uid: UUID = userId, sid: UUID = scheduleId) = post("/queue/enter")
+        .header("X-User-Id", uid.toString())
+        .header("X-User-Role", "USER")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(mapOf("scheduleId" to sid.toString())))
+
+    private fun statusRequest(uid: UUID = userId, sid: UUID = scheduleId) = get("/queue/status")
+        .header("X-User-Id", uid.toString())
+        .header("X-User-Role", "USER")
+        .param("scheduleId", sid.toString())
+
+    @Test
+    @DisplayName("배치 승인 후 queue:token:{token} 키가 생성되고 TTL이 설정된다")
+    fun batchApprove_createsTokenKeyWithTtl() {
+        mockMvc.perform(enterRequest()).andExpect(status().isOk)
+
+        queueService.batchApprove(scheduleId)
+
+        val userTokenKey = "queue:user-token:$userId:$scheduleId"
+        val token = stringRedisTemplate.opsForValue().get(userTokenKey)
+        token shouldNotBe null
+
+        val tokenKey = "queue:token:$token"
+        stringRedisTemplate.hasKey(tokenKey) shouldBe true
+
+        val ttl = stringRedisTemplate.getExpire(tokenKey, TimeUnit.SECONDS)
+        ttl shouldBeGreaterThan 0L
+    }
+
+    @Test
+    @DisplayName("배치 승인 후 queue:user-token:{userId}:{scheduleId} 키가 생성된다")
+    fun batchApprove_createsUserTokenKey() {
+        mockMvc.perform(enterRequest()).andExpect(status().isOk)
+
+        queueService.batchApprove(scheduleId)
+
+        val userTokenKey = "queue:user-token:$userId:$scheduleId"
+        stringRedisTemplate.hasKey(userTokenKey) shouldBe true
+
+        val ttl = stringRedisTemplate.getExpire(userTokenKey, TimeUnit.SECONDS)
+        ttl shouldBeGreaterThan 0L
+    }
+
+    @Test
+    @DisplayName("배치 승인 후 getQueueStatus가 ACTIVE 상태와 token을 반환한다")
+    fun batchApprove_statusBecomesActive() {
+        mockMvc.perform(enterRequest()).andExpect(status().isOk)
+
+        queueService.batchApprove(scheduleId)
+
+        mockMvc.perform(statusRequest())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("ACTIVE"))
+            .andExpect(jsonPath("$.token").isNotEmpty)
+    }
+
+    @Test
+    @DisplayName("빈 대기열에 배치 승인 시 0을 반환하고 active-schedules에서 제거된다")
+    fun batchApprove_emptyQueue_returnsZeroAndRemovesFromActiveSchedules() {
+        // active-schedules에 직접 추가 (대기열 없이)
+        stringRedisTemplate.opsForSet().add("queue:active-schedules", scheduleId.toString())
+
+        val approved = queueService.batchApprove(scheduleId)
+
+        approved shouldBe 0L
+        stringRedisTemplate.opsForSet().isMember("queue:active-schedules", scheduleId.toString()) shouldBe false
+    }
+
+    @Test
+    @DisplayName("batchSize보다 적은 사용자가 있으면 실제 수만큼만 토큰을 발급한다")
+    fun batchApprove_fewerUsersThanBatchSize_issuesExactCount() {
+        val userCount = 3
+        val userIds = (1..userCount).map { UUID.randomUUID() }
+
+        // 3명 진입
+        userIds.forEach { uid ->
+            mockMvc.perform(enterRequest(uid = uid)).andExpect(status().isOk)
+        }
+
+        val approved = queueService.batchApprove(scheduleId)
+
+        approved shouldBe userCount.toLong()
+
+        // 각 사용자별 토큰 키 생성 확인
+        userIds.forEach { uid ->
+            val userTokenKey = "queue:user-token:$uid:$scheduleId"
+            stringRedisTemplate.hasKey(userTokenKey) shouldBe true
+        }
+    }
+}

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/scheduler/BatchApproveSchedulerTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/scheduler/BatchApproveSchedulerTest.kt
@@ -1,0 +1,77 @@
+package com.ticketqueue.queue.scheduler
+
+import com.ticketqueue.queue.service.QueueService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+@DisplayName("BatchApproveScheduler 단위 테스트")
+class BatchApproveSchedulerTest {
+
+    private lateinit var queueService: QueueService
+    private lateinit var scheduler: BatchApproveScheduler
+
+    @BeforeEach
+    fun setUp() {
+        queueService = mockk()
+        scheduler = BatchApproveScheduler(queueService)
+    }
+
+    @Test
+    @DisplayName("활성 스케줄이 없으면 batchApprove를 호출하지 않는다")
+    fun doesNotCallBatchApproveWhenNoActiveSchedules() {
+        every { queueService.getActiveScheduleIds() } returns emptySet()
+
+        scheduler.executeBatchApprove()
+
+        verify(exactly = 0) { queueService.batchApprove(any()) }
+    }
+
+    @Test
+    @DisplayName("활성 스케줄마다 batchApprove를 호출한다")
+    fun callsBatchApproveForEachActiveSchedule() {
+        val id1 = UUID.randomUUID()
+        val id2 = UUID.randomUUID()
+        every { queueService.getActiveScheduleIds() } returns setOf(id1.toString(), id2.toString())
+        every { queueService.batchApprove(any()) } returns 5L
+
+        scheduler.executeBatchApprove()
+
+        verify(exactly = 1) { queueService.batchApprove(id1) }
+        verify(exactly = 1) { queueService.batchApprove(id2) }
+    }
+
+    @Test
+    @DisplayName("하나의 스케줄 처리 실패 시 나머지 스케줄을 계속 처리한다")
+    fun continuesProcessingRemainingSchedulesOnFailure() {
+        val failingId = UUID.randomUUID()
+        val successId = UUID.randomUUID()
+        // getActiveScheduleIds 반환 순서를 보장하기 위해 LinkedHashSet 사용
+        every { queueService.getActiveScheduleIds() } returns linkedSetOf(failingId.toString(), successId.toString())
+        every { queueService.batchApprove(failingId) } throws RuntimeException("Redis timeout")
+        every { queueService.batchApprove(successId) } returns 3L
+
+        scheduler.executeBatchApprove()
+
+        verify(exactly = 1) { queueService.batchApprove(failingId) }
+        verify(exactly = 1) { queueService.batchApprove(successId) }
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 UUID 형식의 scheduleId는 건너뛴다")
+    fun skipsInvalidUuidFormat() {
+        val validId = UUID.randomUUID()
+        every { queueService.getActiveScheduleIds() } returns setOf("not-a-uuid", validId.toString())
+        every { queueService.batchApprove(validId) } returns 2L
+
+        scheduler.executeBatchApprove()
+
+        verify(exactly = 1) { queueService.batchApprove(validId) }
+        // "not-a-uuid"는 UUID.fromString 실패 → skip → batchApprove 호출 안 됨
+        verify(exactly = 1) { queueService.batchApprove(any()) }
+    }
+}

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/QueueServiceTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/QueueServiceTest.kt
@@ -27,6 +27,7 @@ class QueueServiceTest {
     private lateinit var queueStatusScript: DefaultRedisScript<List<*>>
     private lateinit var queueLeaveScript: DefaultRedisScript<List<*>>
     private lateinit var rateLimitScript: DefaultRedisScript<Long>
+    private lateinit var batchApproveScript: DefaultRedisScript<Long>
     private lateinit var queueProperties: QueueProperties
     private lateinit var meterRegistry: SimpleMeterRegistry
     private lateinit var queueService: QueueService
@@ -41,6 +42,7 @@ class QueueServiceTest {
         queueStatusScript = mockk()
         queueLeaveScript = mockk()
         rateLimitScript = mockk()
+        batchApproveScript = mockk()
         queueProperties = QueueProperties(
             batch = QueueProperties.BatchProperties(size = 10, interval = 1000),
             rateLimit = QueueProperties.RateLimitProperties(maxRequests = 15, windowSeconds = 60)
@@ -52,6 +54,7 @@ class QueueServiceTest {
             queueStatusScript,
             queueLeaveScript,
             rateLimitScript,
+            batchApproveScript,
             queueProperties,
             meterRegistry
         )
@@ -297,6 +300,79 @@ class QueueServiceTest {
                 queueService.leaveQueue(userId, scheduleId)
             }
             assertEquals(ErrorCode.INTERNAL_SERVER_ERROR, exception.errorCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("batchApprove")
+    inner class BatchApprove {
+
+        @Test
+        @DisplayName("승인 성공 시 승인 수를 반환하고 메트릭 카운터를 증가시킨다")
+        fun returnsApprovedCountAndIncrementsMetric() {
+            every {
+                stringRedisTemplate.execute(batchApproveScript, any(), *anyVararg<String>())
+            } returns 5L
+
+            val result = queueService.batchApprove(scheduleId)
+
+            assertEquals(5L, result)
+            val counter = meterRegistry.find("queue.batch.approved.total").counter()
+            assertEquals(5.0, counter?.count())
+        }
+
+        @Test
+        @DisplayName("대기열이 비어 있으면 0을 반환하고 메트릭을 증가시키지 않는다")
+        fun returnsZeroAndDoesNotIncrementMetricWhenEmpty() {
+            every {
+                stringRedisTemplate.execute(batchApproveScript, any(), *anyVararg<String>())
+            } returns 0L
+
+            val result = queueService.batchApprove(scheduleId)
+
+            assertEquals(0L, result)
+            // counter가 존재하지 않거나 count=0이어야 함
+            val counter = meterRegistry.find("queue.batch.approved.total").counter()
+            assertEquals(0.0, counter?.count() ?: 0.0)
+        }
+
+        @Test
+        @DisplayName("Redis 실행 실패 시 INTERNAL_SERVER_ERROR를 던진다")
+        fun throwsInternalErrorWhenRedisFailure() {
+            every {
+                stringRedisTemplate.execute(batchApproveScript, any(), *anyVararg<String>())
+            } throws RuntimeException("Redis connection refused")
+
+            val exception = assertThrows<QueueException> {
+                queueService.batchApprove(scheduleId)
+            }
+            assertEquals(ErrorCode.INTERNAL_SERVER_ERROR, exception.errorCode)
+        }
+
+        @Test
+        @DisplayName("batchSize만큼의 token UUID를 ARGV에 전달한다")
+        fun passesCorrectNumberOfTokenUuidsAsArgs() {
+            val capturedArgs = mutableListOf<String>()
+            every {
+                stringRedisTemplate.execute(batchApproveScript, any(), *anyVararg<String>())
+            } answers {
+                // invocation.args: [script, keys, arg1, arg2, ...]
+                // vararg는 배열로 전달됨
+                val varargs = it.invocation.args[2] as Array<*>
+                capturedArgs.addAll(varargs.map { a -> a.toString() })
+                3L
+            }
+
+            queueService.batchApprove(scheduleId)
+
+            // fixedArgs(5개) + tokens(batchSize=10개) = 15개
+            val batchSize = queueProperties.batch.size
+            assertEquals(5 + batchSize, capturedArgs.size)
+            // 마지막 batchSize개의 args가 유효한 UUID 형식인지 검증
+            val tokenArgs = capturedArgs.drop(5)
+            tokenArgs.forEach { token ->
+                UUID.fromString(token) // 파싱 실패 시 IllegalArgumentException
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- 배치 승인 Lua 스크립트(`batch-approve.lua`)를 재작성하여 Queue Token 발급 로직 구현
- `BatchApproveScheduler`를 신규 구현하여 1초 주기로 대기열을 자동 처리
- 배치 승인 후 `queue-status.lua`가 ACTIVE 상태를 정확히 반환하도록 Redis 키 구조 완성

Closes #44

## Changes
- `batch-approve.lua` 재작성: ZRANGE+ZREM 후 각 사용자에게 `queue:token:{token}`, `queue:user-token:{userId}:{scheduleId}` 키 발급, 대기열 소진 시 `active-schedules`에서 SREM
- `queue-enter.lua`: `KEYS[3] = queue:active-schedules` 추가, ZADD 후 `SADD` 호출하여 배치 승인 대상 회차 추적
- `QueueRedisKeys`: `activeSchedules()` 메서드 추가 (`"queue:active-schedules"`)
- `RedisConfig`: `batchApproveScript` 반환 타입 `List<*>` → `Long`으로 변경
- `QueueService`: `batchApprove(scheduleId)`, `getActiveScheduleIds()` 메서드 추가, `enterQueue` keys에 `activeSchedules()` 포함
- `BatchApproveScheduler` 신규: `@Scheduled(fixedDelayString = "${queue.batch.interval}")`, 개별 실패 시 나머지 회차 계속 처리, 잘못된 UUID 형식 skip

## Test plan
- [x] `QueueServiceTest` - `batchApprove` 단위 테스트 4개 추가 (승인 수 반환, 빈 대기열, Redis 실패, UUID token 개수 검증)
- [x] `BatchApproveSchedulerTest` - 스케줄러 단위 테스트 4개 (활성 스케줄 없음, 다수 스케줄 처리, 부분 실패 시 계속 처리, 잘못된 UUID skip)
- [x] `BatchApproveIntegrationTest` - Testcontainers(Valkey) 통합 테스트 5개 (token 키 생성+TTL, user-token 키 생성, ACTIVE 상태 전환, 빈 대기열 처리, batchSize보다 적은 사용자)
- [x] 전체 테스트 통과 확인: `./gradlew :queue-service:test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated batch-approval scheduler to process queued users at configurable intervals.
  * Active-schedule tracking to coordinate batch processing and registration when users enter a queue.
  * Atomic token issuance during batch approvals with configurable TTLs; user status transitions to ACTIVE and backward token lookup keys created.
  * Returns numeric approval counts for batch operations.

* **Tests**
  * New integration and unit tests covering batch approvals, token creation/TTLs, scheduler resilience, metrics, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->