### PR TITLE
fix: [Queue] Queue Token qr_ prefix 누락 버그 수정

### DIFF
--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/service/QueueService.kt
@@ -199,7 +199,7 @@ class QueueService(
      */
     fun batchApprove(scheduleId: UUID): Long {
         val batchSize = queueProperties.batch.size
-        val tokens = (1..batchSize).map { UUID.randomUUID().toString() }
+        val tokens = (1..batchSize).map { "qr_${UUID.randomUUID()}" }
 
         val keys = listOf(
             QueueRedisKeys.queue(scheduleId),

--- a/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/QueueServiceTest.kt
+++ b/backend/queue-service/src/test/kotlin/com/ticketqueue/queue/service/QueueServiceTest.kt
@@ -11,6 +11,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -442,10 +443,11 @@ class QueueServiceTest {
             // fixedArgs(5개) + tokens(batchSize=10개) = 15개
             val batchSize = queueProperties.batch.size
             assertEquals(5 + batchSize, capturedArgs.size)
-            // 마지막 batchSize개의 args가 유효한 UUID 형식인지 검증
+            // 마지막 batchSize개의 args가 qr_ prefix를 포함한 UUID 형식인지 검증
             val tokenArgs = capturedArgs.drop(5)
+            val uuidRegex = Regex("^qr_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
             tokenArgs.forEach { token ->
-                UUID.fromString(token) // 파싱 실패 시 IllegalArgumentException
+                assertTrue(uuidRegex.matches(token), "토큰이 qr_ prefix를 포함한 UUID 형식이어야 함: $token")
             }
         }
     }


### PR DESCRIPTION
## Summary
- `QueueService.batchApprove()`에서 토큰 생성 시 `qr_` prefix가 누락되어, API Gateway `QueueTokenWebFilter`의 정규식(`^qr_[0-9a-f]{8}-...`) 검증이 항상 실패하는 버그 수정
- 좌석 선점/결제 등 Queue Token이 필요한 모든 API가 `401 QUEUE_TOKEN_INVALID`를 반환하던 문제 해결

## Changes
- `QueueService.kt:202`: `UUID.randomUUID().toString()` → `"qr_${UUID.randomUUID()}"` (토큰에 `qr_` prefix 추가)
- `QueueServiceTest.kt`: 토큰 검증 로직을 `UUID.fromString()` 파싱 → `qr_` prefix 포함 정규식 검증으로 수정

## Test plan
- [x] `./gradlew :queue-service:test` — 76개 테스트 전체 통과 확인
- [x] `QueueTokenWebFilter` 정규식(`^qr_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)과 생성 토큰 포맷 일치 확인

Closes #193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated queue token generation to include a standardized prefix format, improving token identification and system processing.

* **Tests**
  * Modified token validation tests to verify adherence to the new standardized token format requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->