### PR TITLE
feat: [Queue] 대기열 정리 배치 작업 (#125)

### DIFF
--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/config/FeignConfig.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/config/FeignConfig.kt
@@ -6,6 +6,7 @@ import feign.Logger
 import feign.RequestInterceptor
 import feign.Retryer
 import feign.codec.ErrorDecoder
+import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.context.annotation.Bean
@@ -22,6 +23,15 @@ class FeignConfig(
     fun internalApiKeyRequestInterceptor(): RequestInterceptor {
         return RequestInterceptor { template ->
             template.header(InternalApiKeyValidator.HEADER_NAME, internalApiKey)
+        }
+    }
+
+    @Bean
+    fun traceIdRequestInterceptor(): RequestInterceptor {
+        return RequestInterceptor { template ->
+            MDC.get("traceId")?.let { traceId ->
+                template.header("X-Trace-Id", traceId)
+            }
         }
     }
 

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/InternalScheduleController.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/InternalScheduleController.kt
@@ -22,4 +22,10 @@ class InternalScheduleController(
     fun checkSellable(@PathVariable scheduleId: UUID): ScheduleDto.SellableResponse {
         return scheduleService.checkSellable(scheduleId)
     }
+
+    /** 종료/취소 후 24시간 경과한 회차 ID 목록 조회 — Queue Service 정리 배치에서 사용 */
+    @GetMapping("/ended")
+    fun getEndedScheduleIds(): ScheduleDto.EndedScheduleIdsResponse {
+        return ScheduleDto.EndedScheduleIdsResponse(scheduleService.getCleanupTargetScheduleIds())
+    }
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/ScheduleDto.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/ScheduleDto.kt
@@ -148,4 +148,7 @@ class ScheduleDto {
         val sellable: Boolean,
         val reason: String? = null
     )
+
+    /** 종료된 회차 ID 목록 응답 (내부 API용 — Queue Service 정리 배치 전용) */
+    data class EndedScheduleIdsResponse(val scheduleIds: List<UUID>)
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepository.kt
@@ -7,7 +7,7 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 @Repository
-interface EventScheduleRepository : JpaRepository<EventSchedule, UUID> {
+interface EventScheduleRepository : JpaRepository<EventSchedule, UUID>, EventScheduleRepositoryCustom {
     fun findByEventIdOrderByPlaySequence(eventId: UUID): List<EventSchedule>
 
     /**

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustom.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustom.kt
@@ -3,6 +3,22 @@ package com.ticketqueue.event.repository
 import java.time.LocalDateTime
 import java.util.UUID
 
+/**
+ * 커서 기반 페이지네이션을 위한 정리 대상 회차 정보
+ * keyset pagination: (eventEndAt, id) 복합 커서
+ */
+data class ScheduleCleanupCursor(val id: UUID, val eventEndAt: LocalDateTime)
+
 interface EventScheduleRepositoryCustom {
-    fun findCleanupTargetScheduleIds(cutoffTime: LocalDateTime): List<UUID>
+    /**
+     * 정리 대상 회차를 커서 기반으로 최대 1000건 조회한다.
+     * - 조건: status IN (ENDED, CANCELLED) AND eventEndAt < cutoffTime
+     * - 정렬: eventEndAt ASC, id ASC (결정적 순서 보장)
+     * - afterEventEndAt, afterId 가 주어지면 해당 커서 이후 행만 반환 (keyset pagination)
+     */
+    fun findCleanupTargetScheduleIds(
+        cutoffTime: LocalDateTime,
+        afterEventEndAt: LocalDateTime? = null,
+        afterId: UUID? = null
+    ): List<ScheduleCleanupCursor>
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustom.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustom.kt
@@ -1,0 +1,8 @@
+package com.ticketqueue.event.repository
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+interface EventScheduleRepositoryCustom {
+    fun findCleanupTargetScheduleIds(cutoffTime: LocalDateTime): List<UUID>
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustomImpl.kt
@@ -12,17 +12,35 @@ class EventScheduleRepositoryCustomImpl(
     private val queryFactory: JPAQueryFactory
 ) : EventScheduleRepositoryCustom {
 
-    override fun findCleanupTargetScheduleIds(cutoffTime: LocalDateTime): List<UUID> {
+    override fun findCleanupTargetScheduleIds(
+        cutoffTime: LocalDateTime,
+        afterEventEndAt: LocalDateTime?,
+        afterId: UUID?
+    ): List<ScheduleCleanupCursor> {
         val schedule = QEventSchedule.eventSchedule
+
+        // keyset pagination: (eventEndAt > after) OR (eventEndAt = after AND id > afterId)
+        val cursorPredicate = if (afterEventEndAt != null && afterId != null) {
+            schedule.eventEndAt.gt(afterEventEndAt)
+                .or(schedule.eventEndAt.eq(afterEventEndAt).and(schedule.id.gt(afterId)))
+        } else null
+
         return queryFactory
-            .select(schedule.id)
+            .select(schedule.id, schedule.eventEndAt)
             .from(schedule)
             .where(
                 schedule.status.`in`(ScheduleStatus.ENDED, ScheduleStatus.CANCELLED),
-                schedule.eventEndAt.lt(cutoffTime)
+                schedule.eventEndAt.lt(cutoffTime),
+                cursorPredicate
             )
-            .orderBy(schedule.eventEndAt.asc())
+            .orderBy(schedule.eventEndAt.asc(), schedule.id.asc())
             .limit(1000)
             .fetch()
+            .map { tuple ->
+                ScheduleCleanupCursor(
+                    id = tuple.get(schedule.id)!!,
+                    eventEndAt = tuple.get(schedule.eventEndAt)!!
+                )
+            }
     }
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustomImpl.kt
@@ -1,0 +1,27 @@
+package com.ticketqueue.event.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.ticketqueue.event.entity.QEventSchedule
+import com.ticketqueue.event.entity.ScheduleStatus
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Transactional(readOnly = true)
+class EventScheduleRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory
+) : EventScheduleRepositoryCustom {
+
+    override fun findCleanupTargetScheduleIds(cutoffTime: LocalDateTime): List<UUID> {
+        val schedule = QEventSchedule.eventSchedule
+        return queryFactory
+            .select(schedule.id)
+            .from(schedule)
+            .where(
+                schedule.status.`in`(ScheduleStatus.ENDED, ScheduleStatus.CANCELLED),
+                schedule.eventEndAt.lt(cutoffTime)
+            )
+            .limit(1000)
+            .fetch()
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustomImpl.kt
@@ -21,6 +21,7 @@ class EventScheduleRepositoryCustomImpl(
                 schedule.status.`in`(ScheduleStatus.ENDED, ScheduleStatus.CANCELLED),
                 schedule.eventEndAt.lt(cutoffTime)
             )
+            .orderBy(schedule.eventEndAt.asc())
             .limit(1000)
             .fetch()
     }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
@@ -272,6 +272,14 @@ class ScheduleService(
         return ScheduleDto.SellableResponse(sellable = true)
     }
 
+    /**
+     * 종료/취소 후 24시간 이상 경과한 회차 ID 목록을 반환한다 (내부 API용 — Queue Service 정리 배치 전용)
+     */
+    fun getCleanupTargetScheduleIds(): List<UUID> {
+        val cutoffTime = LocalDateTime.now().minusHours(24)
+        return eventScheduleRepository.findCleanupTargetScheduleIds(cutoffTime)
+    }
+
     internal fun invalidateScheduleDetailCache(scheduleId: UUID) {
         try {
             redisTemplate.delete("$SCHEDULE_DETAIL_PREFIX$scheduleId")

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
@@ -276,7 +276,7 @@ class ScheduleService(
      * 종료/취소 후 24시간 이상 경과한 회차 ID 목록을 반환한다 (내부 API용 — Queue Service 정리 배치 전용)
      */
     fun getCleanupTargetScheduleIds(): List<UUID> {
-        val cutoffTime = LocalDateTime.now().minusHours(24)
+        val cutoffTime = DateTimeUtils.now().minusHours(24)
         return eventScheduleRepository.findCleanupTargetScheduleIds(cutoffTime)
     }
 

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
@@ -273,11 +273,26 @@ class ScheduleService(
     }
 
     /**
-     * 종료/취소 후 24시간 이상 경과한 회차 ID 목록을 반환한다 (내부 API용 — Queue Service 정리 배치 전용)
+     * 종료/취소 후 24시간 이상 경과한 회차 ID 목록을 모두 반환한다 (내부 API용 — Queue Service 정리 배치 전용)
+     *
+     * 커서 기반 페이지네이션으로 1000건씩 반복 조회하여 1000건 초과 데이터도 누락 없이 처리한다.
      */
     fun getCleanupTargetScheduleIds(): List<UUID> {
         val cutoffTime = DateTimeUtils.now().minusHours(24)
-        return eventScheduleRepository.findCleanupTargetScheduleIds(cutoffTime)
+        val allIds = mutableListOf<UUID>()
+        var cursor: com.ticketqueue.event.repository.ScheduleCleanupCursor? = null
+
+        while (true) {
+            val batch = eventScheduleRepository.findCleanupTargetScheduleIds(
+                cutoffTime = cutoffTime,
+                afterEventEndAt = cursor?.eventEndAt,
+                afterId = cursor?.id
+            )
+            if (batch.isEmpty()) break
+            allIds.addAll(batch.map { it.id })
+            cursor = batch.last()
+        }
+        return allIds
     }
 
     internal fun invalidateScheduleDetailCache(scheduleId: UUID) {

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalScheduleControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalScheduleControllerTest.kt
@@ -68,6 +68,10 @@ class InternalScheduleControllerTest {
 
             mockMvc.perform(get("/internal/schedules/ended"))
                 .andExpect(status().isInternalServerError)
+                .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
+                .andExpect(jsonPath("$.message").isString)
+                .andExpect(jsonPath("$.timestamp").isString)
+                .andExpect(jsonPath("$.traceId").isString)
         }
 
         @Test

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalScheduleControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalScheduleControllerTest.kt
@@ -43,6 +43,35 @@ class InternalScheduleControllerTest {
     }
 
     @Nested
+    @DisplayName("GET /internal/schedules/ended")
+    inner class GetEndedScheduleIds {
+
+        @Test
+        @DisplayName("200 OK - 종료된 회차 ID 목록을 반환한다")
+        fun success() {
+            val id1 = UUID.randomUUID()
+            val id2 = UUID.randomUUID()
+            every { scheduleService.getCleanupTargetScheduleIds() } returns listOf(id1, id2)
+
+            mockMvc.perform(get("/internal/schedules/ended"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.scheduleIds").isArray)
+                .andExpect(jsonPath("$.scheduleIds.length()").value(2))
+        }
+
+        @Test
+        @DisplayName("200 OK - 종료된 회차가 없으면 빈 목록을 반환한다")
+        fun empty() {
+            every { scheduleService.getCleanupTargetScheduleIds() } returns emptyList()
+
+            mockMvc.perform(get("/internal/schedules/ended"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.scheduleIds").isArray)
+                .andExpect(jsonPath("$.scheduleIds.length()").value(0))
+        }
+    }
+
+    @Nested
     @DisplayName("GET /internal/schedules/{scheduleId}/sellable")
     inner class CheckSellable {
 

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalScheduleControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalScheduleControllerTest.kt
@@ -57,6 +57,17 @@ class InternalScheduleControllerTest {
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.scheduleIds").isArray)
                 .andExpect(jsonPath("$.scheduleIds.length()").value(2))
+                .andExpect(jsonPath("$.scheduleIds[0]").value(id1.toString()))
+                .andExpect(jsonPath("$.scheduleIds[1]").value(id2.toString()))
+        }
+
+        @Test
+        @DisplayName("500 Internal Server Error - 서비스 예외 발생 시 에러 응답을 반환한다")
+        fun serviceError() {
+            every { scheduleService.getCleanupTargetScheduleIds() } throws RuntimeException("DB error")
+
+            mockMvc.perform(get("/internal/schedules/ended"))
+                .andExpect(status().isInternalServerError)
         }
 
         @Test

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalScheduleControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalScheduleControllerTest.kt
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.hamcrest.Matchers.emptyOrNullString
+import org.hamcrest.Matchers.matchesPattern
+import org.hamcrest.Matchers.not
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
@@ -70,8 +73,8 @@ class InternalScheduleControllerTest {
                 .andExpect(status().isInternalServerError)
                 .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
                 .andExpect(jsonPath("$.message").isString)
-                .andExpect(jsonPath("$.timestamp").isString)
-                .andExpect(jsonPath("$.traceId").isString)
+                .andExpect(jsonPath("$.timestamp").value(matchesPattern("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}")))
+                .andExpect(jsonPath("$.traceId").value(not(emptyOrNullString())))
         }
 
         @Test

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustomImplTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustomImplTest.kt
@@ -34,8 +34,8 @@ import javax.sql.DataSource
  *
  * findCleanupTargetScheduleIds 메서드를 PostgreSQL 18 환경에서 검증한다.
  * - ENDED/CANCELLED 상태 + cutoff 이전 회차 필터링
- * - LIMIT 1000 적용 여부
  * - lt (strictly before) 경계값 동작
+ * - (eventEndAt ASC, id ASC) 결정적 정렬 보장
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -132,7 +132,7 @@ class EventScheduleRepositoryCustomImplTest {
 
             val result = eventScheduleRepository.findCleanupTargetScheduleIds(cutoffTime)
 
-            assertTrue(result.contains(schedule.id))
+            assertTrue(result.any { it.id == schedule.id })
         }
 
         @Test
@@ -160,7 +160,7 @@ class EventScheduleRepositoryCustomImplTest {
 
             val result = eventScheduleRepository.findCleanupTargetScheduleIds(cutoffTime)
 
-            assertTrue(result.contains(schedule.id))
+            assertTrue(result.any { it.id == schedule.id })
         }
 
         @Test

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustomImplTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustomImplTest.kt
@@ -1,0 +1,195 @@
+package com.ticketqueue.event.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.ticketqueue.event.entity.Event
+import com.ticketqueue.event.entity.EventSchedule
+import com.ticketqueue.event.entity.Hall
+import com.ticketqueue.event.entity.ScheduleStatus
+import com.ticketqueue.event.entity.Venue
+import jakarta.persistence.EntityManagerFactory
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.orm.jpa.SharedEntityManagerCreator
+import org.springframework.test.context.TestPropertySource
+import org.springframework.transaction.annotation.Transactional
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import java.time.LocalDateTime
+import javax.sql.DataSource
+
+/**
+ * EventScheduleRepositoryCustomImpl 통합 테스트
+ *
+ * findCleanupTargetScheduleIds 메서드를 PostgreSQL 18 환경에서 검증한다.
+ * - ENDED/CANCELLED 상태 + cutoff 이전 회차 필터링
+ * - LIMIT 1000 적용 여부
+ * - lt (strictly before) 경계값 동작
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Import(EventScheduleRepositoryCustomImplTest.RepositoryTestConfig::class)
+@TestPropertySource(properties = ["spring.jpa.hibernate.ddl-auto=create-drop"])
+@Transactional
+class EventScheduleRepositoryCustomImplTest {
+
+    companion object {
+        @Container
+        @ServiceConnection
+        val postgres = PostgreSQLContainer<Nothing>(DockerImageName.parse("postgres:18-alpine"))
+            .apply {
+                withDatabaseName("testdb")
+                withUsername("test")
+                withPassword("test")
+                withInitScript("db_init/init.sql")
+            }
+    }
+
+    @TestConfiguration
+    class RepositoryTestConfig {
+        @Bean
+        fun jpaQueryFactory(emf: EntityManagerFactory): JPAQueryFactory =
+            JPAQueryFactory(SharedEntityManagerCreator.createSharedEntityManager(emf))
+    }
+
+    @Autowired private lateinit var dataSource: DataSource
+    @Autowired private lateinit var eventRepository: EventRepository
+    @Autowired private lateinit var venueRepository: VenueRepository
+    @Autowired private lateinit var hallRepository: HallRepository
+    @Autowired private lateinit var eventScheduleRepository: EventScheduleRepository
+
+    private val now: LocalDateTime = LocalDateTime.now()
+
+    @BeforeEach
+    fun cleanAll() {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("DELETE FROM event_service.seats")
+                stmt.execute("DELETE FROM event_service.event_schedules")
+                stmt.execute("DELETE FROM event_service.events")
+                stmt.execute("DELETE FROM event_service.halls")
+                stmt.execute("DELETE FROM event_service.venues")
+            }
+        }
+    }
+
+    private fun saveVenue(): Venue =
+        venueRepository.save(Venue(name = "올림픽공원", address = "서울시 송파구 올림픽로 25", city = "서울"))
+
+    private fun saveHall(venue: Venue): Hall =
+        hallRepository.save(
+            Hall(
+                venue = venue, name = "메인 홀", capacity = 15000,
+                seatTemplate = """{"rows":["A"],"seatsPerRow":2,"gradeMapping":{"A":"VIP"}}"""
+            )
+        )
+
+    private fun saveEvent(venue: Venue, hall: Hall): Event =
+        eventRepository.save(Event(title = "BTS World Tour", artist = "BTS", venue = venue, hall = hall))
+
+    private fun saveSchedule(
+        event: Event,
+        playSequence: Int,
+        status: ScheduleStatus,
+        eventEndAt: LocalDateTime
+    ): EventSchedule =
+        eventScheduleRepository.save(
+            EventSchedule(
+                event = event,
+                playSequence = playSequence,
+                eventStartAt = eventEndAt.minusHours(2),
+                eventEndAt = eventEndAt,
+                saleStartAt = eventEndAt.minusDays(30),
+                saleEndAt = eventEndAt.minusHours(3),
+                status = status
+            )
+        )
+
+    @Nested
+    @DisplayName("findCleanupTargetScheduleIds")
+    inner class FindCleanupTargetScheduleIds {
+
+        @Test
+        @DisplayName("ENDED + cutoff 이전 회차는 결과에 포함된다")
+        fun endedBeforeCutoffIsIncluded() {
+            val cutoffTime = now.minusHours(24)
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+            val schedule = saveSchedule(event, 1, ScheduleStatus.ENDED, cutoffTime.minusHours(1))
+
+            val result = eventScheduleRepository.findCleanupTargetScheduleIds(cutoffTime)
+
+            assertTrue(result.contains(schedule.id))
+        }
+
+        @Test
+        @DisplayName("ENDED + cutoff 이후 회차는 결과에 포함되지 않는다")
+        fun endedAfterCutoffIsExcluded() {
+            val cutoffTime = now.minusHours(24)
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+            saveSchedule(event, 1, ScheduleStatus.ENDED, cutoffTime.plusHours(1))
+
+            val result = eventScheduleRepository.findCleanupTargetScheduleIds(cutoffTime)
+
+            assertTrue(result.isEmpty())
+        }
+
+        @Test
+        @DisplayName("CANCELLED + cutoff 이전 회차는 결과에 포함된다")
+        fun cancelledBeforeCutoffIsIncluded() {
+            val cutoffTime = now.minusHours(24)
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+            val schedule = saveSchedule(event, 1, ScheduleStatus.CANCELLED, cutoffTime.minusHours(1))
+
+            val result = eventScheduleRepository.findCleanupTargetScheduleIds(cutoffTime)
+
+            assertTrue(result.contains(schedule.id))
+        }
+
+        @Test
+        @DisplayName("ONGOING/UPCOMING 상태 회차는 cutoff 이전이어도 결과에 포함되지 않는다")
+        fun ongoingAndUpcomingAreExcluded() {
+            val cutoffTime = now.minusHours(24)
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+            saveSchedule(event, 1, ScheduleStatus.ONGOING, cutoffTime.minusHours(1))
+            saveSchedule(event, 2, ScheduleStatus.UPCOMING, cutoffTime.minusHours(1))
+
+            val result = eventScheduleRepository.findCleanupTargetScheduleIds(cutoffTime)
+
+            assertTrue(result.isEmpty())
+        }
+
+        @Test
+        @DisplayName("eventEndAt이 cutoffTime과 정확히 일치하면 결과에 포함되지 않는다 (lt, not lte)")
+        fun exactCutoffBoundaryIsExcluded() {
+            val cutoffTime = now.minusHours(24)
+            val venue = saveVenue()
+            val hall = saveHall(venue)
+            val event = saveEvent(venue, hall)
+            saveSchedule(event, 1, ScheduleStatus.ENDED, cutoffTime)
+
+            val result = eventScheduleRepository.findCleanupTargetScheduleIds(cutoffTime)
+
+            assertTrue(result.isEmpty())
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
@@ -512,6 +512,34 @@ class ScheduleServiceTest {
     }
 
     @Nested
+    @DisplayName("getCleanupTargetScheduleIds")
+    inner class GetCleanupTargetScheduleIds {
+
+        @Test
+        @DisplayName("repository가 반환한 UUID 목록을 그대로 반환한다")
+        fun success() {
+            val id1 = UUID.randomUUID()
+            val id2 = UUID.randomUUID()
+
+            every { eventScheduleRepository.findCleanupTargetScheduleIds(any()) } returns listOf(id1, id2)
+
+            val result = scheduleService.getCleanupTargetScheduleIds()
+
+            assertEquals(listOf(id1, id2), result)
+        }
+
+        @Test
+        @DisplayName("정리 대상 회차가 없으면 빈 목록을 반환한다")
+        fun empty() {
+            every { eventScheduleRepository.findCleanupTargetScheduleIds(any()) } returns emptyList()
+
+            val result = scheduleService.getCleanupTargetScheduleIds()
+
+            assertTrue(result.isEmpty())
+        }
+    }
+
+    @Nested
     @DisplayName("changeScheduleStatus")
     inner class ChangeScheduleStatus {
 

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
@@ -18,10 +18,13 @@ import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.repository.EventRepository
 import com.ticketqueue.event.repository.EventScheduleRepository
 import com.ticketqueue.event.repository.SeatRepository
+import com.ticketqueue.common.util.DateTimeUtils
+import io.mockk.capture
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -520,12 +523,19 @@ class ScheduleServiceTest {
         fun success() {
             val id1 = UUID.randomUUID()
             val id2 = UUID.randomUUID()
+            val cutoffSlot = slot<LocalDateTime>()
 
-            every { eventScheduleRepository.findCleanupTargetScheduleIds(any()) } returns listOf(id1, id2)
+            every { eventScheduleRepository.findCleanupTargetScheduleIds(capture(cutoffSlot)) } returns listOf(id1, id2)
 
+            val beforeCall = DateTimeUtils.now().minusHours(24)
             val result = scheduleService.getCleanupTargetScheduleIds()
+            val afterCall = DateTimeUtils.now().minusHours(24)
 
             assertEquals(listOf(id1, id2), result)
+            assertTrue(
+                !cutoffSlot.captured.isBefore(beforeCall) && !cutoffSlot.captured.isAfter(afterCall),
+                "cutoff 시간은 24시간 전 기준이어야 한다 (허용 오차 내)"
+            )
         }
 
         @Test

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
@@ -23,7 +23,9 @@ import com.ticketqueue.common.util.DateTimeUtils
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.runs
+import io.mockk.unmockkObject
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -551,6 +553,30 @@ class ScheduleServiceTest {
             val result = scheduleService.getCleanupTargetScheduleIds()
 
             assertTrue(result.isEmpty())
+        }
+
+        @Test
+        @DisplayName("cutoffTime이 현재 시각으로부터 정확히 24시간 전으로 계산된다")
+        fun cutoffTimeIs24HoursAgo() {
+            val fixedNow = LocalDateTime.of(2026, 3, 13, 3, 0, 0)
+            mockkObject(DateTimeUtils)
+            try {
+                every { DateTimeUtils.now() } returns fixedNow
+
+                var capturedCutoffTime: LocalDateTime? = null
+                every {
+                    eventScheduleRepository.findCleanupTargetScheduleIds(any(), null, null)
+                } answers {
+                    capturedCutoffTime = firstArg()
+                    emptyList()
+                }
+
+                scheduleService.getCleanupTargetScheduleIds()
+
+                assertEquals(fixedNow.minusHours(24), capturedCutoffTime)
+            } finally {
+                unmockkObject(DateTimeUtils)
+            }
         }
     }
 

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
@@ -17,14 +17,13 @@ import com.ticketqueue.event.entity.Venue
 import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.repository.EventRepository
 import com.ticketqueue.event.repository.EventScheduleRepository
+import com.ticketqueue.event.repository.ScheduleCleanupCursor
 import com.ticketqueue.event.repository.SeatRepository
 import com.ticketqueue.common.util.DateTimeUtils
-import io.mockk.capture
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
-import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -519,29 +518,35 @@ class ScheduleServiceTest {
     inner class GetCleanupTargetScheduleIds {
 
         @Test
-        @DisplayName("repository가 반환한 UUID 목록을 그대로 반환한다")
+        @DisplayName("repository가 반환한 UUID 목록을 커서 페이지네이션으로 전체 조회해 반환한다")
         fun success() {
             val id1 = UUID.randomUUID()
             val id2 = UUID.randomUUID()
-            val cutoffSlot = slot<LocalDateTime>()
+            val now = DateTimeUtils.now()
+            val cursor1 = ScheduleCleanupCursor(id1, now.minusHours(26))
+            val cursor2 = ScheduleCleanupCursor(id2, now.minusHours(25))
 
-            every { eventScheduleRepository.findCleanupTargetScheduleIds(capture(cutoffSlot)) } returns listOf(id1, id2)
+            // 첫 번째 호출: cursor 없음(null, null) → 결과 반환
+            every {
+                eventScheduleRepository.findCleanupTargetScheduleIds(any(), null, null)
+            } returns listOf(cursor1, cursor2)
 
-            val beforeCall = DateTimeUtils.now().minusHours(24)
+            // 두 번째 호출: cursor 있음 → 빈 목록 → 루프 종료
+            every {
+                eventScheduleRepository.findCleanupTargetScheduleIds(any(), cursor2.eventEndAt, cursor2.id)
+            } returns emptyList()
+
             val result = scheduleService.getCleanupTargetScheduleIds()
-            val afterCall = DateTimeUtils.now().minusHours(24)
 
             assertEquals(listOf(id1, id2), result)
-            assertTrue(
-                !cutoffSlot.captured.isBefore(beforeCall) && !cutoffSlot.captured.isAfter(afterCall),
-                "cutoff 시간은 24시간 전 기준이어야 한다 (허용 오차 내)"
-            )
         }
 
         @Test
         @DisplayName("정리 대상 회차가 없으면 빈 목록을 반환한다")
         fun empty() {
-            every { eventScheduleRepository.findCleanupTargetScheduleIds(any()) } returns emptyList()
+            every {
+                eventScheduleRepository.findCleanupTargetScheduleIds(any(), null, null)
+            } returns emptyList()
 
             val result = scheduleService.getCleanupTargetScheduleIds()
 

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/client/EventServiceClient.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/client/EventServiceClient.kt
@@ -11,5 +11,10 @@ interface EventServiceClient {
     @GetMapping("/internal/schedules/{scheduleId}/sellable")
     fun checkSellable(@PathVariable scheduleId: UUID): SellableResponse
 
+    @GetMapping("/internal/schedules/ended")
+    fun getEndedScheduleIds(): EndedScheduleIdsResponse
+
     data class SellableResponse(val sellable: Boolean, val reason: String?)
+
+    data class EndedScheduleIdsResponse(val scheduleIds: List<UUID>)
 }

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/scheduler/QueueCleanupScheduler.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/scheduler/QueueCleanupScheduler.kt
@@ -1,9 +1,17 @@
 package com.ticketqueue.queue.scheduler
 
+import com.ticketqueue.common.exception.BusinessException
 import com.ticketqueue.queue.client.EventServiceClient
 import com.ticketqueue.queue.service.QueueService
+import feign.RetryableException
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import net.logstash.logback.argument.StructuredArguments.kv
+import org.slf4j.LoggerFactory
 import org.slf4j.MDC
+import org.springframework.data.redis.RedisConnectionFailureException
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import java.util.UUID
@@ -12,58 +20,96 @@ import java.util.UUID
  * 종료된 회차의 대기열 Redis 키 정리 배치 (Issue #125)
  *
  * 매일 03:00 KST 실행:
- * 1. Event Service 내부 API로 종료 + 24시간 경과 회차 ID 목록 조회
- * 2. 해당 회차의 Redis 키 삭제 (queue:{scheduleId}, active-schedules SREM)
- * 3. 실행 결과 로깅 (성공/삭제 건수/실패 건수)
+ * 1. Event Service 내부 API로 종료 + 24시간 경과 회차 ID 목록 조회 (커서 페이지네이션, 전체 처리)
+ * 2. 해당 회차의 Redis 키 파이프라인 삭제 (queue:{scheduleId}, active-schedules SREM)
+ * 3. 실행 결과 구조화 로깅 및 Micrometer 메트릭 기록
  *
  * Event Service 장애 시: 예외 로그 후 다음 실행 주기까지 대기 (데이터 유실 위험 없음)
+ *
+ * 수평 확장 시 중복 실행 주의:
+ * TODO: 다중 인스턴스 배포 전 ShedLock(@SchedulerLock) 적용 필요. 현재는 단일 EC2 배포이므로 문제없음.
+ *       cleanupEndedSchedule은 멱등적(idempotent)이므로 중복 실행해도 데이터 손상 없음.
  */
 @Component
 class QueueCleanupScheduler(
     private val eventServiceClient: EventServiceClient,
-    private val queueService: QueueService
+    private val queueService: QueueService,
+    private val meterRegistry: MeterRegistry
 ) {
 
     private val logger = KotlinLogging.logger {}
+    private val slf4jLogger = LoggerFactory.getLogger(QueueCleanupScheduler::class.java)
+
+    private val executedCounter: Counter = meterRegistry.counter("queue.cleanup.executed.total")
+    private val deletedCounter: Counter = meterRegistry.counter("queue.cleanup.deleted.total")
+    private val failedCounter: Counter = meterRegistry.counter("queue.cleanup.failed.total")
+    private val durationTimer: Timer = Timer.builder("queue.cleanup.duration.seconds")
+        .description("Queue cleanup batch execution duration")
+        .register(meterRegistry)
 
     @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
     fun executeCleanup() {
         MDC.put("traceId", UUID.randomUUID().toString())
         try {
-            logger.info { "Queue cleanup batch started" }
-
-            val scheduleIds = try {
-                eventServiceClient.getEndedScheduleIds().scheduleIds
-            } catch (e: Exception) {
-                logger.error(e) { "Queue cleanup batch failed: unable to fetch ended schedules from Event Service" }
-                return
-            }
-
-            if (scheduleIds.isEmpty()) {
-                logger.info { "Queue cleanup batch completed: no ended schedules to clean up" }
-                return
-            }
-
-            var deletedCount = 0
-            var skippedCount = 0
-            var failedCount = 0
-
-            for (scheduleId in scheduleIds) {
-                try {
-                    val deleted = queueService.cleanupEndedSchedule(scheduleId)
-                    if (deleted) deletedCount++ else skippedCount++
-                    logger.debug { "Queue cleanup: scheduleId=$scheduleId, queueExisted=$deleted" }
-                } catch (e: Exception) {
-                    failedCount++
-                    logger.error(e) { "Queue cleanup failed for scheduleId=$scheduleId, continuing with remaining schedules" }
-                }
-            }
-
-            logger.info {
-                "Queue cleanup batch completed: total=${scheduleIds.size}, deleted=$deletedCount, skipped=$skippedCount, failed=$failedCount"
-            }
+            durationTimer.record(Runnable { runCleanup() })
         } finally {
             MDC.remove("traceId")
         }
+    }
+
+    private fun runCleanup() {
+        logger.info { "Queue cleanup batch started" }
+        executedCounter.increment()
+
+        val scheduleIds = try {
+            eventServiceClient.getEndedScheduleIds().scheduleIds
+        } catch (e: RetryableException) {
+            logger.error(e) { "Queue cleanup batch failed: Event Service 5xx error (transient)" }
+            return
+        } catch (e: BusinessException) {
+            logger.error(e) { "Queue cleanup batch failed: Event Service 4xx error (non-transient), code=${e.errorCode}" }
+            return
+        } catch (e: Exception) {
+            logger.error(e) { "Queue cleanup batch failed: unable to fetch ended schedules from Event Service" }
+            return
+        }
+
+        if (scheduleIds.isEmpty()) {
+            logger.info { "Queue cleanup batch completed: no ended schedules to clean up" }
+            return
+        }
+
+        var deletedCount = 0
+        var skippedCount = 0
+        var failedCount = 0
+
+        for (scheduleId in scheduleIds) {
+            try {
+                val deleted = queueService.cleanupEndedSchedule(scheduleId)
+                if (deleted) {
+                    deletedCount++
+                    deletedCounter.increment()
+                } else {
+                    skippedCount++
+                }
+                logger.debug { "Queue cleanup: scheduleId=$scheduleId, queueExisted=$deleted" }
+            } catch (e: RedisConnectionFailureException) {
+                failedCount++
+                failedCounter.increment()
+                logger.error(e) { "Queue cleanup Redis connection failed for scheduleId=$scheduleId, continuing with remaining schedules" }
+            } catch (e: Exception) {
+                failedCount++
+                failedCounter.increment()
+                logger.error(e) { "Queue cleanup failed for scheduleId=$scheduleId, continuing with remaining schedules" }
+            }
+        }
+
+        slf4jLogger.info(
+            "Queue cleanup batch completed: total={}, deleted={}, skipped={}, failed={}",
+            kv("total", scheduleIds.size),
+            kv("deleted", deletedCount),
+            kv("skipped", skippedCount),
+            kv("failed", failedCount)
+        )
     }
 }

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/scheduler/QueueCleanupScheduler.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/scheduler/QueueCleanupScheduler.kt
@@ -64,13 +64,25 @@ class QueueCleanupScheduler(
         val scheduleIds = try {
             eventServiceClient.getEndedScheduleIds().scheduleIds
         } catch (e: RetryableException) {
-            logger.error(e) { "Queue cleanup batch failed: Event Service 5xx error (transient)" }
+            failedCounter.increment()
+            slf4jLogger.error(
+                "Queue cleanup batch failed: Event Service 5xx error (transient): cause={}",
+                kv("cause", e.javaClass.simpleName), e
+            )
             return
         } catch (e: BusinessException) {
-            logger.error(e) { "Queue cleanup batch failed: Event Service 4xx error (non-transient), code=${e.errorCode}" }
+            failedCounter.increment()
+            slf4jLogger.error(
+                "Queue cleanup batch failed: Event Service 4xx error (non-transient): errorCode={}, cause={}",
+                kv("errorCode", e.errorCode), kv("cause", e.javaClass.simpleName), e
+            )
             return
         } catch (e: Exception) {
-            logger.error(e) { "Queue cleanup batch failed: unable to fetch ended schedules from Event Service" }
+            failedCounter.increment()
+            slf4jLogger.error(
+                "Queue cleanup batch failed: unable to fetch ended schedules from Event Service: cause={}",
+                kv("cause", e.javaClass.simpleName), e
+            )
             return
         }
 
@@ -96,11 +108,17 @@ class QueueCleanupScheduler(
             } catch (e: RedisConnectionFailureException) {
                 failedCount++
                 failedCounter.increment()
-                logger.error(e) { "Queue cleanup Redis connection failed for scheduleId=$scheduleId, continuing with remaining schedules" }
+                slf4jLogger.error(
+                    "Queue cleanup Redis connection failed: scheduleId={}, cause={}",
+                    kv("scheduleId", scheduleId), kv("cause", e.javaClass.simpleName), e
+                )
             } catch (e: Exception) {
                 failedCount++
                 failedCounter.increment()
-                logger.error(e) { "Queue cleanup failed for scheduleId=$scheduleId, continuing with remaining schedules" }
+                slf4jLogger.error(
+                    "Queue cleanup failed: scheduleId={}, cause={}",
+                    kv("scheduleId", scheduleId), kv("cause", e.javaClass.simpleName), e
+                )
             }
         }
 

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/scheduler/QueueCleanupScheduler.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/scheduler/QueueCleanupScheduler.kt
@@ -1,0 +1,61 @@
+package com.ticketqueue.queue.scheduler
+
+import com.ticketqueue.queue.client.EventServiceClient
+import com.ticketqueue.queue.service.QueueService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * 종료된 회차의 대기열 Redis 키 정리 배치 (Issue #125)
+ *
+ * 매일 03:00 KST 실행:
+ * 1. Event Service 내부 API로 종료 + 24시간 경과 회차 ID 목록 조회
+ * 2. 해당 회차의 Redis 키 삭제 (queue:{scheduleId}, active-schedules SREM)
+ * 3. 실행 결과 로깅 (성공/삭제 건수/실패 건수)
+ *
+ * Event Service 장애 시: 예외 로그 후 다음 실행 주기까지 대기 (데이터 유실 위험 없음)
+ */
+@Component
+class QueueCleanupScheduler(
+    private val eventServiceClient: EventServiceClient,
+    private val queueService: QueueService
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    fun executeCleanup() {
+        logger.info { "Queue cleanup batch started" }
+
+        val scheduleIds = try {
+            eventServiceClient.getEndedScheduleIds().scheduleIds
+        } catch (e: Exception) {
+            logger.error(e) { "Queue cleanup batch failed: unable to fetch ended schedules from Event Service" }
+            return
+        }
+
+        if (scheduleIds.isEmpty()) {
+            logger.info { "Queue cleanup batch completed: no ended schedules to clean up" }
+            return
+        }
+
+        var deletedCount = 0
+        var failedCount = 0
+
+        for (scheduleId in scheduleIds) {
+            try {
+                val deleted = queueService.cleanupEndedSchedule(scheduleId)
+                if (deleted) deletedCount++
+                logger.debug { "Queue cleanup: scheduleId=$scheduleId, queueExisted=$deleted" }
+            } catch (e: Exception) {
+                failedCount++
+                logger.error(e) { "Queue cleanup failed for scheduleId=$scheduleId, continuing with remaining schedules" }
+            }
+        }
+
+        logger.info {
+            "Queue cleanup batch completed: total=${scheduleIds.size}, deleted=$deletedCount, failed=$failedCount"
+        }
+    }
+}

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/scheduler/QueueCleanupScheduler.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/scheduler/QueueCleanupScheduler.kt
@@ -3,8 +3,10 @@ package com.ticketqueue.queue.scheduler
 import com.ticketqueue.queue.client.EventServiceClient
 import com.ticketqueue.queue.service.QueueService
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.slf4j.MDC
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import java.util.UUID
 
 /**
  * 종료된 회차의 대기열 Redis 키 정리 배치 (Issue #125)
@@ -26,36 +28,42 @@ class QueueCleanupScheduler(
 
     @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
     fun executeCleanup() {
-        logger.info { "Queue cleanup batch started" }
+        MDC.put("traceId", UUID.randomUUID().toString())
+        try {
+            logger.info { "Queue cleanup batch started" }
 
-        val scheduleIds = try {
-            eventServiceClient.getEndedScheduleIds().scheduleIds
-        } catch (e: Exception) {
-            logger.error(e) { "Queue cleanup batch failed: unable to fetch ended schedules from Event Service" }
-            return
-        }
-
-        if (scheduleIds.isEmpty()) {
-            logger.info { "Queue cleanup batch completed: no ended schedules to clean up" }
-            return
-        }
-
-        var deletedCount = 0
-        var failedCount = 0
-
-        for (scheduleId in scheduleIds) {
-            try {
-                val deleted = queueService.cleanupEndedSchedule(scheduleId)
-                if (deleted) deletedCount++
-                logger.debug { "Queue cleanup: scheduleId=$scheduleId, queueExisted=$deleted" }
+            val scheduleIds = try {
+                eventServiceClient.getEndedScheduleIds().scheduleIds
             } catch (e: Exception) {
-                failedCount++
-                logger.error(e) { "Queue cleanup failed for scheduleId=$scheduleId, continuing with remaining schedules" }
+                logger.error(e) { "Queue cleanup batch failed: unable to fetch ended schedules from Event Service" }
+                return
             }
-        }
 
-        logger.info {
-            "Queue cleanup batch completed: total=${scheduleIds.size}, deleted=$deletedCount, failed=$failedCount"
+            if (scheduleIds.isEmpty()) {
+                logger.info { "Queue cleanup batch completed: no ended schedules to clean up" }
+                return
+            }
+
+            var deletedCount = 0
+            var skippedCount = 0
+            var failedCount = 0
+
+            for (scheduleId in scheduleIds) {
+                try {
+                    val deleted = queueService.cleanupEndedSchedule(scheduleId)
+                    if (deleted) deletedCount++ else skippedCount++
+                    logger.debug { "Queue cleanup: scheduleId=$scheduleId, queueExisted=$deleted" }
+                } catch (e: Exception) {
+                    failedCount++
+                    logger.error(e) { "Queue cleanup failed for scheduleId=$scheduleId, continuing with remaining schedules" }
+                }
+            }
+
+            logger.info {
+                "Queue cleanup batch completed: total=${scheduleIds.size}, deleted=$deletedCount, skipped=$skippedCount, failed=$failedCount"
+            }
+        } finally {
+            MDC.remove("traceId")
         }
     }
 }

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
@@ -9,6 +9,7 @@ import com.ticketqueue.queue.exception.QueueException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.data.redis.connection.StringRedisConnection
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.data.redis.core.script.DefaultRedisScript
 import org.springframework.stereotype.Service
@@ -236,11 +237,19 @@ class QueueService(
      * TTL 10분으로 자동 만료되는 키(queue:active:{userId}, queue:token:{token},
      * queue:user-token:{userId}:{scheduleId})는 24시간 후 이미 만료됨 → 삭제 불필요
      *
+     * 파이프라인을 사용하여 SREM + DEL을 단일 round-trip으로 처리한다.
+     *
      * @return true if the queue key existed and was deleted
      */
     fun cleanupEndedSchedule(scheduleId: UUID): Boolean {
-        stringRedisTemplate.opsForSet().remove(QueueRedisKeys.activeSchedules(), scheduleId.toString())
-        return stringRedisTemplate.delete(QueueRedisKeys.queue(scheduleId))
+        val results = stringRedisTemplate.executePipelined { conn ->
+            val stringConn = conn as StringRedisConnection
+            stringConn.sRem(QueueRedisKeys.activeSchedules(), scheduleId.toString())
+            stringConn.del(QueueRedisKeys.queue(scheduleId))
+            null
+        }
+        // results[0] = SREM count (Long), results[1] = DEL count (Long: 1 deleted, 0 not found)
+        return (results.getOrNull(1) as? Long ?: 0L) > 0
     }
 
     /**

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
@@ -227,6 +227,23 @@ class QueueService(
     }
 
     /**
+     * 종료된 회차의 대기열 Redis 키를 정리한다.
+     *
+     * 삭제 대상:
+     * 1. queue:{scheduleId} — 대기열 Sorted Set (TTL 없음, 반드시 삭제)
+     * 2. queue:active-schedules에서 SREM — 정합성 보장
+     *
+     * TTL 10분으로 자동 만료되는 키(queue:active:{userId}, queue:token:{token},
+     * queue:user-token:{userId}:{scheduleId})는 24시간 후 이미 만료됨 → 삭제 불필요
+     *
+     * @return true if the queue key existed and was deleted
+     */
+    fun cleanupEndedSchedule(scheduleId: UUID): Boolean {
+        stringRedisTemplate.opsForSet().remove(QueueRedisKeys.activeSchedules(), scheduleId.toString())
+        return stringRedisTemplate.delete(QueueRedisKeys.queue(scheduleId))
+    }
+
+    /**
      * 활성 대기열 scheduleId 목록 조회
      *
      * SMEMBERS queue:active-schedules 를 통해 현재 대기 중인 회차 ID를 반환한다.

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/scheduler/QueueCleanupSchedulerTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/scheduler/QueueCleanupSchedulerTest.kt
@@ -1,15 +1,22 @@
 package com.ticketqueue.queue.scheduler
 
+import com.ticketqueue.common.exception.BusinessException
+import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.queue.client.EventServiceClient
 import com.ticketqueue.queue.service.QueueService
+import feign.Request
+import feign.RequestTemplate
+import feign.RetryableException
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.springframework.data.redis.RedisConnectionFailureException
 import java.util.UUID
 
 @DisplayName("QueueCleanupScheduler 단위 테스트")
@@ -17,13 +24,15 @@ class QueueCleanupSchedulerTest {
 
     private lateinit var eventServiceClient: EventServiceClient
     private lateinit var queueService: QueueService
+    private lateinit var registry: SimpleMeterRegistry
     private lateinit var scheduler: QueueCleanupScheduler
 
     @BeforeEach
     fun setUp() {
         eventServiceClient = mockk()
         queueService = mockk()
-        scheduler = QueueCleanupScheduler(eventServiceClient, queueService, SimpleMeterRegistry())
+        registry = SimpleMeterRegistry()
+        scheduler = QueueCleanupScheduler(eventServiceClient, queueService, registry)
     }
 
     @Test
@@ -93,5 +102,89 @@ class QueueCleanupSchedulerTest {
 
         verify(exactly = 1) { queueService.cleanupEndedSchedule(id1) }
         verify(exactly = 1) { queueService.cleanupEndedSchedule(id2) }
+    }
+
+    @Test
+    @DisplayName("RetryableException 발생 시 failedCounter가 1 증가하고 cleanup은 호출되지 않는다")
+    fun failedCounterIncreasesOnRetryableException() {
+        val feignRequest = Request.create(
+            Request.HttpMethod.GET,
+            "http://event-service/internal/schedules/ended",
+            emptyMap<String, Collection<String>>(),
+            null as Request.Body?,
+            null as RequestTemplate?
+        )
+        every { eventServiceClient.getEndedScheduleIds() } throws
+            RetryableException(503, "Service Unavailable", Request.HttpMethod.GET, null as Long?, feignRequest)
+
+        scheduler.executeCleanup()
+
+        verify(exactly = 0) { queueService.cleanupEndedSchedule(any()) }
+        assertEquals(1.0, registry.counter("queue.cleanup.failed.total").count())
+    }
+
+    @Test
+    @DisplayName("BusinessException 발생 시 failedCounter가 1 증가하고 cleanup은 호출되지 않는다")
+    fun failedCounterIncreasesOnBusinessException() {
+        every { eventServiceClient.getEndedScheduleIds() } throws
+            BusinessException(ErrorCode.INTERNAL_SERVER_ERROR)
+
+        scheduler.executeCleanup()
+
+        verify(exactly = 0) { queueService.cleanupEndedSchedule(any()) }
+        assertEquals(1.0, registry.counter("queue.cleanup.failed.total").count())
+    }
+
+    @Test
+    @DisplayName("RedisConnectionFailureException 발생 시 failedCounter가 1 증가하고 나머지 scheduleId를 계속 처리한다")
+    fun failedCounterIncreasesOnRedisConnectionFailure() {
+        val failingId = UUID.randomUUID()
+        val successId = UUID.randomUUID()
+        every { eventServiceClient.getEndedScheduleIds() } returns
+            EventServiceClient.EndedScheduleIdsResponse(listOf(failingId, successId))
+        every { queueService.cleanupEndedSchedule(failingId) } throws
+            RedisConnectionFailureException("connection failed")
+        every { queueService.cleanupEndedSchedule(successId) } returns true
+
+        scheduler.executeCleanup()
+
+        verify(exactly = 1) { queueService.cleanupEndedSchedule(successId) }
+        assertEquals(1.0, registry.counter("queue.cleanup.failed.total").count())
+        assertEquals(1.0, registry.counter("queue.cleanup.deleted.total").count())
+    }
+
+    @Test
+    @DisplayName("정상 처리 시 executedCounter=1, deletedCounter=3이 된다")
+    fun metricsAreCorrectOnSuccess() {
+        val id1 = UUID.randomUUID()
+        val id2 = UUID.randomUUID()
+        val id3 = UUID.randomUUID()
+        every { eventServiceClient.getEndedScheduleIds() } returns
+            EventServiceClient.EndedScheduleIdsResponse(listOf(id1, id2, id3))
+        every { queueService.cleanupEndedSchedule(any()) } returns true
+
+        scheduler.executeCleanup()
+
+        assertEquals(1.0, registry.counter("queue.cleanup.executed.total").count())
+        assertEquals(3.0, registry.counter("queue.cleanup.deleted.total").count())
+        assertEquals(0.0, registry.counter("queue.cleanup.failed.total").count())
+    }
+
+    @Test
+    @DisplayName("deleted/skipped 혼합 시나리오에서 deletedCounter는 실제 삭제된 수만 증가한다")
+    fun deletedCounterOnlyCountsActualDeletions() {
+        val id1 = UUID.randomUUID()
+        val id2 = UUID.randomUUID()
+        val id3 = UUID.randomUUID()
+        every { eventServiceClient.getEndedScheduleIds() } returns
+            EventServiceClient.EndedScheduleIdsResponse(listOf(id1, id2, id3))
+        every { queueService.cleanupEndedSchedule(id1) } returns true
+        every { queueService.cleanupEndedSchedule(id2) } returns true
+        every { queueService.cleanupEndedSchedule(id3) } returns false
+
+        scheduler.executeCleanup()
+
+        assertEquals(2.0, registry.counter("queue.cleanup.deleted.total").count())
+        assertEquals(0.0, registry.counter("queue.cleanup.failed.total").count())
     }
 }

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/scheduler/QueueCleanupSchedulerTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/scheduler/QueueCleanupSchedulerTest.kt
@@ -2,6 +2,7 @@ package com.ticketqueue.queue.scheduler
 
 import com.ticketqueue.queue.client.EventServiceClient
 import com.ticketqueue.queue.service.QueueService
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -22,7 +23,7 @@ class QueueCleanupSchedulerTest {
     fun setUp() {
         eventServiceClient = mockk()
         queueService = mockk()
-        scheduler = QueueCleanupScheduler(eventServiceClient, queueService)
+        scheduler = QueueCleanupScheduler(eventServiceClient, queueService, SimpleMeterRegistry())
     }
 
     @Test

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/scheduler/QueueCleanupSchedulerTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/scheduler/QueueCleanupSchedulerTest.kt
@@ -1,0 +1,96 @@
+package com.ticketqueue.queue.scheduler
+
+import com.ticketqueue.queue.client.EventServiceClient
+import com.ticketqueue.queue.service.QueueService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import java.util.UUID
+
+@DisplayName("QueueCleanupScheduler 단위 테스트")
+class QueueCleanupSchedulerTest {
+
+    private lateinit var eventServiceClient: EventServiceClient
+    private lateinit var queueService: QueueService
+    private lateinit var scheduler: QueueCleanupScheduler
+
+    @BeforeEach
+    fun setUp() {
+        eventServiceClient = mockk()
+        queueService = mockk()
+        scheduler = QueueCleanupScheduler(eventServiceClient, queueService)
+    }
+
+    @Test
+    @DisplayName("Event Service 장애 시 cleanupEndedSchedule을 호출하지 않는다")
+    fun doesNotCallCleanupWhenEventServiceFails() {
+        every { eventServiceClient.getEndedScheduleIds() } throws RuntimeException("Connection refused")
+
+        scheduler.executeCleanup()
+
+        verify(exactly = 0) { queueService.cleanupEndedSchedule(any()) }
+    }
+
+    @Test
+    @DisplayName("빈 목록 반환 시 cleanupEndedSchedule을 호출하지 않는다")
+    fun doesNotCallCleanupWhenEmptyList() {
+        every { eventServiceClient.getEndedScheduleIds() } returns
+            EventServiceClient.EndedScheduleIdsResponse(emptyList())
+
+        scheduler.executeCleanup()
+
+        verify(exactly = 0) { queueService.cleanupEndedSchedule(any()) }
+    }
+
+    @Test
+    @DisplayName("정상 3개 scheduleId 반환 시 cleanupEndedSchedule을 3번 호출한다")
+    fun callsCleanupForEachEndedSchedule() {
+        val id1 = UUID.randomUUID()
+        val id2 = UUID.randomUUID()
+        val id3 = UUID.randomUUID()
+        every { eventServiceClient.getEndedScheduleIds() } returns
+            EventServiceClient.EndedScheduleIdsResponse(listOf(id1, id2, id3))
+        every { queueService.cleanupEndedSchedule(any()) } returns true
+
+        scheduler.executeCleanup()
+
+        verify(exactly = 1) { queueService.cleanupEndedSchedule(id1) }
+        verify(exactly = 1) { queueService.cleanupEndedSchedule(id2) }
+        verify(exactly = 1) { queueService.cleanupEndedSchedule(id3) }
+    }
+
+    @Test
+    @DisplayName("개별 scheduleId 처리 실패 시 나머지 scheduleId를 계속 처리한다")
+    fun continuesProcessingRemainingSchedulesOnIndividualFailure() {
+        val failingId = UUID.randomUUID()
+        val successId = UUID.randomUUID()
+        every { eventServiceClient.getEndedScheduleIds() } returns
+            EventServiceClient.EndedScheduleIdsResponse(listOf(failingId, successId))
+        every { queueService.cleanupEndedSchedule(failingId) } throws RuntimeException("Redis timeout")
+        every { queueService.cleanupEndedSchedule(successId) } returns true
+
+        scheduler.executeCleanup()
+
+        verify(exactly = 1) { queueService.cleanupEndedSchedule(failingId) }
+        verify(exactly = 1) { queueService.cleanupEndedSchedule(successId) }
+    }
+
+    @Test
+    @DisplayName("모든 scheduleId 처리가 실패해도 예외 없이 완료된다")
+    fun completesWithoutExceptionWhenAllFail() {
+        val id1 = UUID.randomUUID()
+        val id2 = UUID.randomUUID()
+        every { eventServiceClient.getEndedScheduleIds() } returns
+            EventServiceClient.EndedScheduleIdsResponse(listOf(id1, id2))
+        every { queueService.cleanupEndedSchedule(any()) } throws RuntimeException("Redis down")
+
+        assertDoesNotThrow { scheduler.executeCleanup() }
+
+        verify(exactly = 1) { queueService.cleanupEndedSchedule(id1) }
+        verify(exactly = 1) { queueService.cleanupEndedSchedule(id2) }
+    }
+}

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/QueueServiceTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/QueueServiceTest.kt
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.data.redis.RedisConnectionFailureException
+import org.springframework.data.redis.core.RedisCallback
 import org.springframework.data.redis.core.SetOperations
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.data.redis.core.script.DefaultRedisScript
@@ -452,37 +454,40 @@ class QueueServiceTest {
     @DisplayName("cleanupEndedSchedule")
     inner class CleanupEndedSchedule {
 
-        private lateinit var setOps: SetOperations<String, String>
-
-        @BeforeEach
-        fun setUpSetOps() {
-            setOps = mockk()
-            every { stringRedisTemplate.opsForSet() } returns setOps
-            every { setOps.remove(any(), any()) } returns 1L
-        }
-
         @Test
-        @DisplayName("대기열 키가 존재하면 delete가 true를 반환하고 메서드도 true를 반환한다")
+        @DisplayName("대기열 키가 존재하면 파이프라인 DEL이 1을 반환하고 메서드도 true를 반환한다")
         fun returnsTrueWhenQueueKeyExisted() {
-            every { stringRedisTemplate.delete(any<String>()) } returns true
+            // results[0]=SREM count, results[1]=DEL count (1 = key existed)
+            every { stringRedisTemplate.executePipelined(any<RedisCallback<Any>>()) } returns listOf(1L, 1L)
 
             val result = queueService.cleanupEndedSchedule(scheduleId)
 
             assertEquals(true, result)
-            verify(exactly = 1) { setOps.remove("queue:active-schedules", scheduleId.toString()) }
-            verify(exactly = 1) { stringRedisTemplate.delete("queue:$scheduleId") }
+            verify(exactly = 1) { stringRedisTemplate.executePipelined(any<RedisCallback<Any>>()) }
         }
 
         @Test
-        @DisplayName("대기열 키가 없으면 delete가 false를 반환하고 메서드도 false를 반환한다")
+        @DisplayName("대기열 키가 없으면 파이프라인 DEL이 0을 반환하고 메서드도 false를 반환한다")
         fun returnsFalseWhenQueueKeyAbsent() {
-            every { stringRedisTemplate.delete(any<String>()) } returns false
+            // results[0]=SREM count, results[1]=DEL count (0 = key not found)
+            every { stringRedisTemplate.executePipelined(any<RedisCallback<Any>>()) } returns listOf(0L, 0L)
 
             val result = queueService.cleanupEndedSchedule(scheduleId)
 
             assertEquals(false, result)
-            verify(exactly = 1) { setOps.remove("queue:active-schedules", scheduleId.toString()) }
-            verify(exactly = 1) { stringRedisTemplate.delete("queue:$scheduleId") }
+            verify(exactly = 1) { stringRedisTemplate.executePipelined(any<RedisCallback<Any>>()) }
+        }
+
+        @Test
+        @DisplayName("Redis 연결 실패 시 RedisConnectionFailureException이 호출자에게 전파된다")
+        fun propagatesRedisConnectionFailureException() {
+            every {
+                stringRedisTemplate.executePipelined(any<RedisCallback<Any>>())
+            } throws RedisConnectionFailureException("Connection refused")
+
+            assertThrows<RedisConnectionFailureException> {
+                queueService.cleanupEndedSchedule(scheduleId)
+            }
         }
     }
 

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/QueueServiceTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/QueueServiceTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.data.redis.core.SetOperations
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.data.redis.core.script.DefaultRedisScript
 import java.util.UUID
@@ -444,6 +445,44 @@ class QueueServiceTest {
             tokenArgs.forEach { token ->
                 UUID.fromString(token) // 파싱 실패 시 IllegalArgumentException
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("cleanupEndedSchedule")
+    inner class CleanupEndedSchedule {
+
+        private lateinit var setOps: SetOperations<String, String>
+
+        @BeforeEach
+        fun setUpSetOps() {
+            setOps = mockk()
+            every { stringRedisTemplate.opsForSet() } returns setOps
+            every { setOps.remove(any(), any()) } returns 1L
+        }
+
+        @Test
+        @DisplayName("대기열 키가 존재하면 delete가 true를 반환하고 메서드도 true를 반환한다")
+        fun returnsTrueWhenQueueKeyExisted() {
+            every { stringRedisTemplate.delete(any<String>()) } returns true
+
+            val result = queueService.cleanupEndedSchedule(scheduleId)
+
+            assertEquals(true, result)
+            verify(exactly = 1) { setOps.remove("queue:active-schedules", scheduleId.toString()) }
+            verify(exactly = 1) { stringRedisTemplate.delete("queue:$scheduleId") }
+        }
+
+        @Test
+        @DisplayName("대기열 키가 없으면 delete가 false를 반환하고 메서드도 false를 반환한다")
+        fun returnsFalseWhenQueueKeyAbsent() {
+            every { stringRedisTemplate.delete(any<String>()) } returns false
+
+            val result = queueService.cleanupEndedSchedule(scheduleId)
+
+            assertEquals(false, result)
+            verify(exactly = 1) { setOps.remove("queue:active-schedules", scheduleId.toString()) }
+            verify(exactly = 1) { stringRedisTemplate.delete("queue:$scheduleId") }
         }
     }
 

--- a/docker/db_init/3_event_service_ddl.sql
+++ b/docker/db_init/3_event_service_ddl.sql
@@ -128,7 +128,7 @@ CREATE INDEX idx_schedules_status_sale_start ON event_service.event_schedules(st
 CREATE INDEX idx_schedules_event_date ON event_service.event_schedules(event_id, event_start_at);
 CREATE INDEX idx_schedules_sale_start ON event_service.event_schedules(sale_start_at) WHERE status = 'UPCOMING';
 -- 대기열 정리 배치용: status IN ('ENDED','CANCELLED') AND event_end_at < cutoff, id for keyset pagination
-CREATE INDEX idx_schedules_status_event_end ON event_service.event_schedules(status, event_end_at, id);
+CREATE INDEX idx_schedules_status_event_end ON event_service.event_schedules(status, event_end_at, id) WHERE status IN ('ENDED', 'CANCELLED');
 
 -- updated_at Trigger
 CREATE TRIGGER trg_schedules_updated_at

--- a/docker/db_init/3_event_service_ddl.sql
+++ b/docker/db_init/3_event_service_ddl.sql
@@ -127,6 +127,8 @@ CREATE TABLE event_service.event_schedules (
 CREATE INDEX idx_schedules_status_sale_start ON event_service.event_schedules(status, sale_start_at);
 CREATE INDEX idx_schedules_event_date ON event_service.event_schedules(event_id, event_start_at);
 CREATE INDEX idx_schedules_sale_start ON event_service.event_schedules(sale_start_at) WHERE status = 'UPCOMING';
+-- 대기열 정리 배치용: status IN ('ENDED','CANCELLED') AND event_end_at < cutoff
+CREATE INDEX idx_schedules_status_event_end ON event_service.event_schedules(status, event_end_at);
 
 -- updated_at Trigger
 CREATE TRIGGER trg_schedules_updated_at

--- a/docker/db_init/3_event_service_ddl.sql
+++ b/docker/db_init/3_event_service_ddl.sql
@@ -127,8 +127,8 @@ CREATE TABLE event_service.event_schedules (
 CREATE INDEX idx_schedules_status_sale_start ON event_service.event_schedules(status, sale_start_at);
 CREATE INDEX idx_schedules_event_date ON event_service.event_schedules(event_id, event_start_at);
 CREATE INDEX idx_schedules_sale_start ON event_service.event_schedules(sale_start_at) WHERE status = 'UPCOMING';
--- 대기열 정리 배치용: status IN ('ENDED','CANCELLED') AND event_end_at < cutoff
-CREATE INDEX idx_schedules_status_event_end ON event_service.event_schedules(status, event_end_at);
+-- 대기열 정리 배치용: status IN ('ENDED','CANCELLED') AND event_end_at < cutoff, id for keyset pagination
+CREATE INDEX idx_schedules_status_event_end ON event_service.event_schedules(status, event_end_at, id);
 
 -- updated_at Trigger
 CREATE TRIGGER trg_schedules_updated_at

--- a/docs/architecture/04_data.md
+++ b/docs/architecture/04_data.md
@@ -1087,6 +1087,7 @@ COMMENT ON TABLE common.processed_events IS 'Kafka Consumer 멱등성 보장. (e
 | `queue:{scheduleId}` | Sorted Set | 대기열 (score: timestamp) | 없음 | Queue |
 | `queue:token:{token}` | String | Queue Token (qr_xxx) | 10분 | Queue |
 | `queue:active:{userId}` | String | 사용자 활성 대기열 (중복 방지) | 10분 | Queue |
+| `queue:active-schedules` | Set | 활성 대기열 scheduleId 추적 (정리 배치 기준) | 없음 | Queue |
 | `rate:ip:{ip}` | String (Integer) | IP 기반 Rate Limiting (Token Bucket) | 1분 | Gateway |
 | `rate:user:{userId}:{endpoint}` | String (Integer) | 사용자 기반 Rate Limiting | 1분 | Gateway |
 | `seat:hold:{scheduleId}:{seatId}` | String | 좌석 선점 락 (userId) | 5분 | Reservation |
@@ -1154,7 +1155,7 @@ EXISTS queue:active:user-abc
 - **로직**:
   1. Event Service 내부 API(`/internal/schedules/ended`) 경유로 정리 대상 회차 ID 조회
      - 조건: `event_schedules.status IN ('ENDED', 'CANCELLED') AND event_end_at < now() - INTERVAL '24 hours'`
-     - 최대 1000건, `event_end_at ASC` 정렬 (오래된 것부터 처리)
+     - 1000건씩 커서 페이지네이션 (keyset: `event_end_at ASC, id ASC`), 전체 대상 누락 없이 처리
   2. `queue:active-schedules` Set에서 해당 scheduleId 제거 (`SREM`)
   3. 해당 회차의 Redis 대기열 Sorted Set 삭제 (`DEL queue:{scheduleId}`)
 - **목적**: Redis 메모리 절약, 고아 데이터 제거

--- a/docs/architecture/04_data.md
+++ b/docs/architecture/04_data.md
@@ -1149,7 +1149,7 @@ EXISTS queue:active:user-abc
 ```
 
 **대기열 정리 배치 작업:**
-- **실행 주기**: 매일 03:00 UTC
+- **실행 주기**: 매일 03:00 KST (Asia/Seoul)
 - **정리 조건**: 공연 회차 종료 + 24시간 경과
 - **로직**:
   1. PostgreSQL에서 종료된 회차 조회 (`event_schedules.status = 'ENDED' AND event_end_at < now() - INTERVAL '24 hours'`)

--- a/docs/architecture/04_data.md
+++ b/docs/architecture/04_data.md
@@ -1149,11 +1149,14 @@ EXISTS queue:active:user-abc
 ```
 
 **대기열 정리 배치 작업:**
-- **실행 주기**: 매일 03:00 KST (Asia/Seoul)
-- **정리 조건**: 공연 회차 종료 + 24시간 경과
+- **실행 주기**: 매일 03:00 KST (`cron = "0 0 3 * * *", zone = "Asia/Seoul"`)
+- **정리 조건**: 공연 회차 종료/취소 + 24시간 경과
 - **로직**:
-  1. PostgreSQL에서 종료된 회차 조회 (`event_schedules.status = 'ENDED' AND event_end_at < now() - INTERVAL '24 hours'`)
-  2. 해당 회차의 Redis 대기열 삭제 (`DEL queue:{scheduleId}`)
+  1. Event Service 내부 API(`/internal/schedules/ended`) 경유로 정리 대상 회차 ID 조회
+     - 조건: `event_schedules.status IN ('ENDED', 'CANCELLED') AND event_end_at < now() - INTERVAL '24 hours'`
+     - 최대 1000건, `event_end_at ASC` 정렬 (오래된 것부터 처리)
+  2. `queue:active-schedules` Set에서 해당 scheduleId 제거 (`SREM`)
+  3. 해당 회차의 Redis 대기열 Sorted Set 삭제 (`DEL queue:{scheduleId}`)
 - **목적**: Redis 메모리 절약, 고아 데이터 제거
 
 **관련 요구사항:** REQ-QUEUE-001, REQ-QUEUE-003, REQ-QUEUE-004, REQ-QUEUE-011

--- a/docs/specification/02_event_service.md
+++ b/docs/specification/02_event_service.md
@@ -223,6 +223,27 @@ Reservation Service가 호출합니다.
 }
 ```
 
+### 2.2 대기열 정리 대상 회차 조회
+Queue Service 정리 배치가 호출합니다. 종료/취소 후 24시간 이상 경과한 회차 ID 전체를 반환합니다.
+
+- **URL:** `GET /internal/schedules/ended`
+- **Headers:** `X-Service-Api-Key: {UUID}`
+
+**Response (200 OK)**
+```json
+{
+  "scheduleIds": [
+    "schedule_uuid_1",
+    "schedule_uuid_2"
+  ]
+}
+```
+
+**에러 응답**
+| 상태 코드 | code | 설명 |
+|----------|------|------|
+| 500 | `INTERNAL_SERVER_ERROR` | 내부 처리 오류 |
+
 ## 3. 공연장 (Venues)
 
 ### 3.1 공연장 생성

--- a/docs/specification/02_event_service.md
+++ b/docs/specification/02_event_service.md
@@ -224,12 +224,14 @@ Reservation Service가 호출합니다.
 ```
 
 ### 2.2 대기열 정리 대상 회차 조회
+
 Queue Service 정리 배치가 호출합니다. 종료/취소 후 24시간 이상 경과한 회차 ID 전체를 반환합니다.
 
 - **URL:** `GET /internal/schedules/ended`
 - **Headers:** `X-Service-Api-Key: {UUID}`
 
 **Response (200 OK)**
+
 ```json
 {
   "scheduleIds": [
@@ -240,6 +242,7 @@ Queue Service 정리 배치가 호출합니다. 종료/취소 후 24시간 이�
 ```
 
 **에러 응답**
+
 | 상태 코드 | code | 설명 |
 |----------|------|------|
 | 500 | `INTERNAL_SERVER_ERROR` | 내부 처리 오류 |


### PR DESCRIPTION
## Summary
- 종료(ENDED) 또는 취소(CANCELLED)된 회차의 Redis 대기열 키를 주기적으로 정리하는 배치 작업 구현
- CANCELLED 회차도 정리 대상에 포함하고, LIMIT 1000으로 쿼리 부하 제한
- cutoff 계산 책임을 Controller에서 Service로 이동 (SRP 준수)
- Redis 작업 순서를 SREM → DEL로 변경하여 active-schedules 정합성 보장

## Changes
- `QueueCleanupScheduler`: `@Scheduled` 배치 — 매일 03:00 KST, Event Service Feign 호출 후 scheduleId별 Redis 정리
- `EventScheduleRepositoryCustom` / `EventScheduleRepositoryCustomImpl`: QueryDSL로 ENDED/CANCELLED 회차 조회 (`findCleanupTargetScheduleIds`), LIMIT 1000
- `QueueService.cleanupEndedSchedule`: SREM → DEL 순서 변경 (DEL 실패 시 다음 배치에서 idempotent 재시도 가능)
- `ScheduleService.getCleanupTargetScheduleIds`: 24시간 cutoff 계산을 Service 내부로 이동
- `EventServiceClient`: `getEndedScheduleIds()` Feign 메서드 추가
- `InternalScheduleController`: `GET /internal/schedules/ended` 엔드포인트 추가
- `EventScheduleRepositoryCustomImplTest`: TestContainers PostgreSQL 통합 테스트 5개 (ENDED/CANCELLED 포함, cutoff 경계값 검증)
- `QueueCleanupSchedulerTest`: 전체 실패 시나리오 추가
- `QueueServiceTest`: Redis key 정확성 검증 (`queue:active-schedules`, `queue:{scheduleId}`)

## Test plan
- [x] `ScheduleServiceTest` — `getCleanupTargetScheduleIds` 단위 테스트 통과
- [x] `InternalScheduleControllerTest` — `GET /internal/schedules/ended` 단위 테스트 통과
- [x] `QueueServiceTest` — `cleanupEndedSchedule` 정확한 Redis key 검증 통과
- [x] `QueueCleanupSchedulerTest` — 정상/실패/전체실패 시나리오 통과
- [x] `EventScheduleRepositoryCustomImplTest` — TestContainers 통합 테스트 5개 통과

Closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated daily queue cleanup at 03:00 KST for completed and cancelled schedules; internal API to fetch ended schedule IDs; Redis removal of orphaned queue data; trace-id header propagation to downstream calls.
* **Tests**
  * Added unit and integration tests for scheduler, repository cleanup query, and Redis cleanup logic.
* **Documentation**
  * Updated architecture and API docs with KST schedule, cleanup workflow, and new internal endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->