### PR TITLE
fix: [Common] IdempotentConsumerTemplate non-retryable 예외 시 DLQ replay 차단 수정

### DIFF
--- a/backend/common-kafka/src/main/kotlin/com/ticketqueue/common/kafka/IdempotentConsumerTemplate.kt
+++ b/backend/common-kafka/src/main/kotlin/com/ticketqueue/common/kafka/IdempotentConsumerTemplate.kt
@@ -50,6 +50,7 @@ class IdempotentConsumerTemplate(
                 throw e
             } else {
                 logger.error(e) { "Non-retryable error processing event: eventId=$eventId, consumer=$consumerService, error=${e.message}" }
+                processedEventService.deleteRecord(eventId, consumerService)
                 throw e
             }
         }

--- a/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/kafka/IdempotentConsumerTemplateTest.kt
+++ b/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/kafka/IdempotentConsumerTemplateTest.kt
@@ -1,0 +1,110 @@
+package com.ticketqueue.common.kafka
+
+import com.ticketqueue.common.event.BaseEvent
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.kafka.support.Acknowledgment
+import java.time.Instant
+import java.util.UUID
+
+class IdempotentConsumerTemplateTest {
+
+    private val processedEventService = mockk<ProcessedEventService>()
+    private val acknowledgment = mockk<Acknowledgment>()
+    private val template = IdempotentConsumerTemplate(processedEventService)
+
+    private val testEventId = UUID.randomUUID()
+    private val consumerService = "test-consumer"
+
+    private val testEvent = object : BaseEvent(
+        eventId = testEventId,
+        eventType = "TEST_EVENT",
+        aggregateId = UUID.randomUUID(),
+        aggregateType = "TEST_AGGREGATE",
+    ) {}
+
+    @BeforeEach
+    fun setUp() {
+        justRun { acknowledgment.acknowledge() }
+        justRun { processedEventService.deleteRecord(any(), any()) }
+    }
+
+    @Test
+    fun `non-retryable 예외 발생 시 deleteRecord 호출 후 예외 전파`() {
+        every { processedEventService.tryRecord(any(), any(), any(), any()) } returns true
+
+        assertThrows<IllegalArgumentException> {
+            template.process(testEvent, consumerService, acknowledgment) {
+                throw IllegalArgumentException("validation error")
+            }
+        }
+
+        verify(exactly = 1) { processedEventService.deleteRecord(testEventId, consumerService) }
+        verify(exactly = 0) { acknowledgment.acknowledge() }
+    }
+
+    @Test
+    fun `retryable 예외 발생 시 deleteRecord 호출 후 예외 전파`() {
+        every { processedEventService.tryRecord(any(), any(), any(), any()) } returns true
+
+        assertThrows<java.util.concurrent.TimeoutException> {
+            template.process(testEvent, consumerService, acknowledgment) {
+                throw java.util.concurrent.TimeoutException("timeout")
+            }
+        }
+
+        verify(exactly = 1) { processedEventService.deleteRecord(testEventId, consumerService) }
+        verify(exactly = 0) { acknowledgment.acknowledge() }
+    }
+
+    @Test
+    fun `중복 이벤트 skip 시 deleteRecord 미호출`() {
+        every { processedEventService.tryRecord(any(), any(), any(), any()) } returns false
+
+        template.process(testEvent, consumerService, acknowledgment) {
+            // should not be called
+        }
+
+        verify(exactly = 0) { processedEventService.deleteRecord(any(), any()) }
+        verify(exactly = 1) { acknowledgment.acknowledge() }
+    }
+
+    @Test
+    fun `정상 처리 시 deleteRecord 미호출 및 acknowledge 호출`() {
+        every { processedEventService.tryRecord(any(), any(), any(), any()) } returns true
+
+        template.process(testEvent, consumerService, acknowledgment) {
+            // success
+        }
+
+        verify(exactly = 0) { processedEventService.deleteRecord(any(), any()) }
+        verify(exactly = 1) { acknowledgment.acknowledge() }
+    }
+
+    @Test
+    fun `DLQ replay 시나리오 - 동일 eventId로 재처리 가능`() {
+        // 1차 처리: non-retryable 예외 → deleteRecord 호출
+        every { processedEventService.tryRecord(any(), any(), any(), any()) } returns true
+
+        assertThrows<IllegalArgumentException> {
+            template.process(testEvent, consumerService, acknowledgment) {
+                throw IllegalArgumentException("first attempt fails")
+            }
+        }
+        verify(exactly = 1) { processedEventService.deleteRecord(testEventId, consumerService) }
+
+        // 2차 처리 (DLQ replay): tryRecord가 true 반환 → 재처리 가능
+        every { processedEventService.tryRecord(any(), any(), any(), any()) } returns true
+
+        template.process(testEvent, consumerService, acknowledgment) {
+            // replay succeeds
+        }
+
+        verify(exactly = 1) { acknowledgment.acknowledge() }
+    }
+}


### PR DESCRIPTION
## Summary
- `IdempotentConsumerTemplate`의 non-retryable 예외 처리 `else` 브랜치에서 `deleteRecord()` 호출이 누락되어, DLQ replay 시 동일 `eventId`가 중복으로 감지되어 이벤트가 영구 유실되는 버그 수정
- `deleteRecord()`는 이미 `Propagation.REQUIRES_NEW`로 선언되어 있어 비즈니스 로직 트랜잭션 롤백과 무관하게 안전하게 실행됨

## Changes
- `IdempotentConsumerTemplate.kt`: non-retryable `else` 브랜치에 `processedEventService.deleteRecord(eventId, consumerService)` 1줄 추가
- `IdempotentConsumerTemplateTest.kt`: 신규 단위 테스트 추가 (5개 시나리오)
  - non-retryable 예외 시 `deleteRecord` 호출 검증
  - retryable 예외 시 기존 동작 회귀 없음 확인
  - 중복 이벤트 skip 시 `deleteRecord` 미호출 검증
  - 정상 처리 시 `acknowledge` 호출 검증
  - DLQ replay 시나리오 — 동일 `eventId`로 재처리 가능 검증

## Test plan
- [x] `IdempotentConsumerTemplateTest` 5개 테스트 모두 통과
- [x] `./gradlew :common-kafka:test` BUILD SUCCESSFUL

Closes #196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event processing reliability by ensuring processed event records are consistently cleaned up across all error scenarios.

* **Tests**
  * Added comprehensive test coverage for event processing behavior including error handling, duplicate detection, and dead-letter queue replay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->