### PR TITLE
fix: [Event] Consumer Poison Pill 처리 및 Consumer Group ID 명세 정합성 (#197)

### DIFF
--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumer.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumer.kt
@@ -39,21 +39,30 @@ class PaymentEventConsumer(
         val eventType = try {
             objectMapper.readTree(rawJson).get("eventType")?.asText()
         } catch (e: JsonProcessingException) {
-            log.error("Malformed JSON in payment.events, skipping: ${e.message}")
-            ack.acknowledge()
-            return
+            log.error("Malformed JSON in payment.events, sending to DLQ: {}", rawJson, e)
+            throw e
         }
 
         when (eventType) {
             "PaymentSuccess" -> {
-                val event = objectMapper.readValue(rawJson, PaymentSuccessEvent::class.java)
+                val event = try {
+                    objectMapper.readValue(rawJson, PaymentSuccessEvent::class.java)
+                } catch (e: JsonProcessingException) {
+                    log.error("Malformed JSON in payment.events, sending to DLQ: {}", rawJson, e)
+                    throw e
+                }
                 idempotentConsumerTemplate.process(event, CONSUMER_SERVICE, ack) { e ->
                     seatService.markSeatsAsSold(e.scheduleId, e.seatIds)
                     log.info("PaymentSuccess: paymentId=${e.aggregateId}, reservationId=${e.reservationId}")
                 }
             }
             "PaymentFailed" -> {
-                val event = objectMapper.readValue(rawJson, PaymentFailedEvent::class.java)
+                val event = try {
+                    objectMapper.readValue(rawJson, PaymentFailedEvent::class.java)
+                } catch (e: JsonProcessingException) {
+                    log.error("Malformed JSON in payment.events, sending to DLQ: {}", rawJson, e)
+                    throw e
+                }
                 idempotentConsumerTemplate.process(event, CONSUMER_SERVICE, ack) { e ->
                     log.info("PaymentFailed: paymentId=${e.aggregateId}, reservationId=${e.reservationId}, reason=${e.reason}")
                 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/consumer/ReservationEventConsumer.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/consumer/ReservationEventConsumer.kt
@@ -1,5 +1,6 @@
 package com.ticketqueue.event.consumer
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.event.ReservationCancelledEvent
 import com.ticketqueue.common.event.ReservationConfirmedEvent
@@ -37,17 +38,32 @@ class ReservationEventConsumer(
     )
     fun consume(record: ConsumerRecord<String, String>, ack: Acknowledgment) {
         val rawJson = record.value()
-        val eventType = objectMapper.readTree(rawJson).get("eventType")?.asText()
+        val eventType = try {
+            objectMapper.readTree(rawJson).get("eventType")?.asText()
+        } catch (e: JsonProcessingException) {
+            log.error("Malformed JSON in reservation.events, sending to DLQ: {}", rawJson, e)
+            throw e
+        }
 
         when (eventType) {
             "ReservationConfirmed" -> {
-                val event = objectMapper.readValue(rawJson, ReservationConfirmedEvent::class.java)
+                val event = try {
+                    objectMapper.readValue(rawJson, ReservationConfirmedEvent::class.java)
+                } catch (e: JsonProcessingException) {
+                    log.error("Malformed JSON in reservation.events, sending to DLQ: {}", rawJson, e)
+                    throw e
+                }
                 idempotentConsumerTemplate.process(event, CONSUMER_SERVICE, ack) { e ->
                     log.info("ReservationConfirmed: reservationId=${e.aggregateId}, scheduleId=${e.scheduleId} (SOLD 처리는 PaymentSuccess에서 수행)")
                 }
             }
             "ReservationCancelled" -> {
-                val event = objectMapper.readValue(rawJson, ReservationCancelledEvent::class.java)
+                val event = try {
+                    objectMapper.readValue(rawJson, ReservationCancelledEvent::class.java)
+                } catch (e: JsonProcessingException) {
+                    log.error("Malformed JSON in reservation.events, sending to DLQ: {}", rawJson, e)
+                    throw e
+                }
                 idempotentConsumerTemplate.process(event, CONSUMER_SERVICE, ack) { e ->
                     seatService.releaseHoldSeats(e.scheduleId, e.seatIds)
                 }

--- a/backend/event-service/src/main/resources/application-local.yml
+++ b/backend/event-service/src/main/resources/application-local.yml
@@ -15,6 +15,9 @@ spring:
   kafka:
     bootstrap-servers: 192.168.50.111:9092
     consumer:
+      # 기본값. 각 Consumer의 실제 group-id는 @KafkaListener(groupId=...) 어노테이션이 오버라이드함.
+      # - event-reservation-consumer (ReservationEventConsumer)
+      # - event-payment-consumer (PaymentEventConsumer)
       group-id: event-service
       auto-offset-reset: earliest
       enable-auto-commit: false

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumerTest.kt
@@ -1,5 +1,6 @@
 package com.ticketqueue.event.consumer
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.ticketqueue.common.event.PaymentFailedEvent
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.kafka.support.Acknowledgment
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -129,6 +131,22 @@ class PaymentEventConsumerTest {
 
             verify { ack.acknowledge() }
             verify(exactly = 0) { idempotentConsumerTemplate.process(any(), any(), any(), any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("Malformed JSON (Poison Pill)")
+    inner class MalformedJson {
+
+        @Test
+        @DisplayName("malformed JSON 수신 시 JsonProcessingException을 던져 DLQ로 이동한다")
+        fun throwsJsonProcessingExceptionOnMalformedJson() {
+            val malformedJson = "{broken json"
+
+            assertThrows<JsonProcessingException> {
+                consumer.consume(record(malformedJson), ack)
+            }
+            verify(exactly = 0) { ack.acknowledge() }
         }
     }
 }

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/consumer/ReservationEventConsumerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/consumer/ReservationEventConsumerTest.kt
@@ -1,5 +1,6 @@
 package com.ticketqueue.event.consumer
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.ticketqueue.common.event.ReservationCancelledEvent
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.kafka.support.Acknowledgment
 import java.util.UUID
 
@@ -140,6 +142,33 @@ class ReservationEventConsumerTest {
 
             verify { ack.acknowledge() }
             verify(exactly = 0) { idempotentConsumerTemplate.process(any(), any(), any(), any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("Malformed JSON (Poison Pill)")
+    inner class MalformedJson {
+
+        @Test
+        @DisplayName("readTree 실패 시 JsonProcessingException을 던져 DLQ로 이동한다")
+        fun throwsJsonProcessingExceptionOnMalformedJson() {
+            val malformedJson = "{broken json"
+
+            assertThrows<JsonProcessingException> {
+                consumer.consume(record(malformedJson), ack)
+            }
+            verify(exactly = 0) { ack.acknowledge() }
+        }
+
+        @Test
+        @DisplayName("올바른 JSON이지만 이벤트 역직렬화 실패 시 JsonProcessingException을 던진다")
+        fun throwsJsonProcessingExceptionOnDeserializationFailure() {
+            val invalidJson = """{"eventType":"ReservationConfirmed","aggregateId":"not-a-uuid"}"""
+
+            assertThrows<JsonProcessingException> {
+                consumer.consume(record(invalidJson), ack)
+            }
+            verify(exactly = 0) { ack.acknowledge() }
         }
     }
 }


### PR DESCRIPTION
## Summary
- `ReservationEventConsumer`의 malformed JSON 미처리 취약점(Poison Pill) 수정 — `JsonProcessingException` catch 후 re-throw로 DLQ 즉시 라우팅
- `PaymentEventConsumer`의 `ack.acknowledge()+return` 조용한 스킵 방식을 `JsonProcessingException` re-throw로 통일 (두 Consumer 간 처리 방식 정합성)
- `application-local.yml` Consumer Group ID 기본값에 실제 `@KafkaListener` groupId 안내 주석 추가

## Changes
- `ReservationEventConsumer.kt`: `readTree()` 및 `readValue()` 3곳 모두 `try/catch(JsonProcessingException)` + `log.error` + `throw e` 적용
- `PaymentEventConsumer.kt`: 기존 catch 블록의 `ack.acknowledge()+return` 제거, `readValue()` 2곳도 동일 패턴 추가
- `application-local.yml`: `group-id: event-service` 위에 Consumer별 실제 group-id 명시 주석
- `ReservationEventConsumerTest.kt`: `MalformedJson` Nested 클래스 추가 (readTree 실패, 역직렬화 실패 2개)
- `PaymentEventConsumerTest.kt`: `MalformedJson` Nested 클래스 추가 (malformed JSON 1개)

## Test plan
- [x] `./gradlew :event-service:test` — BUILD SUCCESSFUL (19 tasks 통과)
- [x] malformed JSON 수신 시 `JsonProcessingException` throw + `ack.acknowledge()` 미호출 검증
- [x] `ExceptionClassifier.nonRetryableExceptions`에 `JsonProcessingException` 등록 확인 → `DefaultErrorHandler`가 DLQ로 즉시 라우팅

Closes #197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Payment and reservation event consumers now properly handle and surface malformed messages instead of silently discarding them
  * Invalid event payloads are consistently routed for error visibility and recovery

* **Tests**
  * Added test coverage for malformed event payload handling scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->