### PR TITLE
chore: [Common] 코드 품질 개선 (UTC 시간, 의존성 최적화, Redis 효율화, CSP 헤더)

### DIFF
--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/SecurityHeadersWebFilter.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/SecurityHeadersWebFilter.kt
@@ -16,6 +16,7 @@ import reactor.core.publisher.Mono
  * - X-Frame-Options: DENY — Clickjacking 방지
  * - Strict-Transport-Security: max-age=31536000; includeSubDomains — HTTPS 강제 (HSTS)
  * - X-XSS-Protection: 0 — 최신 브라우저에서 비활성화 권장 (CSP로 대체)
+ * - Content-Security-Policy: default-src 'self' — XSS 및 데이터 인젝션 방지
  *
  * REQ-GW-011 준수
  *
@@ -38,6 +39,8 @@ class SecurityHeadersWebFilter : WebFilter {
         const val DENY = "DENY"
         const val HSTS_VALUE = "max-age=31536000; includeSubDomains"
         const val XSS_DISABLED = "0"
+        const val CONTENT_SECURITY_POLICY = "Content-Security-Policy"
+        const val CSP_DEFAULT_SRC_SELF = "default-src 'self'"
     }
 
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
@@ -46,6 +49,7 @@ class SecurityHeadersWebFilter : WebFilter {
             set(X_FRAME_OPTIONS, DENY)
             set(STRICT_TRANSPORT_SECURITY, HSTS_VALUE)
             set(X_XSS_PROTECTION, XSS_DISABLED)
+            set(CONTENT_SECURITY_POLICY, CSP_DEFAULT_SRC_SELF)
         }
         return chain.filter(exchange)
     }

--- a/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/WebFilterErrorResponseWriter.kt
+++ b/backend/api-gateway/src/main/kotlin/com/ticketqueue/gateway/filter/WebFilterErrorResponseWriter.kt
@@ -6,6 +6,7 @@ import org.springframework.http.MediaType
 import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 /**
@@ -32,7 +33,7 @@ internal object WebFilterErrorResponseWriter {
         val body = mapOf(
             "code" to code,
             "message" to message,
-            "timestamp" to LocalDateTime.now().format(TIMESTAMP_FORMATTER),
+            "timestamp" to LocalDateTime.now(ZoneOffset.UTC).format(TIMESTAMP_FORMATTER),
             "traceId" to traceId,
         )
 

--- a/backend/common-core/build.gradle.kts
+++ b/backend/common-core/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     api(libs.logstash.logback.encoder)
 
     // Spring Security (GlobalExceptionHandler에서 AccessDeniedException 사용)
-    api(libs.spring.boot.starter.security)
+    api(libs.spring.security.core)
 
     // Test
     testImplementation(libs.bundles.test.base)

--- a/backend/common-kafka/src/main/kotlin/com/ticketqueue/common/outbox/OutboxPollerService.kt
+++ b/backend/common-kafka/src/main/kotlin/com/ticketqueue/common/outbox/OutboxPollerService.kt
@@ -9,6 +9,7 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 /**
  * Transactional Outbox Pattern Poller 서비스
@@ -132,7 +133,7 @@ class OutboxPollerService(
 
             // 발행 성공 시 DB 상태 업데이트
             event.published = true
-            event.publishedAt = LocalDateTime.now()
+            event.publishedAt = LocalDateTime.now(ZoneOffset.UTC)
             outboxEventRepository.save(event)
 
             log.info(
@@ -175,7 +176,7 @@ class OutboxPollerService(
             // 재시도 횟수 초과 → DLQ로 이동
             moveToDlq(event)
             event.published = true // 폴링 대상에서 제외
-            event.publishedAt = LocalDateTime.now()
+            event.publishedAt = LocalDateTime.now(ZoneOffset.UTC)
 
             log.error(
                 "Outbox event exceeded max retries, moved to DLQ: id={}, type={}, retries={}",

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
@@ -387,20 +387,14 @@ class EventService(
     internal fun invalidateEventListCaches() {
         try {
             redisTemplate.execute { conn ->
+                val keys = mutableListOf<ByteArray>()
                 conn.scan(
                     ScanOptions.scanOptions().match("${EVENT_LIST_PREFIX}*").count(100).build()
                 ).use { cursor ->
-                    val batch = mutableListOf<String>()
-                    cursor.forEach { keyBytes ->
-                        batch.add(String(keyBytes))
-                        if (batch.size >= 100) {
-                            redisTemplate.delete(batch)
-                            batch.clear()
-                        }
-                    }
-                    if (batch.isNotEmpty()) {
-                        redisTemplate.delete(batch)
-                    }
+                    cursor.forEach { keyBytes -> keys.add(keyBytes) }
+                }
+                if (keys.isNotEmpty()) {
+                    conn.keyCommands().del(*keys.toTypedArray())
                 }
                 null
             }

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-
 spring-boot-starter-data-redis = { module = "org.springframework.boot:spring-boot-starter-data-redis" }
 spring-boot-starter-data-redis-reactive = { module = "org.springframework.boot:spring-boot-starter-data-redis-reactive" }
 spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
+spring-security-core = { module = "org.springframework.security:spring-security-core" }
 spring-boot-starter-validation = { module = "org.springframework.boot:spring-boot-starter-validation" }
 spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }

--- a/backend/reservation-service/build.gradle.kts
+++ b/backend/reservation-service/build.gradle.kts
@@ -13,6 +13,9 @@ dependencies {
     implementation(project(":common-kafka"))
     implementation(project(":common-web"))
 
+    // Spring Security (SecurityConfig에서 HttpSecurity, EnableWebSecurity 사용)
+    implementation(libs.spring.boot.starter.security)
+
     // Redis with Redisson for distributed locks
     implementation(libs.redisson.spring.boot.starter)
 


### PR DESCRIPTION
## Summary
- `LocalDateTime.now()` → `LocalDateTime.now(ZoneOffset.UTC)` 명시적 UTC 적용 (OutboxPollerService, WebFilterErrorResponseWriter)
- `common-core` 의존성 경량화: `spring-boot-starter-security` → `spring-security-core` (웹 Auto-Config 제거)
- `EventService.invalidateEventListCaches`: Redis DEL N회 왕복 → `conn.keyCommands().del()` 단일 호출
- `SecurityHeadersWebFilter`: `Content-Security-Policy: default-src 'self'` 헤더 추가

## Changes
- `backend/common-kafka/.../OutboxPollerService.kt` — `publishedAt` 설정 시 UTC 명시 (line 135, 178)
- `backend/api-gateway/.../WebFilterErrorResponseWriter.kt` — 응답 timestamp UTC 명시
- `backend/common-core/build.gradle.kts` — `spring-boot-starter-security` → `spring-security-core`
- `backend/gradle/libs.versions.toml` — `spring-security-core` 라이브러리 별칭 추가
- `backend/reservation-service/build.gradle.kts` — `spring-boot-starter-security` 명시적 추가 (common-core 전이 의존성 제거에 따른 대응)
- `backend/event-service/.../EventService.kt` — `invalidateEventListCaches` Redis 단일 DEL 명령으로 최적화
- `backend/api-gateway/.../SecurityHeadersWebFilter.kt` — CSP 헤더 추가

## Test plan
- [x] `./gradlew build -x test` — BUILD SUCCESSFUL (전체 서비스)
- [ ] 로컬 통합 테스트 (Docker Compose 인프라 기동 후 각 서비스 정상 구동 확인)

Closes #200