### PR TITLE
feat: [Frontend] 공연 상세 페이지 (SSR + SEO + JSON-LD) #116

### DIFF
--- a/frontend/e2e/event-detail.spec.ts
+++ b/frontend/e2e/event-detail.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * Issue #116 — 공연 상세 페이지 E2E 테스트
+ *
+ * 테스트 전제:
+ *   - Docker 인프라 실행 중 (PostgreSQL:5432)
+ *   - API Gateway (8080) + Event Service 실행 중
+ *   - Playwright webServer가 자동으로 Next.js dev 서버 실행
+ *
+ * SSR 전략:
+ *   - SSR 페이지는 서버에서 fetch()를 직접 호출하므로 page.route()로 인터셉트 불가
+ *   - PostgreSQL에 직접 테스트 데이터를 INSERT하여 실제 렌더링 결과 검증
+ */
+
+import { test, expect } from '@playwright/test'
+import { seedTestEvent, TEST_EVENT_IDS, TEST_EVENT } from './helpers/seed-event'
+
+const EVENT_URL = `/events/${TEST_EVENT_IDS.eventId}`
+const NOT_FOUND_URL = `/events/00000000-0000-0000-0000-000000000999`
+
+test.describe('Issue #116 — 공연 상세 페이지 (SSR + SEO + JSON-LD)', () => {
+  test.beforeAll(async () => {
+    // DB에 테스트 공연 데이터 삽입 (이미 있으면 스킵)
+    await seedTestEvent()
+  })
+
+  // ────────────────────────────────────────────────────────
+  // 1. 페이지 렌더링 검증
+  // ────────────────────────────────────────────────────────
+  test('공연 상세 페이지가 SSR로 올바르게 렌더링된다', async ({ page }) => {
+    await page.goto(EVENT_URL)
+
+    // 공연 제목 (h1)
+    await expect(page.locator('h1')).toHaveText(TEST_EVENT.title)
+
+    // 아티스트
+    await expect(page.getByText(TEST_EVENT.artist).first()).toBeVisible()
+
+    // 공연장 정보
+    await expect(page.getByText(new RegExp(TEST_EVENT.venueName))).toBeVisible()
+    await expect(page.getByText(new RegExp(TEST_EVENT.hallName))).toBeVisible()
+
+    // 공연 설명
+    await expect(page.getByText(TEST_EVENT.description)).toBeVisible()
+  })
+
+  // ────────────────────────────────────────────────────────
+  // 2. SEO 메타 태그 검증
+  // ────────────────────────────────────────────────────────
+  test('SEO 메타 태그와 canonical URL이 올바르게 설정된다', async ({ page }) => {
+    await page.goto(EVENT_URL)
+
+    // <title> — 루트 레이아웃 template "%s | Ticket Queue" 적용
+    await expect(page).toHaveTitle(`${TEST_EVENT.title} | Ticket Queue`)
+
+    // Open Graph 태그
+    const ogTitle = page.locator('meta[property="og:title"]')
+    await expect(ogTitle).toHaveAttribute('content', TEST_EVENT.title)
+
+    const ogDescription = page.locator('meta[property="og:description"]')
+    await expect(ogDescription).toHaveAttribute('content', /.+/)
+
+    // Canonical URL
+    const canonical = page.locator('link[rel="canonical"]')
+    await expect(canonical).toHaveAttribute(
+      'href',
+      `https://ticket-queue.com/events/${TEST_EVENT_IDS.eventId}`,
+    )
+  })
+
+  // ────────────────────────────────────────────────────────
+  // 3. JSON-LD Structured Data 검증
+  // ────────────────────────────────────────────────────────
+  test('JSON-LD Structured Data가 올바른 Schema.org Event 형식으로 삽입된다', async ({ page }) => {
+    await page.goto(EVENT_URL)
+
+    const scriptContent = await page
+      .locator('script[type="application/ld+json"]')
+      .first()
+      .textContent()
+
+    expect(scriptContent).not.toBeNull()
+    const jsonLd = JSON.parse(scriptContent!)
+
+    expect(jsonLd['@context']).toBe('https://schema.org')
+    expect(jsonLd['@type']).toBe('Event')
+    expect(jsonLd.name).toBe(TEST_EVENT.title)
+    expect(jsonLd.performer).toMatchObject({ '@type': 'Person', name: TEST_EVENT.artist })
+    expect(jsonLd.location).toMatchObject({
+      '@type': 'Place',
+      name: TEST_EVENT.venueName,
+    })
+  })
+
+  // ────────────────────────────────────────────────────────
+  // 4. 공연 일정 목록 검증
+  // ────────────────────────────────────────────────────────
+  test('공연 일정이 날짜별 그룹으로 표시된다', async ({ page }) => {
+    await page.goto(EVENT_URL)
+
+    // 섹션 제목
+    await expect(page.getByRole('heading', { name: '공연 일정' })).toBeVisible()
+
+    // 날짜 헤더 (2026-06-01 = 월요일, 2026-06-02 = 화요일)
+    await expect(page.getByText('2026.06.01 (월)')).toBeVisible()
+    await expect(page.getByText('2026.06.02 (화)')).toBeVisible()
+
+    // 1회차 시간대
+    await expect(page.getByText('19:00 ~ 22:00')).toBeVisible()
+
+    // "예매하기" 버튼 (1회차 — 미매진)
+    const bookingButton = page.getByRole('link', { name: '예매하기' }).first()
+    await expect(bookingButton).toBeVisible()
+    await expect(bookingButton).toHaveAttribute('href', `/queue/${TEST_EVENT_IDS.schedule1Id}`)
+  })
+
+  // ────────────────────────────────────────────────────────
+  // 5. 매진 회차 처리 검증
+  // ────────────────────────────────────────────────────────
+  test('매진 회차는 "매진" 배지와 비활성화된 버튼으로 표시된다', async ({ page }) => {
+    await page.goto(EVENT_URL)
+
+    // "매진" 배지 표시
+    await expect(page.getByText('매진').first()).toBeVisible()
+
+    // 2회차 시간대
+    await expect(page.getByText('17:00 ~ 20:00')).toBeVisible()
+
+    // 비활성화된 버튼 — 매진 버튼은 disabled
+    const soldOutButtons = page.getByRole('button', { name: '매진' })
+    await expect(soldOutButtons.first()).toBeDisabled()
+  })
+
+  // ────────────────────────────────────────────────────────
+  // 6. 좌석 등급 및 가격 표시 검증
+  // ────────────────────────────────────────────────────────
+  test('좌석 등급별 이름과 가격이 올바르게 표시된다', async ({ page }) => {
+    await page.goto(EVENT_URL)
+
+    // 좌석 정보 섹션
+    await expect(page.getByRole('heading', { name: '좌석 정보' })).toBeVisible()
+
+    // VIP 등급 및 가격
+    await expect(page.getByText('VIP')).toBeVisible()
+    await expect(page.getByText('150,000원')).toBeVisible()
+
+    // S 등급 및 가격
+    await expect(page.getByText(/^S$/).first()).toBeVisible()
+    await expect(page.getByText('120,000원')).toBeVisible()
+  })
+
+  // ────────────────────────────────────────────────────────
+  // 7. 404 처리 검증
+  // ────────────────────────────────────────────────────────
+  test('존재하지 않는 공연 ID로 접속하면 not-found 페이지가 렌더링된다', async ({ page }) => {
+    await page.goto(NOT_FOUND_URL)
+
+    await expect(page.locator('h1')).toHaveText('404')
+    await expect(page.getByText('페이지를 찾을 수 없습니다')).toBeVisible()
+  })
+})

--- a/frontend/e2e/event-detail.spec.ts
+++ b/frontend/e2e/event-detail.spec.ts
@@ -89,6 +89,8 @@ test.describe('Issue #116 — 공연 상세 페이지 (SSR + SEO + JSON-LD)', ()
       '@type': 'Place',
       name: TEST_EVENT.venueName,
     })
+    expect(jsonLd.eventStatus).toBe('https://schema.org/EventScheduled')
+    expect(jsonLd.eventAttendanceMode).toBe('https://schema.org/OfflineEventAttendanceMode')
   })
 
   // ────────────────────────────────────────────────────────
@@ -155,6 +157,6 @@ test.describe('Issue #116 — 공연 상세 페이지 (SSR + SEO + JSON-LD)', ()
     await page.goto(NOT_FOUND_URL)
 
     await expect(page.locator('h1')).toHaveText('404')
-    await expect(page.getByText('페이지를 찾을 수 없습니다')).toBeVisible()
+    await expect(page.locator('main')).toContainText('페이지를 찾을 수 없습니다')
   })
 })

--- a/frontend/e2e/helpers/seed-event.ts
+++ b/frontend/e2e/helpers/seed-event.ts
@@ -41,8 +41,8 @@ export async function seedTestEvent(): Promise<void> {
     host: getRequiredEnv('DB_HOST'),
     port: parseInt(getRequiredEnv('DB_PORT'), 10),
     database: getRequiredEnv('DB_NAME'),
-    user: getRequiredEnv('DB_USER'),
-    password: getRequiredEnv('DB_PASSWORD'),
+    user: process.env.EVENT_DB_USER || getRequiredEnv('DB_USER'),
+    password: process.env.EVENT_DB_PASSWORD || getRequiredEnv('DB_PASSWORD'),
     options: '-c search_path=event_service',
   })
 
@@ -76,14 +76,15 @@ export async function seedTestEvent(): Promise<void> {
     await client.query(
       `INSERT INTO event_service.halls (id, venue_id, name, capacity, seat_template)
        VALUES ($1, $2, $3, $4, $5::jsonb)
-       ON CONFLICT (id) DO NOTHING`,
+       ON CONFLICT DO NOTHING`,
       [TEST_EVENT_IDS.hallId, TEST_EVENT_IDS.venueId, TEST_EVENT.hallName, 6, seatTemplate],
     )
 
     // 3. Event 삽입
     await client.query(
       `INSERT INTO event_service.events (id, title, artist, description, venue_id, hall_id, status)
-       VALUES ($1, $2, $3, $4, $5, $6, 'OPEN')`,
+       VALUES ($1, $2, $3, $4, $5, $6, 'OPEN')
+       ON CONFLICT DO NOTHING`,
       [
         TEST_EVENT_IDS.eventId,
         TEST_EVENT.title,
@@ -98,13 +99,14 @@ export async function seedTestEvent(): Promise<void> {
     await client.query(
       `INSERT INTO event_service.event_schedules
          (id, event_id, play_sequence, event_start_at, event_end_at, sale_start_at, sale_end_at, status)
-       VALUES ($1, $2, 1, $3, $4, $5, $6, 'UPCOMING')`,
+       VALUES ($1, $2, 1, $3, $4, $5, $6, 'UPCOMING')
+       ON CONFLICT DO NOTHING`,
       [
         TEST_EVENT_IDS.schedule1Id,
         TEST_EVENT_IDS.eventId,
         '2026-06-01T19:00:00',
         '2026-06-01T22:00:00',
-        '2026-05-01T20:00:00',
+        '2026-01-01T00:00:00',
         '2026-05-31T23:59:59',
       ],
     )
@@ -113,13 +115,14 @@ export async function seedTestEvent(): Promise<void> {
     await client.query(
       `INSERT INTO event_service.event_schedules
          (id, event_id, play_sequence, event_start_at, event_end_at, sale_start_at, sale_end_at, status)
-       VALUES ($1, $2, 2, $3, $4, $5, $6, 'UPCOMING')`,
+       VALUES ($1, $2, 2, $3, $4, $5, $6, 'UPCOMING')
+       ON CONFLICT DO NOTHING`,
       [
         TEST_EVENT_IDS.schedule2Id,
         TEST_EVENT_IDS.eventId,
         '2026-06-02T17:00:00',
         '2026-06-02T20:00:00',
-        '2026-05-02T20:00:00',
+        '2026-01-01T00:00:00',
         '2026-06-01T23:59:59',
       ],
     )
@@ -136,7 +139,8 @@ export async function seedTestEvent(): Promise<void> {
     for (const [seatNumber, grade, price, status] of schedule1Seats) {
       await client.query(
         `INSERT INTO event_service.seats (event_schedule_id, seat_number, grade, price, status)
-         VALUES ($1, $2, $3, $4, $5)`,
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT DO NOTHING`,
         [TEST_EVENT_IDS.schedule1Id, seatNumber, grade, price, status],
       )
     }
@@ -153,7 +157,8 @@ export async function seedTestEvent(): Promise<void> {
     for (const [seatNumber, grade, price, status] of schedule2Seats) {
       await client.query(
         `INSERT INTO event_service.seats (event_schedule_id, seat_number, grade, price, status)
-         VALUES ($1, $2, $3, $4, $5)`,
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT DO NOTHING`,
         [TEST_EVENT_IDS.schedule2Id, seatNumber, grade, price, status],
       )
     }

--- a/frontend/e2e/helpers/seed-event.ts
+++ b/frontend/e2e/helpers/seed-event.ts
@@ -1,0 +1,168 @@
+/**
+ * E2E 테스트용 공연 데이터 시딩 헬퍼
+ *
+ * event_service 스키마에 테스트 데이터를 직접 INSERT합니다.
+ * 고정 UUID를 사용하여 idempotent하게 동작합니다 (이미 존재하면 스킵).
+ */
+
+import { Client } from 'pg'
+
+function getRequiredEnv(key: string): string {
+  const value = process.env[key]
+  if (!value) {
+    throw new Error(`[seed-event] 필수 환경변수 누락: ${key}. .env.local 또는 CI 설정을 확인하세요.`)
+  }
+  return value
+}
+
+/** E2E 테스트에서 직접 URL 접근에 사용되는 고정 UUID */
+export const TEST_EVENT_IDS = {
+  venueId: '00000000-0000-0000-0001-000000000001',
+  hallId: '00000000-0000-0000-0001-000000000002',
+  eventId: '00000000-0000-0000-0001-000000000003',
+  schedule1Id: '00000000-0000-0000-0001-000000000004',
+  schedule2Id: '00000000-0000-0000-0001-000000000005',
+} as const
+
+export const TEST_EVENT = {
+  title: 'E2E 테스트 공연',
+  artist: 'E2E 테스트 아티스트',
+  description: 'E2E 테스트용 공연 설명입니다.',
+  venueName: 'E2E 테스트 공연장',
+  hallName: 'E2E 테스트 홀',
+} as const
+
+/**
+ * DB에 테스트 공연 데이터를 삽입합니다.
+ * 이미 존재하면 스킵합니다 (eventId 기준).
+ */
+export async function seedTestEvent(): Promise<void> {
+  const client = new Client({
+    host: getRequiredEnv('DB_HOST'),
+    port: parseInt(getRequiredEnv('DB_PORT'), 10),
+    database: getRequiredEnv('DB_NAME'),
+    user: getRequiredEnv('DB_USER'),
+    password: getRequiredEnv('DB_PASSWORD'),
+    options: '-c search_path=event_service',
+  })
+
+  try {
+    await client.connect()
+
+    // 이미 존재하면 스킵
+    const existing = await client.query(
+      'SELECT id FROM event_service.events WHERE id = $1',
+      [TEST_EVENT_IDS.eventId],
+    )
+    if (existing.rows.length > 0) {
+      console.log(`[seed-event] 테스트 공연 이미 존재, 스킵: ${TEST_EVENT_IDS.eventId}`)
+      return
+    }
+
+    // 1. Venue 삽입
+    await client.query(
+      `INSERT INTO event_service.venues (id, name, address, city)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (id) DO NOTHING`,
+      [TEST_EVENT_IDS.venueId, TEST_EVENT.venueName, '서울특별시 테스트구 테스트로 1', 'SEOUL'],
+    )
+
+    // 2. Hall 삽입
+    const seatTemplate = JSON.stringify({
+      rows: ['A', 'B'],
+      seatsPerRow: 3,
+      gradeMapping: { A: 'VIP', B: 'S' },
+    })
+    await client.query(
+      `INSERT INTO event_service.halls (id, venue_id, name, capacity, seat_template)
+       VALUES ($1, $2, $3, $4, $5::jsonb)
+       ON CONFLICT (id) DO NOTHING`,
+      [TEST_EVENT_IDS.hallId, TEST_EVENT_IDS.venueId, TEST_EVENT.hallName, 6, seatTemplate],
+    )
+
+    // 3. Event 삽입
+    await client.query(
+      `INSERT INTO event_service.events (id, title, artist, description, venue_id, hall_id, status)
+       VALUES ($1, $2, $3, $4, $5, $6, 'OPEN')`,
+      [
+        TEST_EVENT_IDS.eventId,
+        TEST_EVENT.title,
+        TEST_EVENT.artist,
+        TEST_EVENT.description,
+        TEST_EVENT_IDS.venueId,
+        TEST_EVENT_IDS.hallId,
+      ],
+    )
+
+    // 4. EventSchedule 1 삽입 (UPCOMING, 매진 아님)
+    await client.query(
+      `INSERT INTO event_service.event_schedules
+         (id, event_id, play_sequence, event_start_at, event_end_at, sale_start_at, sale_end_at, status)
+       VALUES ($1, $2, 1, $3, $4, $5, $6, 'UPCOMING')`,
+      [
+        TEST_EVENT_IDS.schedule1Id,
+        TEST_EVENT_IDS.eventId,
+        '2026-06-01T19:00:00',
+        '2026-06-01T22:00:00',
+        '2026-05-01T20:00:00',
+        '2026-05-31T23:59:59',
+      ],
+    )
+
+    // 5. EventSchedule 2 삽입 (UPCOMING, 매진 처리용)
+    await client.query(
+      `INSERT INTO event_service.event_schedules
+         (id, event_id, play_sequence, event_start_at, event_end_at, sale_start_at, sale_end_at, status)
+       VALUES ($1, $2, 2, $3, $4, $5, $6, 'UPCOMING')`,
+      [
+        TEST_EVENT_IDS.schedule2Id,
+        TEST_EVENT_IDS.eventId,
+        '2026-06-02T17:00:00',
+        '2026-06-02T20:00:00',
+        '2026-05-02T20:00:00',
+        '2026-06-01T23:59:59',
+      ],
+    )
+
+    // 6. Schedule 1 좌석 삽입 (AVAILABLE)
+    const schedule1Seats = [
+      ['A-1', 'VIP', 150000, 'AVAILABLE'],
+      ['A-2', 'VIP', 150000, 'AVAILABLE'],
+      ['A-3', 'VIP', 150000, 'AVAILABLE'],
+      ['B-1', 'S', 120000, 'AVAILABLE'],
+      ['B-2', 'S', 120000, 'AVAILABLE'],
+      ['B-3', 'S', 120000, 'AVAILABLE'],
+    ]
+    for (const [seatNumber, grade, price, status] of schedule1Seats) {
+      await client.query(
+        `INSERT INTO event_service.seats (event_schedule_id, seat_number, grade, price, status)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [TEST_EVENT_IDS.schedule1Id, seatNumber, grade, price, status],
+      )
+    }
+
+    // 7. Schedule 2 좌석 삽입 (전부 SOLD → isSoldOut: true)
+    const schedule2Seats = [
+      ['A-1', 'VIP', 150000, 'SOLD'],
+      ['A-2', 'VIP', 150000, 'SOLD'],
+      ['A-3', 'VIP', 150000, 'SOLD'],
+      ['B-1', 'S', 120000, 'SOLD'],
+      ['B-2', 'S', 120000, 'SOLD'],
+      ['B-3', 'S', 120000, 'SOLD'],
+    ]
+    for (const [seatNumber, grade, price, status] of schedule2Seats) {
+      await client.query(
+        `INSERT INTO event_service.seats (event_schedule_id, seat_number, grade, price, status)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [TEST_EVENT_IDS.schedule2Id, seatNumber, grade, price, status],
+      )
+    }
+
+    console.log(`[seed-event] 테스트 공연 생성 완료: ${TEST_EVENT_IDS.eventId}`)
+  } catch (err) {
+    console.error('[seed-event] DB 시딩 실패:', (err as Error).message)
+    throw err
+  } finally {
+    await client.end().catch(() => {})
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "@types/react-google-recaptcha": "^2.1.9",
     "axios-mock-adapter": "^2.1.0",
     "bcryptjs": "^2.4.3",
+    "dotenv": "^17.3.1",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "eslint-config-prettier": "^10.1.8",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig, devices } from '@playwright/test'
+import { config } from 'dotenv'
+
+config({ path: '.env.local' })
 
 export default defineConfig({
   testDir: './e2e',

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3
+      dotenv:
+        specifier: ^17.3.1
+        version: 17.3.1
       eslint:
         specifier: ^9
         version: 9.39.2(jiti@2.6.1)
@@ -2299,6 +2302,10 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dotenv@17.3.1:
+    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -6525,6 +6532,8 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dotenv@17.3.1: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/frontend/src/app/(main)/events/[id]/error.tsx
+++ b/frontend/src/app/(main)/events/[id]/error.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+import { AlertCircle } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="max-w-7xl mx-auto px-6 py-12">
+      <div className="flex flex-col items-center text-center space-y-6 max-w-md mx-auto">
+        <AlertCircle className="size-16 text-destructive" />
+        <div className="space-y-2">
+          <h2 className="text-2xl font-bold text-foreground">공연 정보를 불러올 수 없습니다</h2>
+          <p className="text-muted-foreground">
+            {error.message || '일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'}
+          </p>
+        </div>
+        <div className="flex gap-3">
+          <Button onClick={reset} size="lg">
+            다시 시도
+          </Button>
+          <Button asChild variant="outline" size="lg">
+            <Link href="/events">공연 목록으로 돌아가기</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/(main)/events/[id]/error.tsx
+++ b/frontend/src/app/(main)/events/[id]/error.tsx
@@ -24,7 +24,7 @@ export default function Error({
         <div className="space-y-2">
           <h2 className="text-2xl font-bold text-foreground">공연 정보를 불러올 수 없습니다</h2>
           <p className="text-muted-foreground">
-            {error.message || '일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.'}
+            일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.
           </p>
         </div>
         <div className="flex gap-3">

--- a/frontend/src/app/(main)/events/[id]/loading.tsx
+++ b/frontend/src/app/(main)/events/[id]/loading.tsx
@@ -1,0 +1,9 @@
+import { EventDetailSkeleton } from '@/components/skeleton/event-detail-skeleton'
+
+export default function Loading() {
+  return (
+    <div className="max-w-7xl mx-auto px-6 py-12">
+      <EventDetailSkeleton />
+    </div>
+  )
+}

--- a/frontend/src/app/(main)/events/[id]/page.tsx
+++ b/frontend/src/app/(main)/events/[id]/page.tsx
@@ -45,7 +45,7 @@ export default async function EventDetailPage({ params }: EventDetailPageProps) 
   if (firstTime) {
     try {
       const seatsData = await getScheduleSeatsServer(firstTime.id)
-      grades = seatsData.grades
+      grades = seatsData?.grades ?? []
     } catch {
       // 좌석 정보 조회 실패 시 빈 배열로 렌더링
     }

--- a/frontend/src/app/(main)/events/[id]/page.tsx
+++ b/frontend/src/app/(main)/events/[id]/page.tsx
@@ -1,14 +1,67 @@
-export default async function EventDetailPage({ params }: { params: Promise<{ id: string }> }) {
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import { getEventDetailServer, getScheduleSeatsServer } from '@/lib/api/server/events'
+import { EventDetail } from '@/components/domain/event/EventDetail'
+import { SeatInfo } from '@/components/domain/event/SeatInfo'
+import { EventStructuredData } from '@/components/domain/event/EventStructuredData'
+import type { SeatGrade } from '@/types/event'
+
+interface EventDetailPageProps {
+  params: Promise<{ id: string }>
+}
+
+export async function generateMetadata({ params }: EventDetailPageProps): Promise<Metadata> {
   const { id } = await params
+  const event = await getEventDetailServer(id)
+  if (!event) return {}
+
+  const description = event.description ?? `${event.artist} - ${event.venueName}`
+
+  return {
+    title: event.title,
+    description,
+    openGraph: {
+      title: event.title,
+      description,
+      type: 'website',
+      locale: 'ko_KR',
+    },
+    twitter: {
+      card: 'summary_large_image',
+    },
+    alternates: {
+      canonical: `https://ticket-queue.com/events/${id}`,
+    },
+  }
+}
+
+export default async function EventDetailPage({ params }: EventDetailPageProps) {
+  const { id } = await params
+  const event = await getEventDetailServer(id)
+  if (!event) notFound()
+
+  let grades: SeatGrade[] = []
+  const firstTime = event.schedules[0]?.times[0]
+  if (firstTime) {
+    try {
+      const seatsData = await getScheduleSeatsServer(firstTime.id)
+      grades = seatsData.grades
+    } catch {
+      // 좌석 정보 조회 실패 시 빈 배열로 렌더링
+    }
+  }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-spacing-xl">
-      <div className="max-w-2xl text-center">
-        <h1 className="mb-spacing-lg text-4xl font-bold text-gray-900">공연 상세</h1>
-        <p className="text-gray-600">
-          공연 ID: <span className="font-mono">{id}</span>
-        </p>
-      </div>
-    </main>
+    <>
+      <EventStructuredData event={event} grades={grades} />
+      <main className="max-w-7xl mx-auto px-6 py-12">
+        <EventDetail event={event} />
+        {grades.length > 0 && (
+          <div className="mt-12">
+            <SeatInfo grades={grades} />
+          </div>
+        )}
+      </main>
+    </>
   )
 }

--- a/frontend/src/components/domain/event/EventCard.tsx
+++ b/frontend/src/components/domain/event/EventCard.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { Music } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
+import { StatusBadge } from './StatusBadge'
 import { cn } from '@/lib/utils'
 import type { EventSummary } from '@/types/event'
 
@@ -19,17 +19,6 @@ function formatDateRange(startDate: string, endDate: string): string {
     `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`
   if (startDate === endDate) return fmt(start)
   return `${fmt(start)} ~ ${fmt(end)}`
-}
-
-function StatusBadge({ status }: { status: string }) {
-  const map: Record<string, { label: string; variant: 'default' | 'secondary' | 'outline' | 'success' | 'warning' | 'danger' }> = {
-    OPEN: { label: '예매중', variant: 'success' },
-    PREPARING: { label: '준비중', variant: 'warning' },
-    ENDED: { label: '종료', variant: 'secondary' },
-    CANCELLED: { label: '취소', variant: 'danger' },
-  }
-  const { label, variant } = map[status] ?? { label: status, variant: 'outline' }
-  return <Badge variant={variant}>{label}</Badge>
 }
 
 export function EventCard({ event, priority = false }: EventCardProps) {

--- a/frontend/src/components/domain/event/EventDetail.tsx
+++ b/frontend/src/components/domain/event/EventDetail.tsx
@@ -1,0 +1,49 @@
+import { Music } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { StatusBadge } from './StatusBadge'
+import { ScheduleList } from './ScheduleList'
+import type { EventDetail as EventDetailType } from '@/types/event'
+
+interface EventDetailProps {
+  event: EventDetailType
+}
+
+export function EventDetail({ event }: EventDetailProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+      {/* 포스터 플레이스홀더 */}
+      <div className="md:col-span-1">
+        <div
+          className={cn(
+            'w-full flex flex-col items-center justify-center rounded-lg',
+            'bg-gradient-to-br from-primary-100 to-primary-300'
+          )}
+          style={{ aspectRatio: '3/4' }}
+        >
+          <Music className="w-24 h-24 text-primary-600 mb-3" aria-hidden="true" />
+          <span className="text-base text-primary-700 font-medium px-4 text-center">
+            {event.artist}
+          </span>
+        </div>
+      </div>
+
+      {/* 공연 정보 */}
+      <div className="md:col-span-2 space-y-6">
+        <div className="space-y-3">
+          <StatusBadge status={event.status} />
+          <h1 className="text-3xl font-bold text-foreground">{event.title}</h1>
+          <p className="text-lg text-muted-foreground">{event.artist}</p>
+          <p className="text-sm text-muted-foreground">
+            {event.venueName} · {event.hallName}
+          </p>
+        </div>
+
+        {event.description && (
+          <p className="text-foreground leading-relaxed">{event.description}</p>
+        )}
+
+        <ScheduleList schedules={event.schedules} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/domain/event/EventStructuredData.tsx
+++ b/frontend/src/components/domain/event/EventStructuredData.tsx
@@ -1,0 +1,80 @@
+import type { EventDetail, SeatGrade } from '@/types/event'
+
+interface EventStructuredDataProps {
+  event: EventDetail
+  grades?: SeatGrade[]
+}
+
+function getAvailability(status: string): string {
+  switch (status) {
+    case 'OPEN':
+      return 'https://schema.org/InStock'
+    case 'PREPARING':
+      return 'https://schema.org/PreOrder'
+    case 'ENDED':
+    case 'CANCELLED':
+      return 'https://schema.org/Discontinued'
+    default:
+      return 'https://schema.org/SoldOut'
+  }
+}
+
+function getEventStatus(status: string): string {
+  switch (status) {
+    case 'CANCELLED':
+      return 'https://schema.org/EventCancelled'
+    case 'ENDED':
+      return 'https://schema.org/EventScheduled'
+    default:
+      return 'https://schema.org/EventScheduled'
+  }
+}
+
+export function EventStructuredData({ event, grades }: EventStructuredDataProps) {
+  const allTimes = event.schedules.flatMap((s) => s.times)
+  const startDate = allTimes.length > 0 ? allTimes[0].eventStartAt : undefined
+  const endDate = allTimes.length > 0 ? allTimes[allTimes.length - 1].eventEndAt : undefined
+
+  const prices = grades?.map((g) => g.price) ?? []
+  const lowPrice = prices.length > 0 ? Math.min(...prices) : undefined
+  const highPrice = prices.length > 0 ? Math.max(...prices) : undefined
+
+  const jsonLd: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'Event',
+    name: event.title,
+    ...(event.description && { description: event.description }),
+    performer: {
+      '@type': 'Person',
+      name: event.artist,
+    },
+    ...(startDate && { startDate }),
+    ...(endDate && { endDate }),
+    location: {
+      '@type': 'Place',
+      name: event.venueName,
+      address: {
+        '@type': 'PostalAddress',
+        addressCountry: 'KR',
+      },
+    },
+    eventStatus: getEventStatus(event.status),
+    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+    ...(prices.length > 0 && {
+      offers: {
+        '@type': 'AggregateOffer',
+        lowPrice,
+        highPrice,
+        priceCurrency: 'KRW',
+        availability: getAvailability(event.status),
+      },
+    }),
+  }
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  )
+}

--- a/frontend/src/components/domain/event/ScheduleList.tsx
+++ b/frontend/src/components/domain/event/ScheduleList.tsx
@@ -14,6 +14,7 @@ function formatDate(dateStr: string): string {
 
 function formatTime(datetimeStr: string): string {
   const timePart = datetimeStr.split('T')[1]
+  if (!timePart) return '--:--'
   const [hours, minutes] = timePart.split(':')
   return `${hours}:${minutes}`
 }

--- a/frontend/src/components/domain/event/ScheduleList.tsx
+++ b/frontend/src/components/domain/event/ScheduleList.tsx
@@ -1,0 +1,88 @@
+import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import type { ScheduleDate, ScheduleTime } from '@/types/event'
+
+const DAYS_KO = ['일', '월', '화', '수', '목', '금', '토']
+
+function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-').map(Number)
+  const date = new Date(year, month - 1, day)
+  const dow = DAYS_KO[date.getDay()]
+  return `${year}.${String(month).padStart(2, '0')}.${String(day).padStart(2, '0')} (${dow})`
+}
+
+function formatTime(datetimeStr: string): string {
+  const timePart = datetimeStr.split('T')[1]
+  const [hours, minutes] = timePart.split(':')
+  return `${hours}:${minutes}`
+}
+
+type TimeStatus = 'cancelled' | 'ended' | 'upcoming' | 'soldout' | 'available'
+
+function getTimeStatus(time: ScheduleTime): TimeStatus {
+  if (time.status === 'CANCELLED') return 'cancelled'
+  if (time.status === 'ENDED') return 'ended'
+  if (new Date(time.saleStartAt) > new Date()) return 'upcoming'
+  if (time.isSoldOut) return 'soldout'
+  return 'available'
+}
+
+interface ScheduleListProps {
+  schedules: ScheduleDate[]
+}
+
+export function ScheduleList({ schedules }: ScheduleListProps) {
+  if (schedules.length === 0) return null
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-semibold text-foreground">공연 일정</h2>
+      {schedules.map((schedule) => (
+        <div key={schedule.date}>
+          <h3 className="text-sm font-medium text-muted-foreground mb-2">
+            {formatDate(schedule.date)}
+          </h3>
+          <div className="space-y-3">
+            {schedule.times.map((time) => {
+              const status = getTimeStatus(time)
+              return (
+                <div
+                  key={time.id}
+                  className="rounded-lg border bg-card p-4 flex items-center justify-between"
+                >
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-foreground">{time.playSequence}회</span>
+                      {status === 'cancelled' && <Badge variant="danger">취소됨</Badge>}
+                      {status === 'ended' && <Badge variant="secondary">종료</Badge>}
+                      {status === 'soldout' && <Badge variant="danger">매진</Badge>}
+                      {status === 'upcoming' && <Badge variant="secondary">예매 예정</Badge>}
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      {formatTime(time.eventStartAt)} ~ {formatTime(time.eventEndAt)}
+                    </p>
+                  </div>
+                  {status === 'available' ? (
+                    <Button asChild variant="primary">
+                      <Link
+                        href={`/queue/${time.id}`}
+                        aria-label={`${time.playSequence}회차 예매하기`}
+                      >
+                        예매하기
+                      </Link>
+                    </Button>
+                  ) : (
+                    <Button variant="outline" disabled>
+                      {status === 'upcoming' ? '예매 예정' : status === 'cancelled' ? '취소됨' : status === 'ended' ? '종료' : '매진'}
+                    </Button>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+    </section>
+  )
+}

--- a/frontend/src/components/domain/event/SeatInfo.tsx
+++ b/frontend/src/components/domain/event/SeatInfo.tsx
@@ -1,0 +1,33 @@
+import type { SeatGrade } from '@/types/event'
+
+interface SeatInfoProps {
+  grades: SeatGrade[]
+}
+
+export function SeatInfo({ grades }: SeatInfoProps) {
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-semibold text-foreground">좌석 정보</h2>
+      {grades.length === 0 ? (
+        <p className="text-sm text-muted-foreground">좌석 정보가 없습니다.</p>
+      ) : (
+        <div className="space-y-2">
+          {grades.map((grade) => (
+            <div
+              key={grade.grade}
+              className="flex items-center justify-between rounded-lg border bg-card px-4 py-3"
+            >
+              <span className="font-medium text-foreground">{grade.grade}</span>
+              <div className="text-right">
+                <p className="font-semibold text-foreground">
+                  {grade.price.toLocaleString('ko-KR')}원
+                </p>
+                <p className="text-xs text-muted-foreground">총 {grade.seats.length}석</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/components/domain/event/StatusBadge.tsx
+++ b/frontend/src/components/domain/event/StatusBadge.tsx
@@ -1,0 +1,15 @@
+import { Badge } from '@/components/ui/badge'
+
+type BadgeVariant = 'default' | 'secondary' | 'outline' | 'success' | 'warning' | 'danger'
+
+const STATUS_MAP: Record<string, { label: string; variant: BadgeVariant }> = {
+  OPEN: { label: '예매중', variant: 'success' },
+  PREPARING: { label: '준비중', variant: 'warning' },
+  ENDED: { label: '종료', variant: 'secondary' },
+  CANCELLED: { label: '취소', variant: 'danger' },
+}
+
+export function StatusBadge({ status }: { status: string }) {
+  const { label, variant } = STATUS_MAP[status] ?? { label: status, variant: 'outline' as BadgeVariant }
+  return <Badge variant={variant}>{label}</Badge>
+}

--- a/frontend/src/components/skeleton/event-detail-skeleton.tsx
+++ b/frontend/src/components/skeleton/event-detail-skeleton.tsx
@@ -2,8 +2,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 
 export function EventDetailSkeleton() {
   return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
         {/* Poster Image */}
         <div className="md:col-span-1">
           <Skeleton className="aspect-[3/4] w-full rounded-lg" />
@@ -42,6 +41,5 @@ export function EventDetailSkeleton() {
           </div>
         </div>
       </div>
-    </div>
   )
 }

--- a/frontend/src/lib/api/server/events.ts
+++ b/frontend/src/lib/api/server/events.ts
@@ -1,5 +1,6 @@
+import { cache } from 'react'
 import type { PaginatedResponse } from '@/types/api'
-import type { EventSummary, EventListParams } from '@/types/event'
+import type { EventSummary, EventDetail, EventListParams, SeatsResponse } from '@/types/event'
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL
 if (!API_BASE_URL) {
@@ -23,5 +24,20 @@ export async function getEventsServer(
     throw new Error(`Failed to fetch events: ${res.status}`)
   }
 
+  return res.json()
+}
+
+export const getEventDetailServer = cache(async (id: string): Promise<EventDetail | null> => {
+  const url = `${API_BASE_URL}/events/${id}`
+  const res = await fetch(url, { next: { revalidate: 300 } })
+  if (res.status === 404) return null
+  if (!res.ok) throw new Error(`Failed to fetch event: ${res.status}`)
+  return res.json()
+})
+
+export async function getScheduleSeatsServer(scheduleId: string): Promise<SeatsResponse> {
+  const url = `${API_BASE_URL}/events/schedules/${scheduleId}/seats`
+  const res = await fetch(url, { next: { revalidate: 60 } })
+  if (!res.ok) throw new Error(`Failed to fetch seats: ${res.status}`)
   return res.json()
 }

--- a/frontend/src/lib/api/server/events.ts
+++ b/frontend/src/lib/api/server/events.ts
@@ -35,9 +35,10 @@ export const getEventDetailServer = cache(async (id: string): Promise<EventDetai
   return res.json()
 })
 
-export async function getScheduleSeatsServer(scheduleId: string): Promise<SeatsResponse> {
+export async function getScheduleSeatsServer(scheduleId: string): Promise<SeatsResponse | null> {
   const url = `${API_BASE_URL}/events/schedules/${scheduleId}/seats`
   const res = await fetch(url, { next: { revalidate: 60 } })
+  if (res.status === 404) return null
   if (!res.ok) throw new Error(`Failed to fetch seats: ${res.status}`)
   return res.json()
 }

--- a/frontend/src/stores/reservation-store.ts
+++ b/frontend/src/stores/reservation-store.ts
@@ -1,12 +1,17 @@
 import { create } from 'zustand'
 import type { Seat } from '@/types/event'
 
+/** 좌석 선택 시 SeatGrade에서 가져온 가격을 함께 저장 */
+export interface SelectedSeat extends Seat {
+  price: number
+}
+
 interface ReservationState {
-  selectedSeats: Seat[]
+  selectedSeats: SelectedSeat[]
   scheduleId: string | null
   totalPrice: number
 
-  addSeat: (seat: Seat) => void
+  addSeat: (seat: SelectedSeat) => void
   removeSeat: (seatId: string) => void
   clearSeats: () => void
   setScheduleId: (id: string) => void
@@ -20,9 +25,9 @@ export const useReservationStore = create<ReservationState>((set) => ({
   addSeat: (seat) =>
     set((state) => {
       // 최대 4장 제한 체크
-      if (state.selectedSeats.length >= 4) {
-        return state
-      }
+      if (state.selectedSeats.length >= 4) return state
+      // 중복 좌석 방지
+      if (state.selectedSeats.some((s) => s.id === seat.id)) return state
 
       const newSeats = [...state.selectedSeats, seat]
       const totalPrice = newSeats.reduce((sum, s) => sum + s.price, 0)
@@ -38,5 +43,5 @@ export const useReservationStore = create<ReservationState>((set) => ({
 
   clearSeats: () => set({ selectedSeats: [], totalPrice: 0 }),
 
-  setScheduleId: (id) => set({ scheduleId: id }),
+  setScheduleId: (id) => set({ scheduleId: id, selectedSeats: [], totalPrice: 0 }),
 }))

--- a/frontend/src/types/event.ts
+++ b/frontend/src/types/event.ts
@@ -13,33 +13,37 @@ export interface EventDetail {
   id: string
   title: string
   artist: string
-  description: string
-  venue: { id: string; name: string }
-  halls: { id: string; name: string }
+  description: string | null
+  venueId: string
+  venueName: string
+  hallId: string
+  hallName: string
+  status: string
   schedules: ScheduleDate[]
+  createdAt: string
+  updatedAt: string
 }
 
 export interface ScheduleDate {
   date: string
-  isSoldOut: boolean
   times: ScheduleTime[]
 }
 
 export interface ScheduleTime {
   id: string
-  sequence: number
-  time: string
+  playSequence: number
+  eventStartAt: string
+  eventEndAt: string
   saleStartAt: string
   saleEndAt: string
   status: string
+  isSoldOut: boolean
 }
 
 export interface Seat {
   id: string
   seatNumber: string
-  status: string
-  grade: string
-  price: number
+  status: 'AVAILABLE' | 'SOLD'
 }
 
 export interface SeatGrade {


### PR DESCRIPTION
## Summary
- 공연 상세 페이지 SSR 구현 (EventDetail, ScheduleList, SeatInfo, StatusBadge 컴포넌트)
- JSON-LD 구조화 데이터에 `eventStatus`, `eventAttendanceMode` 추가 (Google Search Console 경고 해결)
- route-specific `error.tsx` 추가로 500 에러 시 레이아웃(헤더/네비) 유지

## Changes
- `EventDetail.tsx` — 공연 상세 메인 컴포넌트 (SSR)
- `ScheduleList.tsx` — 회차 목록, CANCELLED/ENDED 처리, "예매 예정" 비활성화
- `SeatInfo.tsx` — 좌석 등급별 가격 정보
- `StatusBadge.tsx` — 공연 상태 배지
- `EventStructuredData.tsx` — JSON-LD `eventStatus` + `eventAttendanceMode` 추가
- `events/[id]/error.tsx` — route-specific error boundary (공연 목록 링크 포함)
- `events/[id]/loading.tsx` — 스켈레톤 로딩 UI
- `events.ts` — `getEventDetailServer`에 `React.cache()` 적용
- `reservation-store.ts` — 중복 좌석 방지(line 30) + scheduleId 변경 시 초기화(line 46)
- `event-detail.spec.ts` / `seed-event.ts` — E2E 테스트 및 시드 헬퍼

## Test plan
- [x] `pnpm build` 통과 (TypeScript 오류 없음)
- [x] E2E: `pnpm test:e2e e2e/event-detail.spec.ts` — 7/7 통과
- [x] JSON-LD 수동 확인: `eventStatus: "https://schema.org/EventScheduled"`, `eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode"` E2E assertion으로 자동 검증
- [x] error.tsx 수동 확인: 500 에러 시 `(main)` 레이아웃 유지(헤더/네비) + "공연 목록으로 돌아가기" href="/events" 확인

Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event detail page now displays complete event information including title, artist, venue, and description.
  * Added status badges for event availability (sold out, etc.).
  * Schedule list shows showtimes with booking buttons and status indicators.
  * Seat information section displays seating categories and pricing.
  * Improved SEO with proper metadata and structured data for event pages.

* **Tests**
  * Added comprehensive end-to-end tests for event detail page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->