### PR TITLE
feat: [Queue] 대기열 진입 시 scheduleId 유효성 검증 (#163)

### DIFF
--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/InternalScheduleController.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/InternalScheduleController.kt
@@ -1,0 +1,25 @@
+package com.ticketqueue.event.controller
+
+import com.ticketqueue.event.dto.ScheduleDto
+import com.ticketqueue.event.service.ScheduleService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+// 내부 서비스 간 통신용 회차 API 컨트롤러
+// 엔드포인트: GET /internal/schedules/{scheduleId}/sellable - 티켓 판매 가능 여부 조회 (Queue Service 전용)
+// 보안: InternalApiAuthInterceptor가 X-Service-Api-Key 헤더 검증 (API Gateway는 /internal 경로 차단)
+@RestController
+@RequestMapping("/internal/schedules")
+class InternalScheduleController(
+    private val scheduleService: ScheduleService
+) {
+
+    /** 티켓 판매 가능 여부 조회 - Queue Service가 대기열 진입 전 회차 유효성 검증 시 사용 */
+    @GetMapping("/{scheduleId}/sellable")
+    fun checkSellable(@PathVariable scheduleId: UUID): ScheduleDto.SellableResponse {
+        return scheduleService.checkSellable(scheduleId)
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/ScheduleDto.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/ScheduleDto.kt
@@ -142,4 +142,10 @@ class ScheduleDto {
         val currentStatus: ScheduleStatus,
         val updatedAt: LocalDateTime
     )
+
+    /** 회차 판매 가능 여부 응답 (내부 API용 — Queue Service에서 대기열 진입 전 검증) */
+    data class SellableResponse(
+        val sellable: Boolean,
+        val reason: String? = null
+    )
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
@@ -8,6 +8,7 @@ import com.ticketqueue.event.config.CacheProperties
 import com.ticketqueue.event.dto.ScheduleDto
 import com.ticketqueue.event.dto.SeatTemplateDto
 import com.ticketqueue.event.entity.EventSchedule
+import com.ticketqueue.event.entity.ScheduleStatus
 import com.ticketqueue.event.entity.Seat
 import com.ticketqueue.event.entity.SeatGrade
 import com.ticketqueue.event.exception.EventException
@@ -241,6 +242,34 @@ class ScheduleService(
                 Seat(eventSchedule = schedule, seatNumber = "${row}-${seatIndex}", grade = grade, price = price)
             }
         }
+    }
+
+    /**
+     * 회차의 티켓 판매 가능 여부를 반환한다 (내부 API용 — Queue Service 검증 전용)
+     *
+     * - 회차 없음: SCHEDULE_NOT_FOUND 예외 (404)
+     * - CANCELLED/ENDED 상태: sellable=false, reason=SCHEDULE_NOT_AVAILABLE
+     * - 판매 시작 전: sellable=false, reason=TICKET_SALE_NOT_STARTED
+     * - 판매 종료 후: sellable=false, reason=TICKET_SALE_ENDED
+     * - 그 외: sellable=true
+     */
+    fun checkSellable(scheduleId: UUID): ScheduleDto.SellableResponse {
+        val schedule = eventScheduleRepository.findById(scheduleId)
+            .orElseThrow { EventException(ErrorCode.SCHEDULE_NOT_FOUND) }
+
+        if (schedule.status == ScheduleStatus.CANCELLED || schedule.status == ScheduleStatus.ENDED) {
+            return ScheduleDto.SellableResponse(sellable = false, reason = "SCHEDULE_NOT_AVAILABLE")
+        }
+
+        val now = LocalDateTime.now()
+        if (now.isBefore(schedule.saleStartAt)) {
+            return ScheduleDto.SellableResponse(sellable = false, reason = "TICKET_SALE_NOT_STARTED")
+        }
+        if (now.isAfter(schedule.saleEndAt)) {
+            return ScheduleDto.SellableResponse(sellable = false, reason = "TICKET_SALE_ENDED")
+        }
+
+        return ScheduleDto.SellableResponse(sellable = true)
     }
 
     internal fun invalidateScheduleDetailCache(scheduleId: UUID) {

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalScheduleControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalScheduleControllerTest.kt
@@ -1,0 +1,108 @@
+package com.ticketqueue.event.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.exception.GlobalExceptionHandler
+import com.ticketqueue.event.dto.ScheduleDto
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.service.ScheduleService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.util.UUID
+
+class InternalScheduleControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var scheduleService: ScheduleService
+    private val objectMapper: ObjectMapper = jacksonObjectMapper().apply {
+        registerModule(JavaTimeModule())
+    }
+
+    private val scheduleId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        scheduleService = mockk()
+        val controller = InternalScheduleController(scheduleService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(GlobalExceptionHandler())
+            .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
+            .build()
+    }
+
+    @Nested
+    @DisplayName("GET /internal/schedules/{scheduleId}/sellable")
+    inner class CheckSellable {
+
+        @Test
+        @DisplayName("200 OK - 판매 가능한 회차는 sellable=true를 반환한다")
+        fun sellable() {
+            every { scheduleService.checkSellable(scheduleId) } returns
+                ScheduleDto.SellableResponse(sellable = true)
+
+            mockMvc.perform(get("/internal/schedules/{scheduleId}/sellable", scheduleId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.sellable").value(true))
+                .andExpect(jsonPath("$.reason").doesNotExist())
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 scheduleId는 SCHEDULE_NOT_FOUND를 반환한다")
+        fun notFound() {
+            every { scheduleService.checkSellable(scheduleId) } throws
+                EventException(ErrorCode.SCHEDULE_NOT_FOUND)
+
+            mockMvc.perform(get("/internal/schedules/{scheduleId}/sellable", scheduleId))
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.code").value("SCHEDULE_NOT_FOUND"))
+        }
+
+        @Test
+        @DisplayName("200 OK - 판매 시작 전 회차는 sellable=false, reason=TICKET_SALE_NOT_STARTED")
+        fun saleNotStarted() {
+            every { scheduleService.checkSellable(scheduleId) } returns
+                ScheduleDto.SellableResponse(sellable = false, reason = "TICKET_SALE_NOT_STARTED")
+
+            mockMvc.perform(get("/internal/schedules/{scheduleId}/sellable", scheduleId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.sellable").value(false))
+                .andExpect(jsonPath("$.reason").value("TICKET_SALE_NOT_STARTED"))
+        }
+
+        @Test
+        @DisplayName("200 OK - 판매 종료 회차는 sellable=false, reason=TICKET_SALE_ENDED")
+        fun saleEnded() {
+            every { scheduleService.checkSellable(scheduleId) } returns
+                ScheduleDto.SellableResponse(sellable = false, reason = "TICKET_SALE_ENDED")
+
+            mockMvc.perform(get("/internal/schedules/{scheduleId}/sellable", scheduleId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.sellable").value(false))
+                .andExpect(jsonPath("$.reason").value("TICKET_SALE_ENDED"))
+        }
+
+        @Test
+        @DisplayName("200 OK - CANCELLED/ENDED 상태 회차는 sellable=false, reason=SCHEDULE_NOT_AVAILABLE")
+        fun cancelledOrEnded() {
+            every { scheduleService.checkSellable(scheduleId) } returns
+                ScheduleDto.SellableResponse(sellable = false, reason = "SCHEDULE_NOT_AVAILABLE")
+
+            mockMvc.perform(get("/internal/schedules/{scheduleId}/sellable", scheduleId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.sellable").value(false))
+                .andExpect(jsonPath("$.reason").value("SCHEDULE_NOT_AVAILABLE"))
+        }
+    }
+}

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/QueueServiceApplication.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/QueueServiceApplication.kt
@@ -1,11 +1,13 @@
 package com.ticketqueue.queue
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 import org.springframework.boot.runApplication
 
+@EnableFeignClients(basePackages = ["com.ticketqueue.queue"])
 @SpringBootApplication(
     scanBasePackages = ["com.ticketqueue.queue", "com.ticketqueue.common"],
     exclude = [

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/client/EventServiceClient.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/client/EventServiceClient.kt
@@ -1,0 +1,15 @@
+package com.ticketqueue.queue.client
+
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import java.util.UUID
+
+@FeignClient(name = "event-service", url = "\${feign.client.config.event-service.url}")
+interface EventServiceClient {
+
+    @GetMapping("/internal/schedules/{scheduleId}/sellable")
+    fun checkSellable(@PathVariable scheduleId: UUID): SellableResponse
+
+    data class SellableResponse(val sellable: Boolean, val reason: String?)
+}

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/client/EventServiceClient.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/client/EventServiceClient.kt
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import java.util.UUID
 
-@FeignClient(name = "event-service", url = "\${feign.client.config.event-service.url}")
+@FeignClient(name = "event-service", url = "\${spring.cloud.openfeign.client.config.event-service.url}")
 interface EventServiceClient {
 
     @GetMapping("/internal/schedules/{scheduleId}/sellable")

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
@@ -29,7 +29,8 @@ class QueueService(
     private val rateLimitScript: DefaultRedisScript<Long>,
     private val batchApproveScript: DefaultRedisScript<Long>,
     private val queueProperties: QueueProperties,
-    private val meterRegistry: MeterRegistry
+    private val meterRegistry: MeterRegistry,
+    private val scheduleValidator: ScheduleValidator
 ) {
 
     private val logger = KotlinLogging.logger {}
@@ -49,11 +50,9 @@ class QueueService(
      * - 2: 다른 회차 대기 중 → ALREADY_IN_QUEUE
      * - 3: 대기열 가득 참 → QUEUE_FULL
      * - 4: 이미 배치 승인 완료 → ALREADY_APPROVED
-     *
-     * TODO: scheduleId 유효성 검증 미구현 — 존재하지 않거나 판매 상태가 아닌 회차에 대한 대기열 생성 가능
-     *       Event Service 내부 API 호출 또는 Gateway 레벨 검증 필요 (GitHub Issue #163)
      */
     fun enterQueue(userId: UUID, scheduleId: UUID): QueueDto.EnterResponse {
+        scheduleValidator.validateSchedule(scheduleId)
         val keys = listOf(
             QueueRedisKeys.queue(scheduleId),
             QueueRedisKeys.active(userId),

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/ScheduleValidator.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/ScheduleValidator.kt
@@ -1,5 +1,6 @@
 package com.ticketqueue.queue.service
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.exception.BusinessException
 import com.ticketqueue.common.exception.ErrorCode
@@ -54,9 +55,18 @@ class ScheduleValidator(
         }
 
         if (cached != null) {
-            val response = objectMapper.readValue(cached, EventServiceClient.SellableResponse::class.java)
-            if (response.sellable) return
-            throwValidationError(response.reason)
+            try {
+                val response = objectMapper.readValue(cached, EventServiceClient.SellableResponse::class.java)
+                if (response.sellable) return
+                throwValidationError(response.reason)
+            } catch (e: JsonProcessingException) {
+                logger.warn(e) { "Corrupted JSON in cache for schedule sellable: scheduleId=$scheduleId — treating as cache miss" }
+                try {
+                    stringRedisTemplate.delete(cacheKey)
+                } catch (deleteEx: Exception) {
+                    logger.warn(deleteEx) { "Failed to delete corrupted cache entry: scheduleId=$scheduleId" }
+                }
+            }
         }
 
         // 2. Event Service 호출 (캐시 미스)
@@ -91,7 +101,11 @@ class ScheduleValidator(
         when (reason) {
             "TICKET_SALE_NOT_STARTED" -> throw QueueException(ErrorCode.TICKET_SALE_NOT_STARTED)
             "TICKET_SALE_ENDED" -> throw QueueException(ErrorCode.TICKET_SALE_ENDED)
-            else -> throw QueueException(ErrorCode.SCHEDULE_NOT_FOUND)
+            "SCHEDULE_NOT_AVAILABLE" -> throw QueueException(ErrorCode.SCHEDULE_NOT_FOUND)
+            else -> {
+                logger.warn { "Unknown sellable reason: $reason — defaulting to SCHEDULE_NOT_FOUND" }
+                throw QueueException(ErrorCode.SCHEDULE_NOT_FOUND)
+            }
         }
     }
 }

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/ScheduleValidator.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/ScheduleValidator.kt
@@ -1,0 +1,97 @@
+package com.ticketqueue.queue.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.exception.BusinessException
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.queue.client.EventServiceClient
+import com.ticketqueue.queue.exception.QueueException
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.util.UUID
+
+/**
+ * 대기열 진입 전 회차 유효성 검증 컴포넌트 (REQ-QUEUE-001 보강)
+ *
+ * Event Service 내부 API를 호출하여 회차의 티켓 판매 가능 여부를 확인한다.
+ * Redis 캐시(TTL 30초)를 활용해 반복 호출 비용을 최소화한다.
+ *
+ * Fail-closed 정책: Event Service 호출 실패 시 대기열 진입을 차단한다.
+ * (유령 대기열 생성을 허용하는 것보다 일시적 차단이 더 안전)
+ */
+@Component
+class ScheduleValidator(
+    private val eventServiceClient: EventServiceClient,
+    private val stringRedisTemplate: StringRedisTemplate,
+    private val objectMapper: ObjectMapper
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    companion object {
+        private const val CACHE_KEY_PREFIX = "schedule:sellable:"
+        private val CACHE_TTL = Duration.ofSeconds(30)
+    }
+
+    /**
+     * 회차가 티켓 판매 가능한 상태인지 검증한다.
+     *
+     * @throws QueueException(SCHEDULE_NOT_FOUND) 존재하지 않는 scheduleId
+     * @throws QueueException(TICKET_SALE_NOT_STARTED) 판매 시작 전
+     * @throws QueueException(TICKET_SALE_ENDED) 판매 종료 후
+     * @throws QueueException(INTERNAL_SERVER_ERROR) Event Service 호출 실패
+     */
+    fun validateSchedule(scheduleId: UUID) {
+        val cacheKey = "$CACHE_KEY_PREFIX$scheduleId"
+
+        // 1. Redis 캐시 조회
+        val cached = try {
+            stringRedisTemplate.opsForValue().get(cacheKey)
+        } catch (e: Exception) {
+            logger.warn(e) { "Redis cache read failed for schedule sellable: scheduleId=$scheduleId" }
+            null
+        }
+
+        if (cached != null) {
+            val response = objectMapper.readValue(cached, EventServiceClient.SellableResponse::class.java)
+            if (response.sellable) return
+            throwValidationError(response.reason)
+        }
+
+        // 2. Event Service 호출 (캐시 미스)
+        val response = try {
+            eventServiceClient.checkSellable(scheduleId)
+        } catch (e: BusinessException) {
+            if (e.errorCode == ErrorCode.RESOURCE_NOT_FOUND) {
+                throw QueueException(ErrorCode.SCHEDULE_NOT_FOUND)
+            }
+            logger.error(e) { "Event service call failed (fail-closed): scheduleId=$scheduleId" }
+            throw QueueException(ErrorCode.INTERNAL_SERVER_ERROR)
+        } catch (e: Exception) {
+            logger.error(e) { "Event service call failed (fail-closed): scheduleId=$scheduleId" }
+            throw QueueException(ErrorCode.INTERNAL_SERVER_ERROR)
+        }
+
+        // 3. 결과 캐시 저장 (TTL 30초)
+        try {
+            val json = objectMapper.writeValueAsString(response)
+            stringRedisTemplate.opsForValue().set(cacheKey, json, CACHE_TTL)
+        } catch (e: Exception) {
+            logger.warn(e) { "Redis cache write failed for schedule sellable: scheduleId=$scheduleId" }
+        }
+
+        // 4. 검증
+        if (!response.sellable) {
+            throwValidationError(response.reason)
+        }
+    }
+
+    private fun throwValidationError(reason: String?) {
+        when (reason) {
+            "TICKET_SALE_NOT_STARTED" -> throw QueueException(ErrorCode.TICKET_SALE_NOT_STARTED)
+            "TICKET_SALE_ENDED" -> throw QueueException(ErrorCode.TICKET_SALE_ENDED)
+            else -> throw QueueException(ErrorCode.SCHEDULE_NOT_FOUND)
+        }
+    }
+}

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/ScheduleValidator.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/ScheduleValidator.kt
@@ -73,7 +73,7 @@ class ScheduleValidator(
         val response = try {
             eventServiceClient.checkSellable(scheduleId)
         } catch (e: BusinessException) {
-            if (e.errorCode == ErrorCode.RESOURCE_NOT_FOUND) {
+            if (e.errorCode == ErrorCode.RESOURCE_NOT_FOUND || e.errorCode == ErrorCode.SCHEDULE_NOT_FOUND) {
                 throw QueueException(ErrorCode.SCHEDULE_NOT_FOUND)
             }
             logger.error(e) { "Event service call failed (fail-closed): scheduleId=$scheduleId" }

--- a/backend/queue-service/src/main/resources/application.yml
+++ b/backend/queue-service/src/main/resources/application.yml
@@ -16,14 +16,14 @@ spring:
     import:
       - "optional:classpath:/application-common-${spring.profiles.active}.yml"
       - "optional:aws-secretsmanager:queue-svc/secure-config"
-
-feign:
-  client:
-    config:
-      event-service:
-        url: ${EVENT_SERVICE_URL:http://localhost:8082}
-        connectTimeout: 3000
-        readTimeout: 5000
+  cloud:
+    openfeign:
+      client:
+        config:
+          event-service:
+            url: ${EVENT_SERVICE_URL:http://localhost:8082}
+            connectTimeout: 2000
+            readTimeout: 3000
 
 queue:
   batch:

--- a/backend/queue-service/src/main/resources/application.yml
+++ b/backend/queue-service/src/main/resources/application.yml
@@ -21,7 +21,9 @@ feign:
   client:
     config:
       event-service:
-        url: http://localhost:8082
+        url: ${EVENT_SERVICE_URL:http://localhost:8082}
+        connectTimeout: 3000
+        readTimeout: 5000
 
 queue:
   batch:

--- a/backend/queue-service/src/main/resources/application.yml
+++ b/backend/queue-service/src/main/resources/application.yml
@@ -17,6 +17,12 @@ spring:
       - "optional:classpath:/application-common-${spring.profiles.active}.yml"
       - "optional:aws-secretsmanager:queue-svc/secure-config"
 
+feign:
+  client:
+    config:
+      event-service:
+        url: http://localhost:8082
+
 queue:
   batch:
     size: 10

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/integration/BatchApproveIntegrationTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/integration/BatchApproveIntegrationTest.kt
@@ -1,11 +1,14 @@
 package com.ticketqueue.queue.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.queue.client.EventServiceClient
 import com.ticketqueue.queue.scheduler.BatchApproveScheduler
 import com.ticketqueue.queue.service.QueueService
 import io.kotest.matchers.longs.shouldBeBetween
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -60,6 +63,10 @@ class BatchApproveIntegrationTest {
     @MockitoBean
     private lateinit var batchApproveScheduler: BatchApproveScheduler
 
+    // ScheduleValidator → EventServiceClient HTTP 호출 차단
+    @MockkBean
+    private lateinit var eventServiceClient: EventServiceClient
+
     @Autowired
     private lateinit var mockMvc: MockMvc
 
@@ -76,9 +83,12 @@ class BatchApproveIntegrationTest {
     private val scheduleId = UUID.randomUUID()
 
     @BeforeEach
-    fun flushRedis() {
+    fun setUp() {
         requireNotNull(stringRedisTemplate.connectionFactory) { "RedisConnectionFactory is not configured" }
             .connection.use { it.serverCommands().flushAll() }
+
+        every { eventServiceClient.checkSellable(any()) } returns
+            EventServiceClient.SellableResponse(sellable = true, reason = null)
     }
 
     private fun enterRequest(uid: UUID = userId, sid: UUID = scheduleId) = post("/queue/enter")

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/integration/QueueLeaveIntegrationTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/integration/QueueLeaveIntegrationTest.kt
@@ -1,7 +1,10 @@
 package com.ticketqueue.queue.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.ticketqueue.queue.client.EventServiceClient
 import io.kotest.matchers.shouldBe
+import io.mockk.every
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -51,6 +54,10 @@ class QueueLeaveIntegrationTest {
         }
     }
 
+    // ScheduleValidator → EventServiceClient HTTP 호출 차단
+    @MockkBean
+    private lateinit var eventServiceClient: EventServiceClient
+
     @Autowired
     private lateinit var mockMvc: MockMvc
 
@@ -61,8 +68,11 @@ class QueueLeaveIntegrationTest {
     private lateinit var objectMapper: ObjectMapper
 
     @BeforeEach
-    fun flushRedis() {
+    fun setUp() {
         stringRedisTemplate.connectionFactory!!.connection.use { it.serverCommands().flushAll() }
+
+        every { eventServiceClient.checkSellable(any()) } returns
+            EventServiceClient.SellableResponse(sellable = true, reason = null)
     }
 
     // ── 헬퍼 ──────────────────────────────────────────────────────────────────

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/QueueServiceTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/QueueServiceTest.kt
@@ -6,6 +6,7 @@ import com.ticketqueue.queue.dto.QueueStatus
 import com.ticketqueue.queue.exception.QueueException
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -30,6 +31,7 @@ class QueueServiceTest {
     private lateinit var batchApproveScript: DefaultRedisScript<Long>
     private lateinit var queueProperties: QueueProperties
     private lateinit var meterRegistry: SimpleMeterRegistry
+    private lateinit var scheduleValidator: ScheduleValidator
     private lateinit var queueService: QueueService
 
     private val userId = UUID.randomUUID()
@@ -48,6 +50,7 @@ class QueueServiceTest {
             rateLimit = QueueProperties.RateLimitProperties(maxRequests = 15, windowSeconds = 60)
         )
         meterRegistry = SimpleMeterRegistry()
+        scheduleValidator = mockk()
         queueService = QueueService(
             stringRedisTemplate,
             queueEnterScript,
@@ -56,8 +59,76 @@ class QueueServiceTest {
             rateLimitScript,
             batchApproveScript,
             queueProperties,
-            meterRegistry
+            meterRegistry,
+            scheduleValidator
         )
+    }
+
+    @Nested
+    @DisplayName("enterQueue")
+    inner class EnterQueue {
+
+        @Test
+        @DisplayName("정상 진입 시 WAITING 상태와 순위를 반환한다")
+        fun returnsWaitingOnSuccess() {
+            justRun { scheduleValidator.validateSchedule(scheduleId) }
+            every {
+                stringRedisTemplate.execute(queueEnterScript, any(), *anyVararg<String>())
+            } returns listOf(0L, 4L)
+
+            val result = queueService.enterQueue(userId, scheduleId)
+
+            assertEquals(QueueStatus.WAITING, result.status)
+            assertEquals(5L, result.rank)
+            assertNull(result.token)
+        }
+
+        @Test
+        @DisplayName("동일 회차 중복 진입(멱등성)이면 기존 순위를 반환한다")
+        fun returnsExistingRankOnDuplicate() {
+            justRun { scheduleValidator.validateSchedule(scheduleId) }
+            every {
+                stringRedisTemplate.execute(queueEnterScript, any(), *anyVararg<String>())
+            } returns listOf(1L, 9L)
+
+            val result = queueService.enterQueue(userId, scheduleId)
+
+            assertEquals(QueueStatus.WAITING, result.status)
+            assertEquals(10L, result.rank)
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 scheduleId이면 scheduleValidator에서 SCHEDULE_NOT_FOUND 예외")
+        fun throwsScheduleNotFoundOnInvalidSchedule() {
+            every { scheduleValidator.validateSchedule(scheduleId) } throws
+                QueueException(ErrorCode.SCHEDULE_NOT_FOUND)
+
+            val ex = assertThrows<QueueException> { queueService.enterQueue(userId, scheduleId) }
+            assertEquals(ErrorCode.SCHEDULE_NOT_FOUND, ex.errorCode)
+            verify(exactly = 0) { stringRedisTemplate.execute(queueEnterScript, any(), *anyVararg<String>()) }
+        }
+
+        @Test
+        @DisplayName("판매 미시작 회차이면 scheduleValidator에서 TICKET_SALE_NOT_STARTED 예외")
+        fun throwsTicketSaleNotStarted() {
+            every { scheduleValidator.validateSchedule(scheduleId) } throws
+                QueueException(ErrorCode.TICKET_SALE_NOT_STARTED)
+
+            val ex = assertThrows<QueueException> { queueService.enterQueue(userId, scheduleId) }
+            assertEquals(ErrorCode.TICKET_SALE_NOT_STARTED, ex.errorCode)
+        }
+
+        @Test
+        @DisplayName("다른 회차 대기 중이면 ALREADY_IN_QUEUE 예외")
+        fun throwsAlreadyInQueue() {
+            justRun { scheduleValidator.validateSchedule(scheduleId) }
+            every {
+                stringRedisTemplate.execute(queueEnterScript, any(), *anyVararg<String>())
+            } returns listOf(2L)
+
+            val ex = assertThrows<QueueException> { queueService.enterQueue(userId, scheduleId) }
+            assertEquals(ErrorCode.ALREADY_IN_QUEUE, ex.errorCode)
+        }
     }
 
     @Nested

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/ScheduleValidatorTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/ScheduleValidatorTest.kt
@@ -100,6 +100,16 @@ class ScheduleValidatorTest {
         }
 
         @Test
+        @DisplayName("Feign이 SCHEDULE_NOT_FOUND 예외를 던지면 SCHEDULE_NOT_FOUND 예외")
+        fun throwsScheduleNotFoundOnFeignScheduleNotFound() {
+            every { eventServiceClient.checkSellable(scheduleId) } throws
+                BusinessException(ErrorCode.SCHEDULE_NOT_FOUND)
+
+            val ex = assertThrows<QueueException> { scheduleValidator.validateSchedule(scheduleId) }
+            assert(ex.errorCode == ErrorCode.SCHEDULE_NOT_FOUND)
+        }
+
+        @Test
         @DisplayName("Feign 호출 실패(네트워크 오류)이면 INTERNAL_SERVER_ERROR 예외 (fail-closed)")
         fun throwsInternalErrorOnFeignFailure() {
             every { eventServiceClient.checkSellable(scheduleId) } throws

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/ScheduleValidatorTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/ScheduleValidatorTest.kt
@@ -1,0 +1,169 @@
+package com.ticketqueue.queue.service
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.exception.BusinessException
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.queue.client.EventServiceClient
+import com.ticketqueue.queue.exception.QueueException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.util.UUID
+
+@DisplayName("ScheduleValidator 단위 테스트")
+class ScheduleValidatorTest {
+
+    private lateinit var eventServiceClient: EventServiceClient
+    private lateinit var stringRedisTemplate: StringRedisTemplate
+    private lateinit var valueOps: ValueOperations<String, String>
+    private lateinit var scheduleValidator: ScheduleValidator
+
+    private val objectMapper = jacksonObjectMapper()
+    private val scheduleId = UUID.randomUUID()
+    private val cacheKey = "schedule:sellable:$scheduleId"
+
+    @BeforeEach
+    fun setUp() {
+        eventServiceClient = mockk()
+        stringRedisTemplate = mockk()
+        valueOps = mockk(relaxed = true)
+        every { stringRedisTemplate.opsForValue() } returns valueOps
+        scheduleValidator = ScheduleValidator(eventServiceClient, stringRedisTemplate, objectMapper)
+    }
+
+    @Nested
+    @DisplayName("캐시 미스 — Feign 호출")
+    inner class CacheMiss {
+
+        @BeforeEach
+        fun stubCacheMiss() {
+            every { valueOps.get(cacheKey) } returns null
+        }
+
+        @Test
+        @DisplayName("sellable=true이면 예외를 던지지 않는다")
+        fun passWhenSellable() {
+            every { eventServiceClient.checkSellable(scheduleId) } returns
+                EventServiceClient.SellableResponse(sellable = true, reason = null)
+
+            assertDoesNotThrow { scheduleValidator.validateSchedule(scheduleId) }
+        }
+
+        @Test
+        @DisplayName("sellable=false, reason=TICKET_SALE_NOT_STARTED이면 TICKET_SALE_NOT_STARTED 예외")
+        fun throwsWhenSaleNotStarted() {
+            every { eventServiceClient.checkSellable(scheduleId) } returns
+                EventServiceClient.SellableResponse(sellable = false, reason = "TICKET_SALE_NOT_STARTED")
+
+            val ex = assertThrows<QueueException> { scheduleValidator.validateSchedule(scheduleId) }
+            assert(ex.errorCode == ErrorCode.TICKET_SALE_NOT_STARTED)
+        }
+
+        @Test
+        @DisplayName("sellable=false, reason=TICKET_SALE_ENDED이면 TICKET_SALE_ENDED 예외")
+        fun throwsWhenSaleEnded() {
+            every { eventServiceClient.checkSellable(scheduleId) } returns
+                EventServiceClient.SellableResponse(sellable = false, reason = "TICKET_SALE_ENDED")
+
+            val ex = assertThrows<QueueException> { scheduleValidator.validateSchedule(scheduleId) }
+            assert(ex.errorCode == ErrorCode.TICKET_SALE_ENDED)
+        }
+
+        @Test
+        @DisplayName("sellable=false, reason=SCHEDULE_NOT_AVAILABLE이면 SCHEDULE_NOT_FOUND 예외")
+        fun throwsWhenNotAvailable() {
+            every { eventServiceClient.checkSellable(scheduleId) } returns
+                EventServiceClient.SellableResponse(sellable = false, reason = "SCHEDULE_NOT_AVAILABLE")
+
+            val ex = assertThrows<QueueException> { scheduleValidator.validateSchedule(scheduleId) }
+            assert(ex.errorCode == ErrorCode.SCHEDULE_NOT_FOUND)
+        }
+
+        @Test
+        @DisplayName("Feign이 RESOURCE_NOT_FOUND(404) 예외를 던지면 SCHEDULE_NOT_FOUND 예외")
+        fun throwsScheduleNotFoundOnFeign404() {
+            every { eventServiceClient.checkSellable(scheduleId) } throws
+                BusinessException(ErrorCode.RESOURCE_NOT_FOUND)
+
+            val ex = assertThrows<QueueException> { scheduleValidator.validateSchedule(scheduleId) }
+            assert(ex.errorCode == ErrorCode.SCHEDULE_NOT_FOUND)
+        }
+
+        @Test
+        @DisplayName("Feign 호출 실패(네트워크 오류)이면 INTERNAL_SERVER_ERROR 예외 (fail-closed)")
+        fun throwsInternalErrorOnFeignFailure() {
+            every { eventServiceClient.checkSellable(scheduleId) } throws
+                RuntimeException("Connection refused")
+
+            val ex = assertThrows<QueueException> { scheduleValidator.validateSchedule(scheduleId) }
+            assert(ex.errorCode == ErrorCode.INTERNAL_SERVER_ERROR)
+        }
+
+        @Test
+        @DisplayName("Feign 호출 실패 시 Feign 클라이언트를 다시 호출하지 않는다")
+        fun doesNotRetryOnFeignFailure() {
+            every { eventServiceClient.checkSellable(scheduleId) } throws
+                RuntimeException("Connection refused")
+
+            assertThrows<QueueException> { scheduleValidator.validateSchedule(scheduleId) }
+
+            verify(exactly = 1) { eventServiceClient.checkSellable(scheduleId) }
+        }
+    }
+
+    @Nested
+    @DisplayName("캐시 히트")
+    inner class CacheHit {
+
+        @Test
+        @DisplayName("캐시 히트 시 Feign 클라이언트를 호출하지 않는다")
+        fun doesNotCallFeignOnCacheHit() {
+            val cached = objectMapper.writeValueAsString(
+                EventServiceClient.SellableResponse(sellable = true, reason = null)
+            )
+            every { valueOps.get(cacheKey) } returns cached
+
+            assertDoesNotThrow { scheduleValidator.validateSchedule(scheduleId) }
+
+            verify(exactly = 0) { eventServiceClient.checkSellable(any()) }
+        }
+
+        @Test
+        @DisplayName("캐시 히트 sellable=false이면 reason에 따라 예외를 던진다")
+        fun throwsOnCachedNotSellable() {
+            val cached = objectMapper.writeValueAsString(
+                EventServiceClient.SellableResponse(sellable = false, reason = "TICKET_SALE_ENDED")
+            )
+            every { valueOps.get(cacheKey) } returns cached
+
+            val ex = assertThrows<QueueException> { scheduleValidator.validateSchedule(scheduleId) }
+            assert(ex.errorCode == ErrorCode.TICKET_SALE_ENDED)
+            verify(exactly = 0) { eventServiceClient.checkSellable(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("Redis 장애")
+    inner class RedisFailure {
+
+        @Test
+        @DisplayName("Redis 캐시 읽기 실패 시 Feign을 호출한다 (fail-open)")
+        fun callsFeignOnRedisReadFailure() {
+            every { valueOps.get(cacheKey) } throws RuntimeException("Redis connection refused")
+            every { eventServiceClient.checkSellable(scheduleId) } returns
+                EventServiceClient.SellableResponse(sellable = true, reason = null)
+
+            assertDoesNotThrow { scheduleValidator.validateSchedule(scheduleId) }
+
+            verify(exactly = 1) { eventServiceClient.checkSellable(scheduleId) }
+        }
+    }
+}

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/ScheduleValidatorTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/ScheduleValidatorTest.kt
@@ -6,7 +6,9 @@ import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.queue.client.EventServiceClient
 import com.ticketqueue.queue.exception.QueueException
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.BeforeEach
@@ -117,6 +119,27 @@ class ScheduleValidatorTest {
 
             verify(exactly = 1) { eventServiceClient.checkSellable(scheduleId) }
         }
+
+        @Test
+        @DisplayName("Feign 성공 응답 후 Redis 캐시에 저장한다")
+        fun cachesSellableResponseAfterFeignCall() {
+            every { eventServiceClient.checkSellable(scheduleId) } returns
+                EventServiceClient.SellableResponse(sellable = true, reason = null)
+
+            scheduleValidator.validateSchedule(scheduleId)
+
+            verify { valueOps.set(cacheKey, any(), any<java.time.Duration>()) }
+        }
+
+        @Test
+        @DisplayName("알 수 없는 reason이면 SCHEDULE_NOT_FOUND 예외를 던진다")
+        fun throwsScheduleNotFoundOnUnknownReason() {
+            every { eventServiceClient.checkSellable(scheduleId) } returns
+                EventServiceClient.SellableResponse(sellable = false, reason = "SOMETHING_WEIRD")
+
+            val ex = assertThrows<QueueException> { scheduleValidator.validateSchedule(scheduleId) }
+            assert(ex.errorCode == ErrorCode.SCHEDULE_NOT_FOUND)
+        }
     }
 
     @Nested
@@ -147,6 +170,19 @@ class ScheduleValidatorTest {
             val ex = assertThrows<QueueException> { scheduleValidator.validateSchedule(scheduleId) }
             assert(ex.errorCode == ErrorCode.TICKET_SALE_ENDED)
             verify(exactly = 0) { eventServiceClient.checkSellable(any()) }
+        }
+
+        @Test
+        @DisplayName("손상된 JSON 캐시는 캐시 미스로 처리하고 Feign을 호출한다")
+        fun fallsBackToFeignOnCorruptedCache() {
+            every { valueOps.get(cacheKey) } returns "corrupted-json{"
+            every { stringRedisTemplate.delete(cacheKey) } returns true
+            every { eventServiceClient.checkSellable(scheduleId) } returns
+                EventServiceClient.SellableResponse(sellable = true, reason = null)
+
+            assertDoesNotThrow { scheduleValidator.validateSchedule(scheduleId) }
+
+            verify(exactly = 1) { eventServiceClient.checkSellable(scheduleId) }
         }
     }
 

--- a/backend/queue-service/src/test/resources/application-test.yml
+++ b/backend/queue-service/src/test/resources/application-test.yml
@@ -6,6 +6,12 @@ spring:
       secretsmanager:
         enabled: false
 
+feign:
+  client:
+    config:
+      event-service:
+        url: http://localhost:8082
+
 internal:
   api:
     key: test-internal-api-key


### PR DESCRIPTION
## Summary
- 임의의 UUID로 `POST /queue/enter` 호출 시 유령 대기열(`queue:{임의UUID}`)이 무한 생성되는 문제 수정
- Event Service 내부 API로 회차 판매 가능 여부를 검증한 후에만 대기열 진입 허용

## Changes
- **Event Service**: `GET /internal/schedules/{scheduleId}/sellable` 내부 API 추가
  - `ScheduleService.checkSellable()`: CANCELLED/ENDED 상태, 판매 시작 전/후 조건 검증
  - `ScheduleDto.SellableResponse` DTO 추가
  - `InternalScheduleController` 신규 생성 (기존 `InternalApiAuthInterceptor`가 X-Service-Api-Key 자동 보호)
- **Queue Service**: Feign 클라이언트 및 검증 컴포넌트 추가
  - `EventServiceClient`: Event Service 내부 API Feign 클라이언트
  - `ScheduleValidator`: Redis 캐시(TTL 30초) + Feign 호출, fail-closed 정책 적용
  - `QueueService.enterQueue()`: Lua 스크립트 실행 전 `scheduleValidator.validateSchedule()` 호출 및 TODO 제거
  - `@EnableFeignClients` 활성화, `application.yml`에 Event Service Feign URL 설정

## Test plan
- [ ] `InternalScheduleControllerTest`: sellable 회차, SCHEDULE_NOT_FOUND(404), 판매 미시작, 판매 종료, CANCELLED 상태 (5개 케이스)
- [ ] `ScheduleValidatorTest`: sellable=true 통과, 각 reason별 예외, 캐시 히트 시 Feign 미호출, Feign 실패 시 INTERNAL_SERVER_ERROR (8개 케이스)
- [ ] `QueueServiceTest.enterQueue`: 정상 진입, 멱등성 중복 진입, 유효하지 않은 scheduleId, 판매 미시작, 다른 회차 대기 중 (5개 케이스)

Closes #163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time schedule validation before joining a queue to ensure tickets are sellable.
  * Internal endpoint and client used to determine sellable status with short-lived caching to reduce calls.
* **Behavior Changes**
  * Queue entry blocked when schedule is cancelled, not started, sale ended, or not found.
  * Fail-closed on service errors to avoid invalid queue entries.
* **Tests**
  * Added unit and integration tests covering validation, caching, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->