### PR TITLE
fix/docs: [Queue] BatchApproveScheduler 예외 로그 수정 및 아키텍처 문서 최신화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ Thumbs.db
 .claude
 .mcp.json
 .omc
+PLAN.md
 
 # Frontend / Node.js
 node_modules/

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/scheduler/BatchApproveScheduler.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/scheduler/BatchApproveScheduler.kt
@@ -30,7 +30,7 @@ class BatchApproveScheduler(
             val scheduleId = try {
                 UUID.fromString(rawId)
             } catch (e: IllegalArgumentException) {
-                logger.warn { "Invalid scheduleId format in active-schedules, skipping: $rawId" }
+                logger.warn(e) { "Invalid scheduleId format in active-schedules, skipping: $rawId" }
                 continue
             }
 


### PR DESCRIPTION
## Summary
- BatchApproveScheduler의 `logger.warn` 호출에서 예외(`e`) 누락 수정 — 스택 트레이스가 로그에 보존되지 않던 버그 수정
- 아키텍처 문서 최신화: Redis 키 패턴, Kafka 이벤트 스키마(PaymentSuccess/Failed), JWT 서명 알고리즘, API 엔드포인트 메서드
- PLAN.md를 .gitignore에 추가

## Changes
- `backend/queue-service/.../BatchApproveScheduler.kt`: `logger.warn { ... }` → `logger.warn(e) { ... }` (IllegalArgumentException 스택 트레이스 보존)
- `docs/architecture/04_data.md`: `queue:user-token:{userId}` 키 추가, Event 캐시 자료구조 Hash → String(JSON) 정정
- `docs/architecture/05_kafka.md`: PaymentSuccess payload에 `scheduleId`, `seatIds` 필드 추가; `amount` 타입 Integer → BigDecimal; PaymentFailed payload 간소화(`reason`만 유지)
- `docs/architecture/06_api_security.md`: JWT 서명 알고리즘 HS256 → HS512 (실제 구현 반영)
- `docs/specification/00_overview.md`: 공연/공연장/홀 수정 API 메서드 PUT → PATCH 정정
- `.gitignore`: PLAN.md 추가

## Test plan
- [ ] BatchApproveScheduler 로그 출력 확인 (잘못된 scheduleId 입력 시 스택 트레이스 포함 여부)
- [ ] 문서 변경사항 내용 검토

Ref #202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Enhanced access token signing algorithm for stronger security.

* **Documentation**
  * Updated admin API: three endpoints now use PATCH instead of PUT for events, venues, and venue halls.
  * Revised Kafka event payloads to improve payment processing data handling.

* **Bug Fixes**
  * Improved error logging for invalid schedule handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->