### PR TITLE
feat: [Event] SeatStatus.HOLD 추가 및 좌석 조회 API Redis 오버레이 구현

### DIFF
--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/SeatController.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/SeatController.kt
@@ -1,0 +1,21 @@
+package com.ticketqueue.event.controller
+
+import com.ticketqueue.event.dto.SeatDto
+import com.ticketqueue.event.service.SeatService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/events/schedules")
+class SeatController(
+    private val seatService: SeatService
+) {
+    /** 회차별 좌석 목록 조회 - 등급별 그룹핑, HOLD 상태 실시간 반영 (REQ-EVT-006) */
+    @GetMapping("/{scheduleId}/seats")
+    fun getSeats(@PathVariable scheduleId: UUID): SeatDto.SeatsResponse {
+        return seatService.getSeats(scheduleId)
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/enums.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/entity/enums.kt
@@ -32,4 +32,4 @@ enum class ScheduleStatus {
         allowedTransitions[this]?.contains(target) ?: false
 }
 enum class SeatGrade { VIP, S, A, B }
-enum class SeatStatus { AVAILABLE, SOLD }
+enum class SeatStatus { AVAILABLE, HOLD, SOLD }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.event.config.CacheProperties
 import com.ticketqueue.event.dto.SeatDto
+import com.ticketqueue.event.entity.SeatStatus
 import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.repository.EventScheduleRepository
 import com.ticketqueue.event.repository.SeatRepository
@@ -61,7 +62,9 @@ class SeatService(
                 val grades = hashEntries.values
                     .map { objectMapper.convertValue(it, SeatDto.GradeGroup::class.java) }
                     .sortedBy { it.grade.ordinal }
-                return SeatDto.SeatsResponse(scheduleId = scheduleId, grades = grades)
+                val cachedResponse = SeatDto.SeatsResponse(scheduleId = scheduleId, grades = grades)
+                val holdSeatIds = getHoldSeatIds(scheduleId)
+                return overlayHoldStatus(cachedResponse, holdSeatIds)
             }
         } catch (e: DataAccessException) {
             log.warn("Redis cache read failed for key: $cacheKey", e)
@@ -104,7 +107,8 @@ class SeatService(
             }
         }
 
-        return response
+        val holdSeatIds = getHoldSeatIds(scheduleId)
+        return overlayHoldStatus(response, holdSeatIds)
     }
 
     /**
@@ -157,6 +161,41 @@ class SeatService(
         } catch (e: DataAccessException) {
             log.warn("Failed to evict seats cache: key=$cacheKey", e)
         }
+    }
+
+    /**
+     * Redis hold_seats:{scheduleId} SET에서 선점 중인 좌석 ID 목록을 조회한다.
+     *
+     * Redis 장애 시 emptySet()을 반환하여 오버레이 없이 정상 응답을 보장한다.
+     */
+    private fun getHoldSeatIds(scheduleId: UUID): Set<UUID> {
+        val holdKey = "hold_seats:$scheduleId"
+        return try {
+            redisTemplate.opsForSet().members(holdKey)
+                ?.mapNotNull { runCatching { UUID.fromString(it.toString()) }.getOrNull() }
+                ?.toSet() ?: emptySet()
+        } catch (e: DataAccessException) {
+            log.warn("Failed to read hold seats from Redis: key=$holdKey", e)
+            emptySet()
+        }
+    }
+
+    /**
+     * AVAILABLE 좌석 중 hold SET에 포함된 좌석의 상태를 HOLD로 오버레이한다.
+     *
+     * SOLD 좌석은 DB 상태를 우선하여 오버레이하지 않는다.
+     * 캐시 저장은 오버레이 전(AVAILABLE/SOLD 상태)으로 수행된다.
+     */
+    private fun overlayHoldStatus(response: SeatDto.SeatsResponse, holdSeatIds: Set<UUID>): SeatDto.SeatsResponse {
+        if (holdSeatIds.isEmpty()) return response
+        val overlaidGrades = response.grades.map { gradeGroup ->
+            gradeGroup.copy(seats = gradeGroup.seats.map { seat ->
+                if (seat.status == SeatStatus.AVAILABLE && seat.id in holdSeatIds)
+                    seat.copy(status = SeatStatus.HOLD)
+                else seat
+            })
+        }
+        return response.copy(grades = overlaidGrades)
     }
 
     private fun removeFromHoldSeatsRedis(scheduleId: UUID, seatIds: List<UUID>) {

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/SeatControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/SeatControllerTest.kt
@@ -1,0 +1,92 @@
+package com.ticketqueue.event.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.exception.GlobalExceptionHandler
+import com.ticketqueue.event.dto.SeatDto
+import com.ticketqueue.event.entity.SeatGrade
+import com.ticketqueue.event.entity.SeatStatus
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.service.SeatService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.math.BigDecimal
+import java.util.UUID
+
+class SeatControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var seatService: SeatService
+    private val objectMapper: ObjectMapper = jacksonObjectMapper().apply {
+        registerModule(JavaTimeModule())
+    }
+
+    private val scheduleId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        seatService = mockk()
+        val controller = SeatController(seatService)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(GlobalExceptionHandler())
+            .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
+            .build()
+    }
+
+    @Nested
+    @DisplayName("GET /events/schedules/{scheduleId}/seats")
+    inner class GetSeats {
+
+        @Test
+        @DisplayName("200 OK - 등급별 좌석 목록을 반환한다")
+        fun success() {
+            val seatId = UUID.randomUUID()
+            val response = SeatDto.SeatsResponse(
+                scheduleId = scheduleId,
+                grades = listOf(
+                    SeatDto.GradeGroup(
+                        grade = SeatGrade.VIP,
+                        price = BigDecimal("150000"),
+                        seats = listOf(
+                            SeatDto.SeatInfo(
+                                id = seatId,
+                                seatNumber = "A-1",
+                                grade = SeatGrade.VIP,
+                                status = SeatStatus.AVAILABLE
+                            )
+                        )
+                    )
+                )
+            )
+            every { seatService.getSeats(scheduleId) } returns response
+
+            mockMvc.perform(get("/events/schedules/{scheduleId}/seats", scheduleId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.scheduleId").value(scheduleId.toString()))
+                .andExpect(jsonPath("$.grades").isArray)
+                .andExpect(jsonPath("$.grades[0].grade").value("VIP"))
+                .andExpect(jsonPath("$.grades[0].seats[0].id").value(seatId.toString()))
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 scheduleId")
+        fun scheduleNotFound() {
+            every { seatService.getSeats(scheduleId) } throws EventException(ErrorCode.SCHEDULE_NOT_FOUND)
+
+            mockMvc.perform(get("/events/schedules/{scheduleId}/seats", scheduleId))
+                .andExpect(status().isNotFound)
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
@@ -104,6 +104,7 @@ class SeatServiceTest {
             every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
             every { hashOps.putAll(any<String>(), any()) } just runs
             every { redisTemplate.expire(any<String>(), any<Duration>()) } returns true
+            every { setOps.members(any<String>()) } returns emptySet()
 
             val response = seatService.getSeats(scheduleId)
 
@@ -124,6 +125,7 @@ class SeatServiceTest {
                 seats = emptyList()
             )
             every { hashOps.entries("cache:seats:$scheduleId") } returns mapOf("VIP" to gradeGroup)
+            every { setOps.members(any<String>()) } returns emptySet()
 
             val response = seatService.getSeats(scheduleId)
 
@@ -140,6 +142,7 @@ class SeatServiceTest {
             every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
             every { hashOps.putAll(any<String>(), any()) } just runs
             every { redisTemplate.expire(any<String>(), any<Duration>()) } returns true
+            every { setOps.members(any<String>()) } returns emptySet()
 
             val response = seatService.getSeats(scheduleId)
 
@@ -161,6 +164,7 @@ class SeatServiceTest {
             every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
             every { hashOps.putAll(any<String>(), any()) } just runs
             every { redisTemplate.expire(any<String>(), any<Duration>()) } returns true
+            every { setOps.members(any<String>()) } returns emptySet()
 
             val response = seatService.getSeats(scheduleId)
 
@@ -176,6 +180,7 @@ class SeatServiceTest {
             every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns emptyList()
             every { hashOps.putAll(any<String>(), any()) } just runs
             every { redisTemplate.expire(any<String>(), any<Duration>()) } returns true
+            every { setOps.members(any<String>()) } returns emptySet()
 
             val response = seatService.getSeats(scheduleId)
 
@@ -197,6 +202,72 @@ class SeatServiceTest {
         }
 
         @Test
+        @DisplayName("HOLD 오버레이 - AVAILABLE 좌석이 hold_seats SET에 있으면 HOLD로 변환한다")
+        fun holdOverlay() {
+            val seats = listOf(createSeat(SeatGrade.VIP, "A-1", BigDecimal("150000")))
+            val seatId = seats[0].id!!
+            every { hashOps.entries(any<String>()) } returns emptyMap()
+            every { eventScheduleRepository.existsById(scheduleId) } returns true
+            every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
+            every { hashOps.putAll(any<String>(), any()) } just runs
+            every { redisTemplate.expire(any<String>(), any<Duration>()) } returns true
+            every { setOps.members("hold_seats:$scheduleId") } returns setOf(seatId.toString())
+
+            val response = seatService.getSeats(scheduleId)
+
+            assertEquals(SeatStatus.HOLD, response.grades[0].seats[0].status)
+        }
+
+        @Test
+        @DisplayName("HOLD 오버레이 - SOLD 좌석은 hold_seats SET에 있어도 SOLD 유지한다")
+        fun holdOverlayDoesNotAffectSoldSeats() {
+            val seats = listOf(createSeat(SeatGrade.VIP, "A-1", BigDecimal("150000"), SeatStatus.SOLD))
+            val seatId = seats[0].id!!
+            every { hashOps.entries(any<String>()) } returns emptyMap()
+            every { eventScheduleRepository.existsById(scheduleId) } returns true
+            every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
+            every { hashOps.putAll(any<String>(), any()) } just runs
+            every { redisTemplate.expire(any<String>(), any<Duration>()) } returns true
+            every { setOps.members("hold_seats:$scheduleId") } returns setOf(seatId.toString())
+
+            val response = seatService.getSeats(scheduleId)
+
+            assertEquals(SeatStatus.SOLD, response.grades[0].seats[0].status)
+        }
+
+        @Test
+        @DisplayName("HOLD 오버레이 - Redis SET 조회 장애 시 오버레이 없이 정상 응답한다")
+        fun holdOverlayRedisFailureFallback() {
+            val seats = listOf(createSeat(SeatGrade.VIP, "A-1", BigDecimal("150000")))
+            every { hashOps.entries(any<String>()) } returns emptyMap()
+            every { eventScheduleRepository.existsById(scheduleId) } returns true
+            every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
+            every { hashOps.putAll(any<String>(), any()) } just runs
+            every { redisTemplate.expire(any<String>(), any<Duration>()) } returns true
+            every { setOps.members(any<String>()) } throws RedisConnectionFailureException("connection failed")
+
+            val response = seatService.getSeats(scheduleId)
+
+            assertEquals(SeatStatus.AVAILABLE, response.grades[0].seats[0].status)
+        }
+
+        @Test
+        @DisplayName("HOLD 오버레이 - hold_seats SET이 비어있으면 오버레이 없이 반환한다")
+        fun holdOverlayEmptySet() {
+            val seats = listOf(createSeat(SeatGrade.VIP, "A-1", BigDecimal("150000")))
+            every { hashOps.entries(any<String>()) } returns emptyMap()
+            every { eventScheduleRepository.existsById(scheduleId) } returns true
+            every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
+            every { hashOps.putAll(any<String>(), any()) } just runs
+            every { redisTemplate.expire(any<String>(), any<Duration>()) } returns true
+            every { setOps.members("hold_seats:$scheduleId") } returns emptySet()
+
+            val response = seatService.getSeats(scheduleId)
+
+            assertEquals(SeatStatus.AVAILABLE, response.grades[0].seats[0].status)
+        }
+
+        @Test
         @DisplayName("캐시 저장 실패 시에도 정상 응답한다")
         fun cacheWriteFailure() {
             val seats = listOf(createSeat(SeatGrade.VIP, "A-1", BigDecimal("150000")))
@@ -204,6 +275,7 @@ class SeatServiceTest {
             every { eventScheduleRepository.existsById(scheduleId) } returns true
             every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
             every { hashOps.putAll(any<String>(), any()) } throws RedisConnectionFailureException("Redis write failed")
+            every { setOps.members(any<String>()) } returns emptySet()
 
             val response = seatService.getSeats(scheduleId)
 
@@ -220,6 +292,7 @@ class SeatServiceTest {
             every { seatRepository.findByScheduleIdOrderByGradeAndSeatNumber(scheduleId) } returns seats
             // 락 미획득 (다른 요청이 이미 처리 중)
             every { cacheHelper.tryAcquireStampedeLock(any(), any()) } returns false
+            every { setOps.members(any<String>()) } returns emptySet()
 
             val response = seatService.getSeats(scheduleId)
 


### PR DESCRIPTION
## Summary
- `SeatStatus` enum에 `HOLD` 값 추가 — 다른 사용자가 Redisson 분산 락으로 선점 중인 좌석을 API 응답에서 실시간 반영
- `SeatService.getSeats()`에 Redis `hold_seats:{scheduleId}` SET 오버레이 로직 추가
- 공개 좌석 조회 API `GET /events/schedules/{scheduleId}/seats` 컨트롤러 신규 생성

## Changes
- `entity/enums.kt`: `SeatStatus { AVAILABLE, HOLD, SOLD }` — HOLD는 Redis 기반 동적 상태, DB 저장 안 함
- `service/SeatService.kt`:
  - `getHoldSeatIds()` — `hold_seats:{scheduleId}` SMEMBERS 조회 (Redis KEYS 명령 금지 원칙 준수)
  - `overlayHoldStatus()` — AVAILABLE 좌석 중 hold SET 포함 시 HOLD로 오버레이, SOLD는 DB 상태 우선
  - `getSeats()` — 캐시 히트/DB fallback 두 경로 모두 오버레이 적용, 캐시 저장은 오버레이 전
- `controller/SeatController.kt`: `GET /events/schedules/{scheduleId}/seats` 신규 생성 (인증 없음)
- `SeatServiceTest.kt`: 기존 7개 테스트에 setOps mock 추가 + HOLD 오버레이 테스트 4개 추가
- `SeatControllerTest.kt`: 정상응답 및 404 케이스 테스트 신규 생성

## Test plan
- [x] `./gradlew :event-service:compileKotlin` BUILD SUCCESSFUL
- [x] `SeatServiceTest` 전체 통과 (HOLD 오버레이, Redis 장애 fallback, SOLD 보호 검증)
- [x] `SeatControllerTest` 통과

Closes #198