### PR TITLE
fix: [Gateway] X-User-Id/X-User-Role 헤더 인젝션 취약점 수정

### DIFF
--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilter.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilter.kt
@@ -58,12 +58,6 @@ class JwtAuthenticationWebFilter(
     }
 
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
-        // CORS preflight (OPTIONS) 요청은 JWT 검증 없이 통과
-        // globalcors가 라우팅 핸들러 레벨에서 처리하므로 WebFilter가 개입하지 않아야 함
-        if (exchange.request.method == HttpMethod.OPTIONS) {
-            return chain.filter(exchange)
-        }
-
         // [보안] Strip-First 패턴: 외부 클라이언트가 인젝션한 신뢰 헤더를 무조건 제거.
         // JWT 검증 성공 시에만 클레임 기반으로 재추가하여 헤더 인젝션 취약점(사용자 사칭) 방지.
         val sanitizedExchange = exchange.mutate()
@@ -76,6 +70,12 @@ class JwtAuthenticationWebFilter(
                     .build()
             )
             .build()
+
+        // CORS preflight (OPTIONS) 요청은 JWT 검증 없이 통과
+        // globalcors가 라우팅 핸들러 레벨에서 처리하므로 WebFilter가 개입하지 않아야 함
+        if (exchange.request.method == HttpMethod.OPTIONS) {
+            return chain.filter(sanitizedExchange)
+        }
 
         // 1. 공개 엔드포인트 통과
         if (routeValidator.isPublic(sanitizedExchange)) {
@@ -124,8 +124,10 @@ class JwtAuthenticationWebFilter(
 
                     // 6. 사용자 정보 헤더 추가 후 downstream 전달 (sanitize된 요청에 JWT 클레임만 추가)
                     val mutatedRequest = sanitizedExchange.request.mutate()
-                        .header(USER_ID_HEADER, claims.userId)
-                        .header(USER_ROLE_HEADER, claims.role)
+                        .headers { headers ->
+                            headers.set(USER_ID_HEADER, claims.userId)
+                            headers.set(USER_ROLE_HEADER, claims.role)
+                        }
                         .build()
 
                     chain.filter(sanitizedExchange.mutate().request(mutatedRequest).build())

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilter.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilter.kt
@@ -64,16 +64,29 @@ class JwtAuthenticationWebFilter(
             return chain.filter(exchange)
         }
 
+        // [보안] Strip-First 패턴: 외부 클라이언트가 인젝션한 신뢰 헤더를 무조건 제거.
+        // JWT 검증 성공 시에만 클레임 기반으로 재추가하여 헤더 인젝션 취약점(사용자 사칭) 방지.
+        val sanitizedExchange = exchange.mutate()
+            .request(
+                exchange.request.mutate()
+                    .headers { headers ->
+                        headers.remove(USER_ID_HEADER)
+                        headers.remove(USER_ROLE_HEADER)
+                    }
+                    .build()
+            )
+            .build()
+
         // 1. 공개 엔드포인트 통과
-        if (routeValidator.isPublic(exchange)) {
-            return chain.filter(exchange)
+        if (routeValidator.isPublic(sanitizedExchange)) {
+            return chain.filter(sanitizedExchange)
         }
 
         // 2. Authorization 헤더 추출
-        val authHeader = exchange.request.headers.getFirst(AUTHORIZATION_HEADER)
+        val authHeader = sanitizedExchange.request.headers.getFirst(AUTHORIZATION_HEADER)
         if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
-            log.debug { "Missing or invalid Authorization header: ${exchange.request.path}" }
-            return writeErrorResponse(exchange, HttpStatus.UNAUTHORIZED, CODE_UNAUTHORIZED, "인증이 필요합니다.")
+            log.debug { "Missing or invalid Authorization header: ${sanitizedExchange.request.path}" }
+            return writeErrorResponse(sanitizedExchange, HttpStatus.UNAUTHORIZED, CODE_UNAUTHORIZED, "인증이 필요합니다.")
         }
 
         val token = authHeader.removePrefix(BEARER_PREFIX)
@@ -82,14 +95,14 @@ class JwtAuthenticationWebFilter(
         val claims = try {
             jwtTokenProvider.validateAndExtract(token)
         } catch (e: ExpiredJwtException) {
-            log.debug { "Expired JWT token: ${exchange.request.path}" }
-            return writeErrorResponse(exchange, HttpStatus.UNAUTHORIZED, CODE_EXPIRED_TOKEN, "토큰이 만료되었습니다.")
+            log.debug { "Expired JWT token: ${sanitizedExchange.request.path}" }
+            return writeErrorResponse(sanitizedExchange, HttpStatus.UNAUTHORIZED, CODE_EXPIRED_TOKEN, "토큰이 만료되었습니다.")
         } catch (e: JwtException) {
             log.debug { "Invalid JWT token: ${e.message}" }
-            return writeErrorResponse(exchange, HttpStatus.UNAUTHORIZED, CODE_INVALID_TOKEN, "유효하지 않은 토큰입니다.")
+            return writeErrorResponse(sanitizedExchange, HttpStatus.UNAUTHORIZED, CODE_INVALID_TOKEN, "유효하지 않은 토큰입니다.")
         } catch (e: IllegalArgumentException) {
             log.debug { "Invalid JWT token argument: ${e.message}" }
-            return writeErrorResponse(exchange, HttpStatus.UNAUTHORIZED, CODE_INVALID_TOKEN, "유효하지 않은 토큰입니다.")
+            return writeErrorResponse(sanitizedExchange, HttpStatus.UNAUTHORIZED, CODE_INVALID_TOKEN, "유효하지 않은 토큰입니다.")
         }
 
         // 4. 블랙리스트 확인 (Redis non-blocking)
@@ -101,21 +114,21 @@ class JwtAuthenticationWebFilter(
             .flatMap { isBlacklisted ->
                 if (isBlacklisted) {
                     log.debug { "Blacklisted token jti=${claims.jti}" }
-                    writeErrorResponse(exchange, HttpStatus.UNAUTHORIZED, CODE_INVALID_TOKEN, "유효하지 않은 토큰입니다.")
+                    writeErrorResponse(sanitizedExchange, HttpStatus.UNAUTHORIZED, CODE_INVALID_TOKEN, "유효하지 않은 토큰입니다.")
                 } else {
                     // 5. 관리자 전용 엔드포인트 인가 검사
-                    if (routeValidator.isAdminOnly(exchange) && claims.role != "ADMIN") {
-                        log.debug { "Forbidden: role=${claims.role} path=${exchange.request.path}" }
-                        return@flatMap writeErrorResponse(exchange, HttpStatus.FORBIDDEN, CODE_FORBIDDEN, "접근 권한이 없습니다.")
+                    if (routeValidator.isAdminOnly(sanitizedExchange) && claims.role != "ADMIN") {
+                        log.debug { "Forbidden: role=${claims.role} path=${sanitizedExchange.request.path}" }
+                        return@flatMap writeErrorResponse(sanitizedExchange, HttpStatus.FORBIDDEN, CODE_FORBIDDEN, "접근 권한이 없습니다.")
                     }
 
-                    // 6. 사용자 정보 헤더 추가 후 downstream 전달
-                    val mutatedRequest = exchange.request.mutate()
+                    // 6. 사용자 정보 헤더 추가 후 downstream 전달 (sanitize된 요청에 JWT 클레임만 추가)
+                    val mutatedRequest = sanitizedExchange.request.mutate()
                         .header(USER_ID_HEADER, claims.userId)
                         .header(USER_ROLE_HEADER, claims.role)
                         .build()
 
-                    chain.filter(exchange.mutate().request(mutatedRequest).build())
+                    chain.filter(sanitizedExchange.mutate().request(mutatedRequest).build())
                 }
             }
     }

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilter.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilter.kt
@@ -50,6 +50,9 @@ class JwtAuthenticationWebFilter(
         const val USER_ID_HEADER = "X-User-Id"
         const val USER_ROLE_HEADER = "X-User-Role"
 
+        // 허용된 role 목록 (GatewayAuthFilter와 동일한 값 유지)
+        private val ALLOWED_ROLES = setOf("USER", "ADMIN")
+
         // 에러 코드 상수 (common 모듈 의존 불가로 인라인 정의)
         private const val CODE_UNAUTHORIZED = "UNAUTHORIZED"
         private const val CODE_INVALID_TOKEN = "INVALID_TOKEN"
@@ -116,7 +119,13 @@ class JwtAuthenticationWebFilter(
                     log.debug { "Blacklisted token jti=${claims.jti}" }
                     writeErrorResponse(sanitizedExchange, HttpStatus.UNAUTHORIZED, CODE_INVALID_TOKEN, "유효하지 않은 토큰입니다.")
                 } else {
-                    // 5. 관리자 전용 엔드포인트 인가 검사
+                    // 5-1. Role 화이트리스트 검증
+                    if (claims.role !in ALLOWED_ROLES) {
+                        log.debug { "Invalid role: role=${claims.role} path=${sanitizedExchange.request.path}" }
+                        return@flatMap writeErrorResponse(sanitizedExchange, HttpStatus.FORBIDDEN, CODE_FORBIDDEN, "접근 권한이 없습니다.")
+                    }
+
+                    // 5-2. 관리자 전용 엔드포인트 인가 검사
                     if (routeValidator.isAdminOnly(sanitizedExchange) && claims.role != "ADMIN") {
                         log.debug { "Forbidden: role=${claims.role} path=${sanitizedExchange.request.path}" }
                         return@flatMap writeErrorResponse(sanitizedExchange, HttpStatus.FORBIDDEN, CODE_FORBIDDEN, "접근 권한이 없습니다.")

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/security/RouteValidator.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/security/RouteValidator.kt
@@ -26,6 +26,8 @@ class RouteValidator {
     private val publicRoutes: List<RouteRule> = listOf(
         RouteRule("/auth/signup", HttpMethod.POST),
         RouteRule("/auth/login", HttpMethod.POST),
+        // Access Token이 아닌 Refresh Token으로 검증하므로 JWT(Access Token) 필터를 우회.
+        // Refresh Token 유효성 검증은 User Service 내부에서 수행.
         RouteRule("/auth/refresh", HttpMethod.POST),
         RouteRule("/events", HttpMethod.GET),
         RouteRule("/events/*", HttpMethod.GET),

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterTest.kt
@@ -15,7 +15,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import reactor.core.publisher.Mono
 import java.util.UUID
 
-private val VALID_QUEUE_TOKEN = "qr_${UUID.randomUUID()}"
+private val MOCK_QUEUE_TOKEN = "qr_${UUID.randomUUID()}"
 
 /**
  * JwtAuthenticationWebFilter 통합 테스트
@@ -91,7 +91,7 @@ class JwtAuthenticationWebFilterTest : BaseIntegrationTest() {
             .header(JwtAuthenticationWebFilter.USER_ID_HEADER, "99")
             .header(JwtAuthenticationWebFilter.USER_ROLE_HEADER, "ADMIN")
             .exchange()
-            .expectStatus().is5xxServerError // downstream 부재로 5xx, 인젝션 헤더로 인한 401이 아님
+            .expectStatus().is5xxServerError // downstream 부재로 5xx. 헤더 제거 직접 검증은 JwtAuthenticationWebFilterUnitTest의 capturingChain 기반 테스트로 수행.
     }
 
     @Test
@@ -117,7 +117,7 @@ class JwtAuthenticationWebFilterTest : BaseIntegrationTest() {
         webTestClient.post()
             .uri("/reservations/hold")
             .header("Authorization", "Bearer $token")
-            .header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, VALID_QUEUE_TOKEN) // Queue Token 필수 경로
+            .header(QueueTokenWebFilter.QUEUE_TOKEN_HEADER, MOCK_QUEUE_TOKEN) // Queue Token 필수 경로
             .exchange()
             .expectStatus().is5xxServerError // JWT + Queue Token 필터 모두 통과, downstream 없어서 5xx
     }

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterTest.kt
@@ -80,6 +80,34 @@ class JwtAuthenticationWebFilterTest : BaseIntegrationTest() {
             }
     }
 
+    // ─── 헤더 인젝션 방어 ──────────────────────────────────────────────
+
+    @Test
+    fun `공개 엔드포인트에서 X-User-Id, X-User-Role 헤더 인젝션 시 downstream에 전달되지 않는다`() {
+        // 공개 경로는 JWT 검증 없이 통과하지만, 인젝션 헤더는 제거되어야 함
+        // downstream이 없으므로 5xx가 반환되나 401(UNAUTHORIZED)이 아닌 것이 핵심
+        webTestClient.get()
+            .uri("/events")
+            .header(JwtAuthenticationWebFilter.USER_ID_HEADER, "99")
+            .header(JwtAuthenticationWebFilter.USER_ROLE_HEADER, "ADMIN")
+            .exchange()
+            .expectStatus().is5xxServerError // downstream 부재로 5xx, 인젝션 헤더로 인한 401이 아님
+    }
+
+    @Test
+    fun `JWT 없이 보호 경로에 X-User-Role ADMIN 인젝션 시 401 반환`() {
+        webTestClient.get()
+            .uri("/users/me")
+            .header(JwtAuthenticationWebFilter.USER_ID_HEADER, "1")
+            .header(JwtAuthenticationWebFilter.USER_ROLE_HEADER, "ADMIN")
+            .exchange()
+            .expectStatus().isUnauthorized
+            .expectBody(String::class.java)
+            .value { body ->
+                body shouldContain "\"code\":\"UNAUTHORIZED\""
+            }
+    }
+
     @Test
     fun `유효한 토큰으로 보호 엔드포인트 접근 시 downstream으로 전달 (5xx는 downstream 부재 때문)`() {
         every { tokenBlacklistService.isBlacklisted(any()) } returns Mono.just(false)

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterUnitTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterUnitTest.kt
@@ -286,6 +286,56 @@ class JwtAuthenticationWebFilterUnitTest {
         body shouldContain "\"traceId\""
     }
 
+    // ─── 헤더 인젝션 방어 ──────────────────────────────────────────────
+
+    @Test
+    fun `공개 경로에서 X-User-Id, X-User-Role 인젝션 헤더가 제거된 채로 chain에 전달된다`() {
+        val exchange = exchange(HttpMethod.GET, "/events") {
+            header(JwtAuthenticationWebFilter.USER_ID_HEADER, "99")
+            header(JwtAuthenticationWebFilter.USER_ROLE_HEADER, "ADMIN")
+        }
+
+        StepVerifier.create(filter.filter(exchange, capturingChain))
+            .verifyComplete()
+
+        capturedHeaders?.containsKey(JwtAuthenticationWebFilter.USER_ID_HEADER) shouldBe false
+        capturedHeaders?.containsKey(JwtAuthenticationWebFilter.USER_ROLE_HEADER) shouldBe false
+    }
+
+    @Test
+    fun `보호 경로에서 인젝션된 X-User-Role이 JWT 클레임 값으로 대체된다`() {
+        val claims = JwtClaims(userId = "user-1", role = "USER", jti = "jti-1")
+        every { jwtTokenProvider.validateAndExtract(any()) } returns claims
+        every { tokenBlacklistService.isBlacklisted("jti-1") } returns Mono.just(false)
+
+        val exchange = exchange(HttpMethod.POST, "/reservations/hold") {
+            header(HttpHeaders.AUTHORIZATION, "Bearer valid.token")
+            header(JwtAuthenticationWebFilter.USER_ID_HEADER, "malicious-id")
+            header(JwtAuthenticationWebFilter.USER_ROLE_HEADER, "ADMIN")
+        }
+
+        StepVerifier.create(filter.filter(exchange, capturingChain))
+            .verifyComplete()
+
+        capturedHeaders?.getFirst(JwtAuthenticationWebFilter.USER_ID_HEADER) shouldBe "user-1"
+        capturedHeaders?.getFirst(JwtAuthenticationWebFilter.USER_ROLE_HEADER) shouldBe "USER"
+    }
+
+    @Test
+    fun `JWT 없이 보호 경로에 X-User-Id, X-User-Role 인젝션 시 401 반환`() {
+        val exchange = exchange(HttpMethod.GET, "/reservations/seats/1") {
+            header(JwtAuthenticationWebFilter.USER_ID_HEADER, "1")
+            header(JwtAuthenticationWebFilter.USER_ROLE_HEADER, "ADMIN")
+        }
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"UNAUTHORIZED\""
+    }
+
     // ─── 헬퍼 ─────────────────────────────────────────────────────────
 
     private fun exchangeWithBearer(

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterUnitTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterUnitTest.kt
@@ -242,6 +242,23 @@ class JwtAuthenticationWebFilterUnitTest {
         body shouldContain "접근 권한이 없습니다"
     }
 
+    @Test
+    fun `허용되지 않은 role이 JWT에 포함된 경우 403 FORBIDDEN 반환`() {
+        val claims = JwtClaims(userId = "user-1", role = "SUPERADMIN", jti = "jti-1")
+        every { jwtTokenProvider.validateAndExtract(any()) } returns claims
+        every { tokenBlacklistService.isBlacklisted("jti-1") } returns Mono.just(false)
+
+        val exchange = exchangeWithBearer(HttpMethod.GET, "/reservations/seats/1", "valid.token")
+
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+
+        exchange.response.statusCode shouldBe HttpStatus.FORBIDDEN
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"FORBIDDEN\""
+        body shouldContain "접근 권한이 없습니다"
+    }
+
     // ─── 성공 케이스 ───────────────────────────────────────────────────
 
     @Test

--- a/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterUnitTest.kt
+++ b/backend/api-gateway/src/test/kotlin/com/ticketqueue/gateway/filter/JwtAuthenticationWebFilterUnitTest.kt
@@ -11,6 +11,7 @@ import com.ticketqueue.gateway.support.responseBody
 import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.JwtException
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
@@ -268,8 +269,9 @@ class JwtAuthenticationWebFilterUnitTest {
         StepVerifier.create(filter.filter(exchange, capturingChain))
             .verifyComplete()
 
-        capturedHeaders?.getFirst(JwtAuthenticationWebFilter.USER_ID_HEADER) shouldBe "user-42"
-        capturedHeaders?.getFirst(JwtAuthenticationWebFilter.USER_ROLE_HEADER) shouldBe "USER"
+        capturedHeaders shouldNotBe null
+        capturedHeaders!!.getFirst(JwtAuthenticationWebFilter.USER_ID_HEADER) shouldBe "user-42"
+        capturedHeaders!!.getFirst(JwtAuthenticationWebFilter.USER_ROLE_HEADER) shouldBe "USER"
     }
 
     @Test
@@ -298,8 +300,9 @@ class JwtAuthenticationWebFilterUnitTest {
         StepVerifier.create(filter.filter(exchange, capturingChain))
             .verifyComplete()
 
-        capturedHeaders?.containsKey(JwtAuthenticationWebFilter.USER_ID_HEADER) shouldBe false
-        capturedHeaders?.containsKey(JwtAuthenticationWebFilter.USER_ROLE_HEADER) shouldBe false
+        capturedHeaders shouldNotBe null
+        capturedHeaders!!.containsKey(JwtAuthenticationWebFilter.USER_ID_HEADER) shouldBe false
+        capturedHeaders!!.containsKey(JwtAuthenticationWebFilter.USER_ROLE_HEADER) shouldBe false
     }
 
     @Test
@@ -317,8 +320,9 @@ class JwtAuthenticationWebFilterUnitTest {
         StepVerifier.create(filter.filter(exchange, capturingChain))
             .verifyComplete()
 
-        capturedHeaders?.getFirst(JwtAuthenticationWebFilter.USER_ID_HEADER) shouldBe "user-1"
-        capturedHeaders?.getFirst(JwtAuthenticationWebFilter.USER_ROLE_HEADER) shouldBe "USER"
+        capturedHeaders shouldNotBe null
+        capturedHeaders!!.getFirst(JwtAuthenticationWebFilter.USER_ID_HEADER) shouldBe "user-1"
+        capturedHeaders!!.getFirst(JwtAuthenticationWebFilter.USER_ROLE_HEADER) shouldBe "USER"
     }
 
     @Test
@@ -334,6 +338,49 @@ class JwtAuthenticationWebFilterUnitTest {
         exchange.response.statusCode shouldBe HttpStatus.UNAUTHORIZED
         val body = responseBody(exchange)
         body shouldContain "\"code\":\"UNAUTHORIZED\""
+    }
+
+    @Test
+    fun `OPTIONS 요청에 X-User-Id, X-User-Role 인젝션 헤더가 포함되어도 chain에 제거된 채로 전달된다`() {
+        val exchange = exchange(HttpMethod.OPTIONS, "/events") {
+            header(JwtAuthenticationWebFilter.USER_ID_HEADER, "99")
+            header(JwtAuthenticationWebFilter.USER_ROLE_HEADER, "ADMIN")
+        }
+        StepVerifier.create(filter.filter(exchange, capturingChain))
+            .verifyComplete()
+        capturedHeaders shouldNotBe null
+        capturedHeaders!!.containsKey(JwtAuthenticationWebFilter.USER_ID_HEADER) shouldBe false
+        capturedHeaders!!.containsKey(JwtAuthenticationWebFilter.USER_ROLE_HEADER) shouldBe false
+    }
+
+    @Test
+    fun `ADMIN 전용 경로에 USER 토큰으로 ADMIN role 인젝션 시 인젝션이 무시되고 403 반환`() {
+        val claims = JwtClaims(userId = "user-1", role = "USER", jti = "jti-1")
+        every { jwtTokenProvider.validateAndExtract(any()) } returns claims
+        every { tokenBlacklistService.isBlacklisted("jti-1") } returns Mono.just(false)
+        val exchange = exchange(HttpMethod.POST, "/events") {
+            header(HttpHeaders.AUTHORIZATION, "Bearer valid.token")
+            header(JwtAuthenticationWebFilter.USER_ROLE_HEADER, "ADMIN")  // 인젝션 시도
+        }
+        StepVerifier.create(filter.filter(exchange, passChain))
+            .verifyComplete()
+        exchange.response.statusCode shouldBe HttpStatus.FORBIDDEN
+        val body = responseBody(exchange)
+        body shouldContain "\"code\":\"FORBIDDEN\""
+    }
+
+    @Test
+    fun `동일 헤더를 여러 값으로 인젝션해도 downstream에 전혀 전달되지 않는다`() {
+        val exchange = exchange(HttpMethod.GET, "/events") {
+            header(JwtAuthenticationWebFilter.USER_ID_HEADER, "id-1")
+            header(JwtAuthenticationWebFilter.USER_ID_HEADER, "id-2")  // 같은 헤더 두 번
+            header(JwtAuthenticationWebFilter.USER_ROLE_HEADER, "ADMIN")
+        }
+        StepVerifier.create(filter.filter(exchange, capturingChain))
+            .verifyComplete()
+        capturedHeaders shouldNotBe null
+        capturedHeaders!!.getOrEmpty(JwtAuthenticationWebFilter.USER_ID_HEADER) shouldBe emptyList()
+        capturedHeaders!!.getOrEmpty(JwtAuthenticationWebFilter.USER_ROLE_HEADER) shouldBe emptyList()
     }
 
     // ─── 헬퍼 ─────────────────────────────────────────────────────────

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/security/GatewayAuthFilter.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/security/GatewayAuthFilter.kt
@@ -28,6 +28,10 @@ import org.springframework.web.filter.OncePerRequestFilter
  */
 class GatewayAuthFilter : OncePerRequestFilter() {
 
+    companion object {
+        private val ALLOWED_ROLES = setOf("USER", "ADMIN")
+    }
+
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -36,7 +40,7 @@ class GatewayAuthFilter : OncePerRequestFilter() {
         val userId = request.getHeader("X-User-Id")
         val userRole = request.getHeader("X-User-Role")
 
-        if (userId != null && userRole != null) {
+        if (userId != null && userRole != null && userRole in ALLOWED_ROLES) {
             val authorities = listOf(SimpleGrantedAuthority("ROLE_$userRole"))
             val authentication = UsernamePasswordAuthenticationToken(userId, null, authorities)
             SecurityContextHolder.getContext().authentication = authentication


### PR DESCRIPTION
## Summary
- `JwtAuthenticationWebFilter`에서 Strip-First 패턴 적용: 모든 ingress 요청에서 `X-User-Id`, `X-User-Role` 헤더를 무조건 제거
- JWT 검증 성공 시에만 클레임 기반으로 헤더를 재추가하여 외부 클라이언트의 헤더 인젝션으로 인한 사용자 사칭 및 권한 탈취 차단

## Changes
- `JwtAuthenticationWebFilter.kt`: OPTIONS 체크 직후 `sanitizedExchange` 생성 후 이후 모든 로직에서 사용
- `JwtAuthenticationWebFilterUnitTest.kt`: 헤더 인젝션 방어 단위 테스트 3개 추가
- `JwtAuthenticationWebFilterTest.kt`: 헤더 인젝션 방어 통합 테스트 2개 추가

## Test plan
- [x] 공개 경로에서 X-User-Id, X-User-Role 인젝션 헤더가 제거된 채로 chain에 전달됨
- [x] 보호 경로에서 인젝션된 X-User-Role이 JWT 클레임 값(USER)으로 대체됨
- [x] JWT 없이 보호 경로에 인젝션 헤더 포함 요청 시 401 반환
- [x] 공개 엔드포인트 인젝션 시 5xx (downstream 부재), 401 아님
- [x] 보호 경로 JWT 없이 ADMIN 인젝션 시 401 반환
- [x] 기존 테스트 전체 회귀 없음

Closes #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents forged X-User-Id / X-User-Role headers from reaching downstream, enforces JWT validation, adds role whitelist (USER, ADMIN), preserves correct behavior for CORS preflight (OPTIONS) and duplicate-header cases, and tightens admin-only authorization checks.
* **Tests**
  * Added integration and unit tests covering header-injection defenses, public/protected endpoint behaviors, admin authorization, and error responses.
* **Documentation**
  * Clarified refresh-token route handling in routing rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->