### PR TITLE
feat: [Reservation] 좌석 선점(HOLD) API 구현 (#48)

### DIFF
--- a/backend/common-core/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
+++ b/backend/common-core/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
@@ -40,6 +40,7 @@ enum class ErrorCode(
     MAX_SEATS_EXCEEDED(HttpStatus.BAD_REQUEST, "MAX_SEATS_EXCEEDED", "최대 좌석 수를 초과했습니다. (최대 4석)"),
     HOLD_EXPIRED(HttpStatus.GONE, "HOLD_EXPIRED", "좌석 선점 시간이 만료되었습니다."),
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION_NOT_FOUND", "존재하지 않는 예매입니다."),
+    RESERVATION_IN_PROGRESS(HttpStatus.CONFLICT, "RESERVATION_IN_PROGRESS", "이미 진행 중인 선점 요청이 있습니다. 잠시 후 다시 시도해주세요."),
 
     // Payment
     PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT_FAILED", "결제에 실패했습니다."),

--- a/backend/common-core/src/main/resources/application-common-local.yml
+++ b/backend/common-core/src/main/resources/application-common-local.yml
@@ -7,7 +7,7 @@ spring:
 
   data:
     redis:
-      host: 192.168.50.111
+      host: localhost
       port: 6379
       password: ${valkey_password}
 

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/InternalSeatController.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/InternalSeatController.kt
@@ -5,11 +5,14 @@ import com.ticketqueue.event.service.SeatService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
 // 내부 서비스 간 통신용 좌석 API 컨트롤러
-// 엔드포인트: GET /internal/seats/status/{scheduleId} - SOLD 좌석 ID 조회 (Reservation Service 전용)
+// 엔드포인트:
+//   GET /internal/seats/status/{scheduleId}       - SOLD 좌석 ID 조회 (Reservation Service 전용)
+//   GET /internal/seats/{scheduleId}/details      - 좌석 상세 정보 조회 (Reservation Service 선점 시 스냅샷용)
 // 보안: InternalApiAuthInterceptor가 X-Service-Api-Key 헤더 검증 (API Gateway는 /internal 경로 차단)
 @RestController
 @RequestMapping("/internal/seats")
@@ -21,5 +24,14 @@ class InternalSeatController(
     @GetMapping("/status/{scheduleId}")
     fun getSoldSeatIds(@PathVariable scheduleId: UUID): SeatDto.SoldSeatsResponse {
         return seatService.getSoldSeatIds(scheduleId)
+    }
+
+    /** 좌석 상세 정보 조회 - Reservation Service가 선점 시 스냅샷 저장용으로 사용 */
+    @GetMapping("/{scheduleId}/details")
+    fun getSeatDetails(
+        @PathVariable scheduleId: UUID,
+        @RequestParam seatIds: List<UUID>
+    ): SeatDto.SeatDetailsResponse {
+        return seatService.getSeatDetails(scheduleId, seatIds)
     }
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/SeatDto.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/SeatDto.kt
@@ -51,4 +51,18 @@ class SeatDto {
         val scheduleId: UUID,
         val soldSeatIds: List<UUID>
     )
+
+    /** 내부 API 응답 - Reservation Service가 좌석 선점 시 스냅샷 저장용으로 사용 */
+    data class SeatDetailsResponse(
+        val scheduleId: UUID,
+        val eventId: UUID,
+        val seats: List<SeatDetail>
+    ) {
+        data class SeatDetail(
+            val seatId: UUID,
+            val seatNumber: String,
+            val grade: String,
+            val price: BigDecimal
+        )
+    }
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepository.kt
@@ -9,4 +9,5 @@ import java.util.UUID
 @Repository
 interface SeatRepository : JpaRepository<Seat, UUID>, SeatRepositoryCustom {
     fun existsByEventScheduleIdAndStatus(eventScheduleId: UUID, status: SeatStatus): Boolean
+    fun findByEventScheduleIdAndIdIn(eventScheduleId: UUID, ids: List<UUID>): List<Seat>
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
@@ -149,8 +149,13 @@ class SeatService(
         val schedule = eventScheduleRepository.findById(scheduleId)
             .orElseThrow { EventException(ErrorCode.SCHEDULE_NOT_FOUND) }
 
-        val seats = seatRepository.findByEventScheduleIdAndIdIn(scheduleId, seatIds)
-        if (seats.size != seatIds.size) {
+        val distinctIds = seatIds.toSet()
+        if (distinctIds.size != seatIds.size) {
+            throw EventException(ErrorCode.INVALID_INPUT)
+        }
+
+        val seats = seatRepository.findByEventScheduleIdAndIdIn(scheduleId, distinctIds.toList())
+        if (seats.size != distinctIds.size) {
             throw EventException(ErrorCode.RESOURCE_NOT_FOUND)
         }
 

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
@@ -142,17 +142,23 @@ class SeatService(
      * 좌석 선점 시 스냅샷 저장을 위한 상세 정보 조회 (내부 API - Reservation Service 전용)
      *
      * seatIds 개수와 조회된 좌석 수가 불일치하면 RESOURCE_NOT_FOUND 예외를 던진다.
-     * eventId는 첫 번째 좌석의 eventSchedule.event.id 에서 추출한다 (동일 scheduleId이므로 모두 동일).
+     * AVAILABLE 상태가 아닌 좌석(HOLD/SOLD)이 포함되면 SEAT_NOT_AVAILABLE 예외를 던진다.
+     * eventId는 EventSchedule 로드 시 Hibernate 프록시의 FK 값을 직접 참조하여 추가 쿼리 없이 추출한다.
      */
     fun getSeatDetails(scheduleId: UUID, seatIds: List<UUID>): SeatDto.SeatDetailsResponse {
-        if (!eventScheduleRepository.existsById(scheduleId)) {
-            throw EventException(ErrorCode.SCHEDULE_NOT_FOUND)
-        }
+        val schedule = eventScheduleRepository.findById(scheduleId)
+            .orElseThrow { EventException(ErrorCode.SCHEDULE_NOT_FOUND) }
+
         val seats = seatRepository.findByEventScheduleIdAndIdIn(scheduleId, seatIds)
         if (seats.size != seatIds.size) {
             throw EventException(ErrorCode.RESOURCE_NOT_FOUND)
         }
-        val eventId = seats.first().eventSchedule.event.id!!
+
+        seats.find { it.status != SeatStatus.AVAILABLE }?.let {
+            throw EventException(ErrorCode.SEAT_NOT_AVAILABLE)
+        }
+
+        val eventId = schedule.event.id ?: throw EventException(ErrorCode.INTERNAL_SERVER_ERROR)
         return SeatDto.SeatDetailsResponse(
             scheduleId = scheduleId,
             eventId = eventId,

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
@@ -139,6 +139,35 @@ class SeatService(
     }
 
     /**
+     * 좌석 선점 시 스냅샷 저장을 위한 상세 정보 조회 (내부 API - Reservation Service 전용)
+     *
+     * seatIds 개수와 조회된 좌석 수가 불일치하면 RESOURCE_NOT_FOUND 예외를 던진다.
+     * eventId는 첫 번째 좌석의 eventSchedule.event.id 에서 추출한다 (동일 scheduleId이므로 모두 동일).
+     */
+    fun getSeatDetails(scheduleId: UUID, seatIds: List<UUID>): SeatDto.SeatDetailsResponse {
+        if (!eventScheduleRepository.existsById(scheduleId)) {
+            throw EventException(ErrorCode.SCHEDULE_NOT_FOUND)
+        }
+        val seats = seatRepository.findByEventScheduleIdAndIdIn(scheduleId, seatIds)
+        if (seats.size != seatIds.size) {
+            throw EventException(ErrorCode.RESOURCE_NOT_FOUND)
+        }
+        val eventId = seats.first().eventSchedule.event.id!!
+        return SeatDto.SeatDetailsResponse(
+            scheduleId = scheduleId,
+            eventId = eventId,
+            seats = seats.map { seat ->
+                SeatDto.SeatDetailsResponse.SeatDetail(
+                    seatId = seat.id!!,
+                    seatNumber = seat.seatNumber,
+                    grade = seat.grade.name,
+                    price = seat.price
+                )
+            }
+        )
+    }
+
+    /**
      * 좌석을 AVAILABLE로 복원하고 Redis hold_seats Set에서 선점 해제된 좌석을 제거한다 (Kafka Consumer - ReservationCancelled 처리)
      *
      * DB AVAILABLE 복원이 트랜잭션 내에서 우선 보장되고, Redis는 best-effort로 정리한다.

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
@@ -149,6 +149,7 @@ class SeatService(
         val schedule = eventScheduleRepository.findById(scheduleId)
             .orElseThrow { EventException(ErrorCode.SCHEDULE_NOT_FOUND) }
 
+        if (seatIds.isEmpty()) throw EventException(ErrorCode.INVALID_INPUT)
         val distinctIds = seatIds.toSet()
         if (distinctIds.size != seatIds.size) {
             throw EventException(ErrorCode.INVALID_INPUT)

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/ReservationServiceApplication.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/ReservationServiceApplication.kt
@@ -1,11 +1,15 @@
 package com.ticketqueue.reservation
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.runApplication
 import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication(scanBasePackages = ["com.ticketqueue.reservation", "com.ticketqueue.common"])
+@EnableJpaRepositories(basePackages = ["com.ticketqueue.reservation.repository"])
+@EntityScan(basePackages = ["com.ticketqueue.reservation.entity"])
 @EnableFeignClients
 @EnableScheduling
 class ReservationServiceApplication

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClient.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClient.kt
@@ -3,6 +3,8 @@ package com.ticketqueue.reservation.client
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
+import java.math.BigDecimal
 import java.util.UUID
 
 @FeignClient(name = "event-service", url = "\${feign.client.config.event-service.url}")
@@ -11,8 +13,27 @@ interface EventServiceClient {
     @GetMapping("/internal/seats/status/{scheduleId}")
     fun getSoldSeats(@PathVariable scheduleId: UUID): SoldSeatsResponse
 
+    @GetMapping("/internal/seats/{scheduleId}/details")
+    fun getSeatDetails(
+        @PathVariable scheduleId: UUID,
+        @RequestParam seatIds: List<UUID>
+    ): SeatDetailsResponse
+
     data class SoldSeatsResponse(
         val scheduleId: UUID,
         val soldSeatIds: List<UUID>
     )
+
+    data class SeatDetailsResponse(
+        val scheduleId: UUID,
+        val eventId: UUID,
+        val seats: List<SeatDetail>
+    ) {
+        data class SeatDetail(
+            val seatId: UUID,
+            val seatNumber: String,
+            val grade: String,
+            val price: BigDecimal
+        )
+    }
 }

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/controller/ReservationController.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/controller/ReservationController.kt
@@ -1,0 +1,41 @@
+package com.ticketqueue.reservation.controller
+
+import com.ticketqueue.reservation.dto.ReservationDto.HoldRequest
+import com.ticketqueue.reservation.dto.ReservationDto.HoldResponse
+import com.ticketqueue.reservation.service.ReservationService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/reservations")
+class ReservationController(
+    private val reservationService: ReservationService
+) {
+
+    private val log = KotlinLogging.logger {}
+
+    /**
+     * 좌석 선점 (REQ-RSV-001)
+     *
+     * Gateway가 JWT를 검증하고 X-User-Id 헤더로 userId를 주입한다.
+     * Queue Token은 X-Queue-Token 헤더로 전달되며, Reservation Service에서 Redis 직접 조회로 검증한다.
+     */
+    @PostMapping("/hold")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun holdSeats(
+        @RequestHeader("X-User-Id") userId: UUID,
+        @RequestHeader("X-Queue-Token") queueToken: String,
+        @RequestBody @Valid request: HoldRequest
+    ): HoldResponse {
+        log.info { "Request to hold seat $request" }
+        return reservationService.holdSeats(userId, request, queueToken)
+    }
+}

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationDto.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationDto.kt
@@ -1,0 +1,24 @@
+package com.ticketqueue.reservation.dto
+
+import com.ticketqueue.reservation.entity.ReservationStatus
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+class ReservationDto {
+
+    data class HoldRequest(
+        @field:NotNull val scheduleId: UUID,
+        @field:NotEmpty @field:Size(min = 1, max = 4) val seatIds: List<UUID>
+    )
+
+    data class HoldResponse(
+        val reservationId: UUID,
+        val status: ReservationStatus,
+        val totalAmount: BigDecimal,
+        val holdExpiresAt: LocalDateTime
+    )
+}

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationDto.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationDto.kt
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import java.math.BigDecimal
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class ReservationDto {
@@ -19,6 +19,6 @@ class ReservationDto {
         val reservationId: UUID,
         val status: ReservationStatus,
         val totalAmount: BigDecimal,
-        val holdExpiresAt: LocalDateTime
+        val holdExpiresAt: OffsetDateTime
     )
 }

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/repository/ReservationRepository.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/repository/ReservationRepository.kt
@@ -11,4 +11,5 @@ interface ReservationRepository : JpaRepository<Reservation, UUID> {
     fun findByIdAndUserId(id: UUID, userId: UUID): Reservation?
     fun existsByUserIdAndScheduleIdAndStatusIn(userId: UUID, scheduleId: UUID, statuses: List<ReservationStatus>): Boolean
     fun findAllByStatusAndHoldExpiresAtBefore(status: ReservationStatus, now: LocalDateTime): List<Reservation>
+    fun findByUserIdAndScheduleIdAndStatus(userId: UUID, scheduleId: UUID, status: ReservationStatus): List<Reservation>
 }

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/repository/ReservationSeatRepository.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/repository/ReservationSeatRepository.kt
@@ -6,4 +6,5 @@ import java.util.UUID
 
 interface ReservationSeatRepository : JpaRepository<ReservationSeat, UUID> {
     fun findByReservationId(reservationId: UUID): List<ReservationSeat>
+    fun countByReservationIdIn(reservationIds: List<UUID>): Int
 }

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
@@ -1,0 +1,218 @@
+package com.ticketqueue.reservation.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.reservation.client.EventServiceClient
+import com.ticketqueue.reservation.dto.ReservationDto.HoldRequest
+import com.ticketqueue.reservation.dto.ReservationDto.HoldResponse
+import com.ticketqueue.reservation.entity.Reservation
+import com.ticketqueue.reservation.entity.ReservationSeat
+import com.ticketqueue.reservation.entity.ReservationStatus
+import com.ticketqueue.reservation.exception.ReservationException
+import com.ticketqueue.reservation.repository.ReservationRepository
+import com.ticketqueue.reservation.repository.ReservationSeatRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.Duration
+import java.time.LocalDateTime
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+/**
+ * 좌석 선점 서비스 (REQ-RSV-001, REQ-RSV-005, REQ-RSV-008)
+ *
+ * ## 선점 프로세스
+ * 1. QueueToken 검증 — queue:token:{token} Redis 직접 조회
+ * 2. 기존 선점 수량 검증 — PENDING 예매의 좌석 수 합산 (최대 4장)
+ * 3. Redisson 분산 락 획득 — seat:hold:{scheduleId}:{seatId}, leaseTime=300s (watchdog 비활성)
+ * 4. Redis hold_seats SET 확인 — 이미 선점된 좌석 중복 방지
+ * 5. Event Service SOLD 상태 확인 — Feign 내부 API 호출
+ * 6. 좌석 상세 조회 — 스냅샷 저장용 (seatNumber, grade, price)
+ * 7. DB 저장 + Redis hold_seats SET 업데이트 (TransactionTemplate 내부)
+ *    — Redis 실패 시 예외가 전파되어 DB 트랜잭션이 롤백되므로 정합성이 유지됨
+ *
+ * ## 락 설계
+ * tryLock(waitTime=0, leaseTime=300s)으로 락이 이미 선점 중이면 즉시 실패한다.
+ * 성공/실패 모두 finally 블록에서 즉시 해제 — 선점 마커는 hold_seats SET(600s TTL)이 담당.
+ */
+@Service
+class ReservationService(
+    private val stringRedisTemplate: StringRedisTemplate,
+    private val redissonClient: RedissonClient,
+    private val eventServiceClient: EventServiceClient,
+    private val reservationRepository: ReservationRepository,
+    private val reservationSeatRepository: ReservationSeatRepository,
+    private val objectMapper: ObjectMapper,
+    private val transactionTemplate: TransactionTemplate
+) {
+
+    private val log = KotlinLogging.logger {}
+
+    companion object {
+        private const val MAX_HOLD_SEATS = 4
+        private const val HOLD_MINUTES = 5L
+        private const val HOLD_TTL_SECONDS = 300L
+        private const val HOLD_SEATS_SET_TTL_SECONDS = 600L
+    }
+
+    fun holdSeats(userId: UUID, request: HoldRequest, queueToken: String): HoldResponse {
+        // 1. QueueToken 검증
+        validateQueueToken(queueToken, userId, request.scheduleId)
+
+        // 락 목록 준비 (사용자 락 + 좌석 MultiLock)
+        val userLock = redissonClient.getLock("user:hold:lock:$userId:${request.scheduleId}")
+        val multiSeatLock = redissonClient.getMultiLock(
+            *request.seatIds.sorted().map { 
+                redissonClient.getLock("seat:hold:${request.scheduleId}:$it") 
+            }.toTypedArray()
+        )
+
+        // 락과 그에 따른 에러 코드를 페어로 관리하여 순회 획득
+        val lockTargets = listOf(
+            userLock to ErrorCode.RATE_LIMIT_EXCEEDED,
+            multiSeatLock to ErrorCode.SEAT_ALREADY_HELD
+        )
+        val acquiredLocks = mutableListOf<RLock>()
+
+        try {
+            // 모든 락 획득 시도 (waitTime=0)
+            for ((lock, errorCode) in lockTargets) {
+                if (!lock.tryLock(0, HOLD_TTL_SECONDS, TimeUnit.SECONDS)) {
+                    throw ReservationException(errorCode)
+                }
+                acquiredLocks.add(lock)
+            }
+
+            // 2. 수량 검증 (사용자 락 안에서 수행하여 TOCTOU 방지)
+            validateSeatCount(userId, request.scheduleId, request.seatIds.size)
+
+            // 4. Redis hold_seats SET 중복 확인
+            checkHoldSeatsSet(request.scheduleId, request.seatIds)
+
+            // 5. Event Service SOLD 상태 확인
+            val soldSeatIds = eventServiceClient.getSoldSeats(request.scheduleId).soldSeatIds.toSet()
+            request.seatIds.forEach { seatId ->
+                if (seatId in soldSeatIds) {
+                    throw ReservationException(ErrorCode.SEAT_NOT_AVAILABLE)
+                }
+            }
+
+            // 6. 좌석 상세 조회 (스냅샷용)
+            val seatDetailsResponse = eventServiceClient.getSeatDetails(request.scheduleId, request.seatIds)
+            val seatDetailMap = seatDetailsResponse.seats.associateBy { it.seatId }
+            if (seatDetailMap.size != request.seatIds.size) {
+                throw ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "요청한 좌석 정보를 찾을 수 없습니다.")
+            }
+
+            // 7. DB 저장 + Redis hold_seats SET 업데이트 (원자적 처리)
+            val holdExpiresAt = LocalDateTime.now().plusMinutes(HOLD_MINUTES)
+            val totalAmount = seatDetailsResponse.seats.sumOf { it.price }
+            val reservation = transactionTemplate.execute {
+                val saved = reservationRepository.save(
+                    Reservation(
+                        userId = userId,
+                        scheduleId = request.scheduleId,
+                        eventId = seatDetailsResponse.eventId,
+                        totalAmount = totalAmount,
+                        holdExpiresAt = holdExpiresAt
+                    )
+                )
+                reservationSeatRepository.saveAll(
+                    request.seatIds.map { seatId ->
+                        val detail = seatDetailMap[seatId]
+                            ?: throw ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "좌석 상세 정보 없음: $seatId")
+                        ReservationSeat(
+                            reservationId = saved.id!!,
+                            seatId = seatId,
+                            seatNumber = detail.seatNumber,
+                            grade = detail.grade,
+                            price = detail.price
+                        )
+                    }
+                )
+                updateHoldSeatsSet(request.scheduleId, request.seatIds)
+                saved
+            } ?: throw ReservationException(ErrorCode.INTERNAL_SERVER_ERROR, "좌석 선점 저장에 실패했습니다.")
+
+            log.info { "Seats held: userId=$userId, scheduleId=${request.scheduleId}, seatIds=${request.seatIds}, reservationId=${reservation.id}" }
+
+            return HoldResponse(
+                reservationId = reservation.id!!,
+                status = reservation.status,
+                totalAmount = reservation.totalAmount,
+                holdExpiresAt = reservation.holdExpiresAt
+            )
+        } finally {
+            // 획득한 락을 역순으로 안전하게 해제
+            acquiredLocks.reversed().forEach { lock ->
+                try {
+                    if (lock.isHeldByCurrentThread) lock.unlock()
+                } catch (e: Exception) {
+                    log.warn(e) { "Failed to release lock: ${lock.name}" }
+                }
+            }
+        }
+    }
+
+    private fun validateQueueToken(token: String, userId: UUID, scheduleId: UUID) {
+        val tokenJson = stringRedisTemplate.opsForValue().get("queue:token:$token")
+            ?: throw ReservationException(ErrorCode.QUEUE_TOKEN_EXPIRED)
+
+        try {
+            val node = objectMapper.readTree(tokenJson)
+            val tokenUserId = node.get("userId")?.asText()
+            val tokenScheduleId = node.get("scheduleId")?.asText()
+            if (tokenUserId != userId.toString() || tokenScheduleId != scheduleId.toString()) {
+                throw ReservationException(ErrorCode.QUEUE_TOKEN_INVALID)
+            }
+        } catch (e: ReservationException) {
+            throw e
+        } catch (e: Exception) {
+            throw ReservationException(ErrorCode.QUEUE_TOKEN_INVALID)
+        }
+    }
+
+    private fun validateSeatCount(userId: UUID, scheduleId: UUID, requestedCount: Int) {
+        val pendingReservations = reservationRepository.findByUserIdAndScheduleIdAndStatus(
+            userId, scheduleId, ReservationStatus.PENDING
+        )
+        if (pendingReservations.isEmpty()) return
+
+        val existingCount = reservationSeatRepository.countByReservationIdIn(
+            pendingReservations.mapNotNull { it.id }
+        )
+        if (existingCount + requestedCount > MAX_HOLD_SEATS) {
+            throw ReservationException(ErrorCode.MAX_SEATS_EXCEEDED)
+        }
+    }
+
+    private fun checkHoldSeatsSet(scheduleId: UUID, seatIds: List<UUID>) {
+        val holdSeatsKey = "hold_seats:$scheduleId"
+        seatIds.forEach { seatId ->
+            if (stringRedisTemplate.opsForSet().isMember(holdSeatsKey, seatId.toString()) == true) {
+                throw ReservationException(ErrorCode.SEAT_ALREADY_HELD)
+            }
+        }
+    }
+
+    /**
+     * hold_seats Redis SET에 좌석 ID를 추가하고 TTL을 설정한다.
+     *
+     * 트랜잭션 내부에서 호출되므로 예외가 전파되어 DB 롤백을 트리거한다.
+     *
+     * stringRedisTemplate.expire() 대신 redissonClient.keys.expire() 를 사용하는 이유:
+     * redisson-spring-data-34:3.40.2 가 Spring Data Redis 3.5.x 에서 추가된
+     * pExpire(byte[], long, Condition) 3-arg 메서드를 미구현하여 DefaultedRedisConnection
+     * 에서 무한 재귀가 발생하는 호환성 버그 회피.
+     */
+    private fun updateHoldSeatsSet(scheduleId: UUID, seatIds: List<UUID>) {
+        val holdSeatsKey = "hold_seats:$scheduleId"
+        stringRedisTemplate.opsForSet().add(holdSeatsKey, *seatIds.map { it.toString() }.toTypedArray())
+        redissonClient.keys.expire(holdSeatsKey, HOLD_SEATS_SET_TTL_SECONDS, TimeUnit.SECONDS)
+    }
+
+}

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
@@ -21,6 +21,7 @@ import org.springframework.transaction.support.TransactionSynchronization
 import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -167,7 +168,7 @@ class ReservationService(
                 reservationId = reservation.id!!,
                 status = reservation.status,
                 totalAmount = reservation.totalAmount,
-                holdExpiresAt = reservation.holdExpiresAt
+                holdExpiresAt = reservation.holdExpiresAt.atOffset(ZoneOffset.UTC)
             )
         } finally {
             // 획득한 락을 역순으로 안전하게 해제
@@ -197,6 +198,9 @@ class ReservationService(
     }
 
     private fun validateSeatCount(userId: UUID, scheduleId: UUID, requestedCount: Int) {
+        if (requestedCount > MAX_HOLD_SEATS) {
+            throw ReservationException(ErrorCode.MAX_SEATS_EXCEEDED)
+        }
         val pendingReservations = reservationRepository.findByUserIdAndScheduleIdAndStatus(
             userId, scheduleId, ReservationStatus.PENDING
         )

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
@@ -15,10 +15,13 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
 import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.script.RedisScript
 import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.transaction.support.TransactionTemplate
-import java.time.Duration
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
@@ -27,13 +30,13 @@ import java.util.concurrent.TimeUnit
  *
  * ## 선점 프로세스
  * 1. QueueToken 검증 — queue:token:{token} Redis 직접 조회
- * 2. 기존 선점 수량 검증 — PENDING 예매의 좌석 수 합산 (최대 4장)
- * 3. Redisson 분산 락 획득 — seat:hold:{scheduleId}:{seatId}, leaseTime=300s (watchdog 비활성)
+ * 2. Redisson 분산 락 획득 — user:hold:lock:{userId}:{scheduleId} + seat:hold:{scheduleId}:{seatId}
+ * 3. 기존 선점 수량 검증 — PENDING 예매의 좌석 수 합산, 사용자 락 내부에서 TOCTOU 방지 (최대 4장)
  * 4. Redis hold_seats SET 확인 — 이미 선점된 좌석 중복 방지
- * 5. Event Service SOLD 상태 확인 — Feign 내부 API 호출
- * 6. 좌석 상세 조회 — 스냅샷 저장용 (seatNumber, grade, price)
- * 7. DB 저장 + Redis hold_seats SET 업데이트 (TransactionTemplate 내부)
- *    — Redis 실패 시 예외가 전파되어 DB 트랜잭션이 롤백되므로 정합성이 유지됨
+ * 5. 좌석 상세 조회 — Event Service 내부 API, AVAILABLE 상태 검증 + 스냅샷(seatNumber, grade, price)
+ * 6. DB 저장 (TransactionTemplate) + afterCommit 콜백으로 Redis hold_seats SET 업데이트
+ *    — afterCommit 사용으로 DB commit 성공 후에만 Redis 갱신 (롤백 시 Redis 오염 없음)
+ *    — Redis 갱신 실패 시 경고 로그만 남기고 전파하지 않음 (hold_seats TTL 배치가 보정)
  *
  * ## 락 설계
  * tryLock(waitTime=0, leaseTime=300s)으로 락이 이미 선점 중이면 즉시 실패한다.
@@ -51,6 +54,25 @@ class ReservationService(
 ) {
 
     private val log = KotlinLogging.logger {}
+
+    // SADD + EXPIRE를 단일 RTT로 원자적 처리하는 Lua 스크립트
+    // ARGV[1]: TTL(초), ARGV[2..]: 좌석 ID 목록
+    private val holdSeatsSetScript = RedisScript.of<Long>(
+        """
+        redis.call('SADD', KEYS[1], unpack(ARGV, 2))
+        redis.call('EXPIRE', KEYS[1], ARGV[1])
+        return 1
+        """.trimIndent(),
+        Long::class.java
+    )
+
+    // Queue Service 토큰 페이로드 구조 (batch-approve.lua 발급 형식과 일치)
+    // issuedAt은 Lua cjson.encode가 ARGV 문자열을 JSON string으로 직렬화하므로 String? 타입
+    private data class QueueTokenPayload(
+        val userId: UUID,
+        val scheduleId: UUID,
+        val issuedAt: String? = null
+    )
 
     companion object {
         private const val MAX_HOLD_SEATS = 4
@@ -73,7 +95,7 @@ class ReservationService(
 
         // 락과 그에 따른 에러 코드를 페어로 관리하여 순회 획득
         val lockTargets = listOf(
-            userLock to ErrorCode.RATE_LIMIT_EXCEEDED,
+            userLock to ErrorCode.RESERVATION_IN_PROGRESS,
             multiSeatLock to ErrorCode.SEAT_ALREADY_HELD
         )
         val acquiredLocks = mutableListOf<RLock>()
@@ -87,29 +109,21 @@ class ReservationService(
                 acquiredLocks.add(lock)
             }
 
-            // 2. 수량 검증 (사용자 락 안에서 수행하여 TOCTOU 방지)
+            // 3. 수량 검증 (사용자 락 안에서 수행하여 TOCTOU 방지)
             validateSeatCount(userId, request.scheduleId, request.seatIds.size)
 
             // 4. Redis hold_seats SET 중복 확인
             checkHoldSeatsSet(request.scheduleId, request.seatIds)
 
-            // 5. Event Service SOLD 상태 확인
-            val soldSeatIds = eventServiceClient.getSoldSeats(request.scheduleId).soldSeatIds.toSet()
-            request.seatIds.forEach { seatId ->
-                if (seatId in soldSeatIds) {
-                    throw ReservationException(ErrorCode.SEAT_NOT_AVAILABLE)
-                }
-            }
-
-            // 6. 좌석 상세 조회 (스냅샷용)
+            // 5. 좌석 상세 조회 — AVAILABLE 상태 검증 + 스냅샷 (getSeatDetails 내부에서 SOLD/HOLD 거부)
             val seatDetailsResponse = eventServiceClient.getSeatDetails(request.scheduleId, request.seatIds)
             val seatDetailMap = seatDetailsResponse.seats.associateBy { it.seatId }
             if (seatDetailMap.size != request.seatIds.size) {
                 throw ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "요청한 좌석 정보를 찾을 수 없습니다.")
             }
 
-            // 7. DB 저장 + Redis hold_seats SET 업데이트 (원자적 처리)
-            val holdExpiresAt = LocalDateTime.now().plusMinutes(HOLD_MINUTES)
+            // 6. DB 저장 후 afterCommit 콜백으로 Redis hold_seats SET 업데이트
+            val holdExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(HOLD_MINUTES)
             val totalAmount = seatDetailsResponse.seats.sumOf { it.price }
             val reservation = transactionTemplate.execute {
                 val saved = reservationRepository.save(
@@ -134,7 +148,16 @@ class ReservationService(
                         )
                     }
                 )
-                updateHoldSeatsSet(request.scheduleId, request.seatIds)
+                // DB commit 성공 후에만 Redis 갱신 — 롤백 시 Redis 오염 없음
+                TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+                    override fun afterCommit() {
+                        try {
+                            updateHoldSeatsSet(request.scheduleId, request.seatIds)
+                        } catch (e: Exception) {
+                            log.warn(e) { "hold_seats SET 업데이트 실패 (scheduleId=${request.scheduleId}). 배치가 보정합니다." }
+                        }
+                    }
+                })
                 saved
             } ?: throw ReservationException(ErrorCode.INTERNAL_SERVER_ERROR, "좌석 선점 저장에 실패했습니다.")
 
@@ -162,16 +185,13 @@ class ReservationService(
         val tokenJson = stringRedisTemplate.opsForValue().get("queue:token:$token")
             ?: throw ReservationException(ErrorCode.QUEUE_TOKEN_EXPIRED)
 
-        try {
-            val node = objectMapper.readTree(tokenJson)
-            val tokenUserId = node.get("userId")?.asText()
-            val tokenScheduleId = node.get("scheduleId")?.asText()
-            if (tokenUserId != userId.toString() || tokenScheduleId != scheduleId.toString()) {
-                throw ReservationException(ErrorCode.QUEUE_TOKEN_INVALID)
-            }
-        } catch (e: ReservationException) {
-            throw e
+        val payload = try {
+            objectMapper.readValue(tokenJson, QueueTokenPayload::class.java)
         } catch (e: Exception) {
+            throw ReservationException(ErrorCode.QUEUE_TOKEN_INVALID)
+        }
+
+        if (payload.userId != userId || payload.scheduleId != scheduleId) {
             throw ReservationException(ErrorCode.QUEUE_TOKEN_INVALID)
         }
     }
@@ -202,17 +222,13 @@ class ReservationService(
     /**
      * hold_seats Redis SET에 좌석 ID를 추가하고 TTL을 설정한다.
      *
-     * 트랜잭션 내부에서 호출되므로 예외가 전파되어 DB 롤백을 트리거한다.
-     *
-     * stringRedisTemplate.expire() 대신 redissonClient.keys.expire() 를 사용하는 이유:
-     * redisson-spring-data-34:3.40.2 가 Spring Data Redis 3.5.x 에서 추가된
-     * pExpire(byte[], long, Condition) 3-arg 메서드를 미구현하여 DefaultedRedisConnection
-     * 에서 무한 재귀가 발생하는 호환성 버그 회피.
+     * Lua 스크립트로 SADD + EXPIRE를 단일 RTT에 원자적으로 처리한다.
+     * DB commit 성공 후 afterCommit 콜백에서 호출되므로 DB 롤백 시 Redis 오염이 발생하지 않는다.
      */
     private fun updateHoldSeatsSet(scheduleId: UUID, seatIds: List<UUID>) {
         val holdSeatsKey = "hold_seats:$scheduleId"
-        stringRedisTemplate.opsForSet().add(holdSeatsKey, *seatIds.map { it.toString() }.toTypedArray())
-        redissonClient.keys.expire(holdSeatsKey, HOLD_SEATS_SET_TTL_SECONDS, TimeUnit.SECONDS)
+        val args = (listOf(HOLD_SEATS_SET_TTL_SECONDS.toString()) + seatIds.map { it.toString() }).toTypedArray()
+        stringRedisTemplate.execute(holdSeatsSetScript, listOf(holdSeatsKey), *args)
     }
 
 }

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
@@ -216,10 +216,14 @@ class ReservationService(
 
     private fun checkHoldSeatsSet(scheduleId: UUID, seatIds: List<UUID>) {
         val holdSeatsKey = "hold_seats:$scheduleId"
-        seatIds.forEach { seatId ->
-            if (stringRedisTemplate.opsForSet().isMember(holdSeatsKey, seatId.toString()) == true) {
-                throw ReservationException(ErrorCode.SEAT_ALREADY_HELD)
-            }
+        val result: List<Boolean>? = stringRedisTemplate.execute { conn ->
+            conn.setCommands().sMIsMember(
+                holdSeatsKey.toByteArray(Charsets.UTF_8),
+                *seatIds.map { it.toString().toByteArray(Charsets.UTF_8) }.toTypedArray()
+            )
+        }
+        if (result?.any { it == true } == true) {
+            throw ReservationException(ErrorCode.SEAT_ALREADY_HELD)
         }
     }
 

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsConcurrencyTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsConcurrencyTest.kt
@@ -280,16 +280,13 @@ class HoldSeatsConcurrencyTest {
     /**
      * 동일 유저가 동일 회차의 서로 다른 좌석을 동시에 1장씩 요청하는 경우.
      *
-     * 주의: validateSeatCount는 락 획득 전에 실행되므로, 여러 요청이 동시에
-     * "현재 PENDING 0장"으로 읽어 모두 통과할 수 있다 (낙관적 읽기 경쟁).
-     * 이 테스트는 해당 경쟁 조건을 문서화한다.
-     *
-     * 동일 유저 4장 제한 보장이 필요하다면 DB 레벨 unique constraint나
-     * 유저 단위 락 추가를 검토해야 한다.
+     * user:hold:lock:{userId}:{scheduleId} 의 waitTime=0 정책에 의해
+     * 동일 유저의 동시 요청은 직렬화된다: 락을 먼저 획득한 1건만 201로 성공하고
+     * 나머지 (concurrency - 1) 건은 즉시 409 RESERVATION_IN_PROGRESS로 실패한다.
      */
     @Test
-    @DisplayName("동일 유저가 서로 다른 좌석 4개를 동시 요청하면 모두 성공할 수 있다 (낙관적 읽기 경쟁)")
-    fun sameUserConcurrentDifferentSeatsCanAllSucceed() {
+    @DisplayName("동일 유저가 서로 다른 좌석을 동시 요청하면 유저 락 직렬화로 1개만 성공한다")
+    fun sameUserConcurrentDifferentSeatsOnlyOneSucceeds() {
         val concurrency = 4
         val seatIds = List(concurrency) { UUID.randomUUID() }
         val userId = UUID.randomUUID()
@@ -320,12 +317,9 @@ class HoldSeatsConcurrencyTest {
         val statuses = futures.map { it.get() }
         executor.shutdown()
 
-        // 각 좌석에 대한 분산 락은 독립적이므로 모두 성공하는 경로가 존재함
-        // (validateSeatCount가 동시에 "기존 0장"으로 읽는 경쟁 조건)
-        val successCount = statuses.count { it == 201 }
-        val dbCount = reservationRepository.findAll().size
-
-        // DB 저장 건수와 HTTP 성공 건수가 일치해야 한다
-        dbCount shouldBe successCount
+        // waitTime=0 유저 락으로 동시 요청은 직렬화 — 정확히 1건만 성공
+        statuses.count { it == 201 } shouldBe 1
+        statuses.count { it == 409 } shouldBe (concurrency - 1)
+        reservationRepository.findAll().size shouldBe 1
     }
 }

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsConcurrencyTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsConcurrencyTest.kt
@@ -28,6 +28,7 @@ import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 /**
  * 좌석 선점 동시성 테스트
@@ -183,6 +184,7 @@ class HoldSeatsConcurrencyTest {
         startLatch.countDown()
         val statuses = futures.map { it.get() }
         executor.shutdown()
+        if (!executor.awaitTermination(5, TimeUnit.SECONDS)) executor.shutdownNow()
 
         // HTTP 응답 검증
         statuses.count { it == 201 } shouldBe 1

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsConcurrencyTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsConcurrencyTest.kt
@@ -1,0 +1,331 @@
+package com.ticketqueue.reservation.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.ticketqueue.reservation.client.EventServiceClient
+import com.ticketqueue.reservation.repository.ReservationRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.math.BigDecimal
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+/**
+ * 좌석 선점 동시성 테스트
+ *
+ * HoldSeatsIntegrationTest 와의 차이점:
+ * - RedissonClient를 mock하지 않고 실제 Valkey 컨테이너에 연결한다.
+ * - 여러 스레드가 CountDownLatch로 동시에 출발해 실제 분산 락 경합을 유발한다.
+ *
+ * 보호 레이어:
+ *   1차 — Redisson tryLock(waitTime=0): 락을 선점한 스레드 외 나머지는 즉시 false 반환 → 409
+ *   2차 — hold_seats SET: 락 해제 후 재시도해도 SET에 이미 존재하면 → 409
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "spring.config.import=",
+        "spring.cloud.aws.region.static=us-east-1",
+        "spring.cloud.aws.credentials.access-key=test",
+        "spring.cloud.aws.credentials.secret-key=test",
+        "spring.cloud.aws.secretsmanager.enabled=false"
+    ]
+)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("좌석 선점 동시성 테스트")
+class HoldSeatsConcurrencyTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("ticketing")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("db/init.sql")
+
+        @Container
+        @JvmStatic
+        val valkey = GenericContainer("valkey/valkey:8.1-alpine")
+            .withExposedPorts(6379)
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
+            registry.add("spring.datasource.username") { postgres.username }
+            registry.add("spring.datasource.password") { postgres.password }
+            registry.add("spring.data.redis.host") { valkey.host }
+            registry.add("spring.data.redis.port") { valkey.getMappedPort(6379) }
+        }
+    }
+
+    @Autowired private lateinit var mockMvc: MockMvc
+    @Autowired private lateinit var stringRedisTemplate: StringRedisTemplate
+    @Autowired private lateinit var objectMapper: ObjectMapper
+    @Autowired private lateinit var reservationRepository: ReservationRepository
+
+    // EventServiceClient만 mock — RedissonClient는 실제 Valkey 컨테이너 사용
+    @MockkBean private lateinit var eventServiceClient: EventServiceClient
+
+    private val scheduleId = UUID.randomUUID()
+    private val eventId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        stringRedisTemplate.connectionFactory?.connection?.serverCommands()?.flushAll()
+        reservationRepository.deleteAll()
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // 헬퍼
+    // ─────────────────────────────────────────────────────────
+
+    private fun seedQueueToken(userId: UUID, token: String) {
+        stringRedisTemplate.opsForValue().set(
+            "queue:token:$token",
+            """{"userId":"$userId","scheduleId":"$scheduleId","issuedAt":"1234567890"}"""
+        )
+    }
+
+    /**
+     * getSeatDetails 응답을 요청된 seatId 목록 기준으로 동적으로 반환한다.
+     * 동시성 테스트에서 좌석마다 다른 UUID를 쓰므로, 고정 mock 대신 answers 블록을 사용한다.
+     */
+    private fun mockAllSeatsAvailable() {
+        every { eventServiceClient.getSoldSeats(scheduleId) } returns
+            EventServiceClient.SoldSeatsResponse(scheduleId, emptyList())
+
+        every { eventServiceClient.getSeatDetails(scheduleId, any()) } answers {
+            val requestedIds = arg<List<UUID>>(1)
+            EventServiceClient.SeatDetailsResponse(
+                scheduleId = scheduleId,
+                eventId = eventId,
+                seats = requestedIds.map { id ->
+                    EventServiceClient.SeatDetailsResponse.SeatDetail(
+                        seatId = id,
+                        seatNumber = "A-${id.toString().take(4)}",
+                        grade = "VIP",
+                        price = BigDecimal("150000")
+                    )
+                }
+            )
+        }
+    }
+
+    private fun holdRequestBody(seatIds: List<UUID>): String =
+        objectMapper.writeValueAsString(mapOf("scheduleId" to scheduleId, "seatIds" to seatIds))
+
+    // ─────────────────────────────────────────────────────────
+    // 테스트
+    // ─────────────────────────────────────────────────────────
+
+    /**
+     * 핵심 시나리오: 동일 좌석에 N명이 동시 요청 → 정확히 1명만 성공
+     *
+     * 흐름:
+     *  - 10개 스레드가 CountDownLatch로 동시에 출발
+     *  - 각 스레드는 tryLock(waitTime=0) 으로 Valkey 분산 락 경합
+     *  - 락을 획득한 1명이 DB + hold_seats SET을 갱신하고 락 해제
+     *  - 나머지 9명은 tryLock 실패(즉시) → 409 SEAT_ALREADY_HELD
+     *  - 락 해제 후 재시도하더라도 hold_seats SET 확인에서 추가로 차단됨
+     */
+    @Test
+    @DisplayName("동일 좌석에 N명이 동시 요청하면 정확히 1명만 성공하고 나머지는 409를 반환한다")
+    fun onlyOneSucceedsForSameSeatConcurrentRequests() {
+        val concurrency = 10
+        val seatId = UUID.randomUUID()
+        mockAllSeatsAvailable()
+
+        val users = List(concurrency) { UUID.randomUUID() }
+        val tokens = List(concurrency) { "token-${UUID.randomUUID()}" }
+        users.zip(tokens).forEach { (userId, token) -> seedQueueToken(userId, token) }
+
+        val requestBody = holdRequestBody(listOf(seatId))
+        val executor = Executors.newFixedThreadPool(concurrency)
+        val startLatch = CountDownLatch(1)
+
+        val futures = users.zip(tokens).map { (userId, token) ->
+            CompletableFuture.supplyAsync({
+                startLatch.await()  // 모든 스레드 준비 완료 후 일제히 출발
+                mockMvc.perform(
+                    post("/reservations/hold")
+                        .header("X-User-Id", userId)
+                        .header("X-User-Role", "USER")
+                        .header("X-Queue-Token", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                ).andReturn().response.status
+            }, executor)
+        }
+
+        startLatch.countDown()
+        val statuses = futures.map { it.get() }
+        executor.shutdown()
+
+        // HTTP 응답 검증
+        statuses.count { it == 201 } shouldBe 1
+        statuses.count { it == 409 } shouldBe concurrency - 1
+
+        // DB — 예매 레코드가 정확히 1건
+        reservationRepository.findAll().size shouldBe 1
+
+        // Redis — hold_seats SET에 해당 좌석이 1건
+        stringRedisTemplate.opsForSet().size("hold_seats:$scheduleId") shouldBe 1L
+    }
+
+    /**
+     * 선점 성공 후 동일 좌석 재요청: hold_seats SET이 2차 방어선 역할을 한다.
+     *
+     * 분산 락은 이미 해제된 상태이지만, hold_seats SET에 이미 존재하므로
+     * checkHoldSeatsSet 에서 차단 → 409 SEAT_ALREADY_HELD
+     */
+    @Test
+    @DisplayName("선점 성공 후 동일 좌석 재요청은 409 SEAT_ALREADY_HELD를 반환한다")
+    fun secondRequestForSameSeatFailsAfterFirstSucceeds() {
+        val seatId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
+        val token = "token-${UUID.randomUUID()}"
+        mockAllSeatsAvailable()
+        seedQueueToken(userId, token)
+
+        val requestBody = holdRequestBody(listOf(seatId))
+
+        // 1차 요청 — 성공
+        val firstStatus = mockMvc.perform(
+            post("/reservations/hold")
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+                .header("X-Queue-Token", token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody)
+        ).andReturn().response.status
+        firstStatus shouldBe 201
+
+        // 2차 요청 — hold_seats SET에서 차단 (분산 락은 이미 해제됨)
+        val secondStatus = mockMvc.perform(
+            post("/reservations/hold")
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+                .header("X-Queue-Token", token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody)
+        ).andReturn().response.status
+        secondStatus shouldBe 409
+
+        reservationRepository.findAll().size shouldBe 1
+    }
+
+    /**
+     * 서로 다른 좌석 동시 요청: 락은 좌석별로 독립적이므로 경합 없이 모두 성공해야 한다.
+     */
+    @Test
+    @DisplayName("서로 다른 유저가 서로 다른 좌석을 동시 요청하면 모두 성공한다")
+    fun allSucceedWhenDifferentUsersRequestDifferentSeats() {
+        val concurrency = 4
+        val seatIds = List(concurrency) { UUID.randomUUID() }
+        mockAllSeatsAvailable()
+
+        val users = List(concurrency) { UUID.randomUUID() }
+        val tokens = List(concurrency) { "token-${UUID.randomUUID()}" }
+        users.zip(tokens).forEach { (userId, token) -> seedQueueToken(userId, token) }
+
+        val executor = Executors.newFixedThreadPool(concurrency)
+        val startLatch = CountDownLatch(1)
+
+        val futures = (0 until concurrency).map { i ->
+            CompletableFuture.supplyAsync({
+                startLatch.await()
+                mockMvc.perform(
+                    post("/reservations/hold")
+                        .header("X-User-Id", users[i])
+                        .header("X-User-Role", "USER")
+                        .header("X-Queue-Token", tokens[i])
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(holdRequestBody(listOf(seatIds[i])))
+                ).andReturn().response.status
+            }, executor)
+        }
+
+        startLatch.countDown()
+        val statuses = futures.map { it.get() }
+        executor.shutdown()
+
+        statuses.count { it == 201 } shouldBe concurrency
+        reservationRepository.findAll().size shouldBe concurrency
+        stringRedisTemplate.opsForSet().size("hold_seats:$scheduleId") shouldBe concurrency.toLong()
+    }
+
+    /**
+     * 동일 유저가 동일 회차의 서로 다른 좌석을 동시에 1장씩 요청하는 경우.
+     *
+     * 주의: validateSeatCount는 락 획득 전에 실행되므로, 여러 요청이 동시에
+     * "현재 PENDING 0장"으로 읽어 모두 통과할 수 있다 (낙관적 읽기 경쟁).
+     * 이 테스트는 해당 경쟁 조건을 문서화한다.
+     *
+     * 동일 유저 4장 제한 보장이 필요하다면 DB 레벨 unique constraint나
+     * 유저 단위 락 추가를 검토해야 한다.
+     */
+    @Test
+    @DisplayName("동일 유저가 서로 다른 좌석 4개를 동시 요청하면 모두 성공할 수 있다 (낙관적 읽기 경쟁)")
+    fun sameUserConcurrentDifferentSeatsCanAllSucceed() {
+        val concurrency = 4
+        val seatIds = List(concurrency) { UUID.randomUUID() }
+        val userId = UUID.randomUUID()
+        mockAllSeatsAvailable()
+
+        // 동일 유저이므로 토큰마다 같은 userId를 심는다
+        val tokens = List(concurrency) { "token-${UUID.randomUUID()}" }
+        tokens.forEach { token -> seedQueueToken(userId, token) }
+
+        val executor = Executors.newFixedThreadPool(concurrency)
+        val startLatch = CountDownLatch(1)
+
+        val futures = (0 until concurrency).map { i ->
+            CompletableFuture.supplyAsync({
+                startLatch.await()
+                mockMvc.perform(
+                    post("/reservations/hold")
+                        .header("X-User-Id", userId)
+                        .header("X-User-Role", "USER")
+                        .header("X-Queue-Token", tokens[i])
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(holdRequestBody(listOf(seatIds[i])))
+                ).andReturn().response.status
+            }, executor)
+        }
+
+        startLatch.countDown()
+        val statuses = futures.map { it.get() }
+        executor.shutdown()
+
+        // 각 좌석에 대한 분산 락은 독립적이므로 모두 성공하는 경로가 존재함
+        // (validateSeatCount가 동시에 "기존 0장"으로 읽는 경쟁 조건)
+        val successCount = statuses.count { it == 201 }
+        val dbCount = reservationRepository.findAll().size
+
+        // DB 저장 건수와 HTTP 성공 건수가 일치해야 한다
+        dbCount shouldBe successCount
+    }
+}

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsIntegrationTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsIntegrationTest.kt
@@ -1,0 +1,281 @@
+package com.ticketqueue.reservation.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.ninjasquad.springmockk.SpykBean
+import com.ticketqueue.reservation.client.EventServiceClient
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.math.BigDecimal
+import java.util.UUID
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "spring.config.import=",                             // aws-secretsmanager import 비활성화
+        "spring.cloud.aws.region.static=us-east-1",
+        "spring.cloud.aws.credentials.access-key=test",
+        "spring.cloud.aws.credentials.secret-key=test",
+        "spring.cloud.aws.secretsmanager.enabled=false"
+    ]
+)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("좌석 선점 API 통합 테스트 (POST /reservations/hold)")
+class HoldSeatsIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("ticketing")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("db/init.sql")
+
+        @Container
+        @JvmStatic
+        val valkey = GenericContainer("valkey/valkey:8.1.5-alpine3.23")
+            .withExposedPorts(6379)
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
+            registry.add("spring.datasource.username") { postgres.username }
+            registry.add("spring.datasource.password") { postgres.password }
+            registry.add("spring.data.redis.host") { valkey.host }
+            registry.add("spring.data.redis.port") { valkey.getMappedPort(6379) }
+        }
+    }
+
+    @Autowired private lateinit var mockMvc: MockMvc
+    @Autowired private lateinit var stringRedisTemplate: StringRedisTemplate
+    @Autowired private lateinit var objectMapper: ObjectMapper
+
+    @SpykBean private lateinit var redissonClient: RedissonClient
+    @MockkBean private lateinit var eventServiceClient: EventServiceClient
+
+    private val userId = UUID.randomUUID()
+    private val scheduleId = UUID.randomUUID()
+    private val eventId = UUID.randomUUID()
+    private val seatId = UUID.randomUUID()
+    private val validToken = "test-queue-token-${UUID.randomUUID()}"
+    private lateinit var rLock: RLock
+    private lateinit var multiLock: RLock
+
+    @BeforeEach
+    fun setUp() {
+        stringRedisTemplate.connectionFactory?.connection?.serverCommands()?.flushAll()
+
+        rLock = mockk()
+        multiLock = mockk()
+        every { redissonClient.getLock(any<String>()) } returns rLock
+        every { redissonClient.getMultiLock(*varargAny { true }) } returns multiLock
+        every { rLock.tryLock(any<Long>(), any<Long>(), any()) } returns true
+        every { rLock.isHeldByCurrentThread } returns true
+        justRun { rLock.unlock() }
+        every { multiLock.tryLock(any<Long>(), any<Long>(), any()) } returns true
+        every { multiLock.isHeldByCurrentThread } returns true
+        justRun { multiLock.unlock() }
+
+        every { eventServiceClient.getSoldSeats(scheduleId) } returns
+            EventServiceClient.SoldSeatsResponse(scheduleId, emptyList())
+        every { eventServiceClient.getSeatDetails(scheduleId, any()) } returns
+            EventServiceClient.SeatDetailsResponse(
+                scheduleId = scheduleId,
+                eventId = eventId,
+                seats = listOf(
+                    EventServiceClient.SeatDetailsResponse.SeatDetail(
+                        seatId = seatId,
+                        seatNumber = "A-1",
+                        grade = "VIP",
+                        price = BigDecimal("150000")
+                    )
+                )
+            )
+    }
+
+    private fun seedQueueToken(token: String) {
+        val payload = """{"userId":"$userId","scheduleId":"$scheduleId","issuedAt":"1234567890"}"""
+        stringRedisTemplate.opsForValue().set("queue:token:$token", payload)
+    }
+
+    private fun holdRequestBody(seatIds: List<UUID> = listOf(seatId)) =
+        objectMapper.writeValueAsString(mapOf("scheduleId" to scheduleId, "seatIds" to seatIds))
+
+    // ─────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("성공 시나리오")
+    inner class Success {
+
+        @Test
+        @DisplayName("유효한 QueueToken으로 선점 시 201 Created와 PENDING 상태를 반환한다")
+        fun returns201OnValidToken() {
+            seedQueueToken(validToken)
+
+            mockMvc.perform(
+                post("/reservations/hold")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(holdRequestBody())
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andExpect(jsonPath("$.totalAmount").value(150000))
+                .andExpect(jsonPath("$.reservationId").isNotEmpty)
+                .andExpect(jsonPath("$.holdExpiresAt").isNotEmpty)
+        }
+
+        @Test
+        @DisplayName("선점 성공 후 Redis hold_seats SET에 좌석 ID가 추가된다")
+        fun addsToHoldSeatsSetOnSuccess() {
+            seedQueueToken(validToken)
+
+            mockMvc.perform(
+                post("/reservations/hold")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(holdRequestBody())
+            ).andExpect(status().isCreated)
+
+            val members = stringRedisTemplate.opsForSet().members("hold_seats:$scheduleId")
+            assert(members?.contains(seatId.toString()) == true) {
+                "hold_seats SET에 $seatId 가 존재해야 합니다. 실제 members: $members"
+            }
+        }
+
+        @Test
+        @DisplayName("성공 시 Redisson 락을 즉시 해제한다")
+        fun unlocksOnSuccess() {
+            seedQueueToken(validToken)
+
+            mockMvc.perform(
+                post("/reservations/hold")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(holdRequestBody())
+            ).andExpect(status().isCreated)
+
+            verify(exactly = 1) { rLock.unlock() }   // userLock
+            verify(exactly = 1) { multiLock.unlock() } // multiSeatLock
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("QueueToken 검증 실패")
+    inner class TokenValidationFailure {
+
+        @Test
+        @DisplayName("Redis에 토큰이 없으면 401 QUEUE_TOKEN_EXPIRED를 반환한다")
+        fun returns401WhenTokenMissing() {
+            mockMvc.perform(
+                post("/reservations/hold")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", "non-existent-token")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(holdRequestBody())
+            )
+                .andExpect(status().isUnauthorized)
+                .andExpect(jsonPath("$.code").value("QUEUE_TOKEN_EXPIRED"))
+        }
+
+        @Test
+        @DisplayName("토큰의 userId가 다르면 401 QUEUE_TOKEN_INVALID를 반환한다")
+        fun returns401WhenUserIdMismatch() {
+            val otherUserId = UUID.randomUUID()
+            stringRedisTemplate.opsForValue()
+                .set("queue:token:$validToken", """{"userId":"$otherUserId","scheduleId":"$scheduleId","issuedAt":"123"}""")
+
+            mockMvc.perform(
+                post("/reservations/hold")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(holdRequestBody())
+            )
+                .andExpect(status().isUnauthorized)
+                .andExpect(jsonPath("$.code").value("QUEUE_TOKEN_INVALID"))
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("요청 유효성 검증")
+    inner class RequestValidation {
+
+        @Test
+        @DisplayName("seatIds가 비어있으면 400을 반환한다")
+        fun returns400WhenSeatIdsEmpty() {
+            seedQueueToken(validToken)
+
+            mockMvc.perform(
+                post("/reservations/hold")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(holdRequestBody(emptyList()))
+            ).andExpect(status().isBadRequest)
+        }
+
+        @Test
+        @DisplayName("seatIds가 5개면 400 MAX_SEATS_EXCEEDED를 반환한다")
+        fun returns400WhenFiveSeatsRequested() {
+            seedQueueToken(validToken)
+            val fiveSeats = (1..5).map { UUID.randomUUID() }
+            // 5개 seats에 대한 details mock
+            every { eventServiceClient.getSeatDetails(scheduleId, any()) } returns
+                EventServiceClient.SeatDetailsResponse(
+                    scheduleId = scheduleId,
+                    eventId = eventId,
+                    seats = fiveSeats.map { id ->
+                        EventServiceClient.SeatDetailsResponse.SeatDetail(id, "X-$id", "VIP", BigDecimal("150000"))
+                    }
+                )
+
+            mockMvc.perform(
+                post("/reservations/hold")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(holdRequestBody(fiveSeats))
+            ).andExpect(status().isBadRequest)
+        }
+    }
+}

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsIntegrationTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsIntegrationTest.kt
@@ -8,7 +8,8 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.jupiter.api.Assertions.assertTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -170,8 +171,7 @@ class HoldSeatsIntegrationTest {
             ).andExpect(status().isCreated)
 
             val members = stringRedisTemplate.opsForSet().members("hold_seats:$scheduleId")
-            assertTrue(members?.contains(seatId.toString()) == true,
-                "hold_seats SET에 $seatId 가 존재해야 합니다. 실제 members: $members")
+            members.shouldNotBeNull().shouldContain(seatId.toString())
         }
 
         @Test
@@ -258,15 +258,6 @@ class HoldSeatsIntegrationTest {
         fun returns400WhenFiveSeatsRequested() {
             seedQueueToken(validToken)
             val fiveSeats = (1..5).map { UUID.randomUUID() }
-            // 5개 seats에 대한 details mock
-            every { eventServiceClient.getSeatDetails(scheduleId, any()) } returns
-                EventServiceClient.SeatDetailsResponse(
-                    scheduleId = scheduleId,
-                    eventId = eventId,
-                    seats = fiveSeats.map { id ->
-                        EventServiceClient.SeatDetailsResponse.SeatDetail(id, "X-$id", "VIP", BigDecimal("150000"))
-                    }
-                )
 
             mockMvc.perform(
                 post("/reservations/hold")

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsIntegrationTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsIntegrationTest.kt
@@ -8,6 +8,7 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -169,9 +170,8 @@ class HoldSeatsIntegrationTest {
             ).andExpect(status().isCreated)
 
             val members = stringRedisTemplate.opsForSet().members("hold_seats:$scheduleId")
-            assert(members?.contains(seatId.toString()) == true) {
-                "hold_seats SET에 $seatId 가 존재해야 합니다. 실제 members: $members"
-            }
+            assertTrue(members?.contains(seatId.toString()) == true,
+                "hold_seats SET에 $seatId 가 존재해야 합니다. 실제 members: $members")
         }
 
         @Test

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ReservationServiceTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ReservationServiceTest.kt
@@ -1,0 +1,265 @@
+package com.ticketqueue.reservation.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.reservation.client.EventServiceClient
+import com.ticketqueue.reservation.dto.ReservationDto.HoldRequest
+import com.ticketqueue.reservation.entity.Reservation
+import com.ticketqueue.reservation.entity.ReservationSeat
+import com.ticketqueue.reservation.entity.ReservationStatus
+import com.ticketqueue.reservation.exception.ReservationException
+import com.ticketqueue.reservation.repository.ReservationRepository
+import com.ticketqueue.reservation.repository.ReservationSeatRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.redisson.api.RKeys
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
+import org.springframework.data.redis.core.SetOperations
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import org.springframework.transaction.TransactionStatus
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+@DisplayName("ReservationService 단위 테스트")
+class ReservationServiceTest {
+
+    private lateinit var stringRedisTemplate: StringRedisTemplate
+    private lateinit var valueOps: ValueOperations<String, String>
+    private lateinit var setOps: SetOperations<String, String>
+    private lateinit var redissonClient: RedissonClient
+    private lateinit var userLock: RLock
+    private lateinit var seatLock: RLock
+    private lateinit var multiLock: RLock
+    private lateinit var eventServiceClient: EventServiceClient
+    private lateinit var reservationRepository: ReservationRepository
+    private lateinit var reservationSeatRepository: ReservationSeatRepository
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var transactionTemplate: TransactionTemplate
+    private lateinit var reservationService: ReservationService
+
+    private val userId = UUID.randomUUID()
+    private val scheduleId = UUID.randomUUID()
+    private val eventId = UUID.randomUUID()
+    private val seatId1 = UUID.randomUUID()
+    private val validToken = "valid-queue-token"
+    private val tokenJson get() = """{"userId":"$userId","scheduleId":"$scheduleId","issuedAt":"1234567890"}"""
+
+    @BeforeEach
+    fun setUp() {
+        stringRedisTemplate = mockk()
+        valueOps = mockk()
+        setOps = mockk()
+        redissonClient = mockk()
+        userLock = mockk()
+        seatLock = mockk()
+        multiLock = mockk()
+        eventServiceClient = mockk()
+        reservationRepository = mockk()
+        reservationSeatRepository = mockk()
+        objectMapper = ObjectMapper()
+        transactionTemplate = mockk()
+
+        every { stringRedisTemplate.opsForValue() } returns valueOps
+        every { stringRedisTemplate.opsForSet() } returns setOps
+
+        reservationService = ReservationService(
+            stringRedisTemplate,
+            redissonClient,
+            eventServiceClient,
+            reservationRepository,
+            reservationSeatRepository,
+            objectMapper,
+            transactionTemplate
+        )
+    }
+
+    @Nested
+    @DisplayName("QueueToken 검증")
+    inner class QueueTokenValidation {
+        @Test
+        @DisplayName("Redis에 토큰이 없으면 QUEUE_TOKEN_EXPIRED 예외를 던진다")
+        fun throwsWhenTokenNotFound() {
+            every { valueOps.get("queue:token:$validToken") } returns null
+            val ex = assertThrows<ReservationException> {
+                reservationService.holdSeats(userId, holdRequest(), validToken)
+            }
+            ex.errorCode shouldBe ErrorCode.QUEUE_TOKEN_EXPIRED
+        }
+    }
+
+    @Nested
+    @DisplayName("최대 좌석 수 검증")
+    inner class SeatCountValidation {
+        @Test
+        @DisplayName("기존 PENDING 예매 좌석 + 신규 요청이 4개를 초과하면 MAX_SEATS_EXCEEDED 예외를 던진다")
+        fun throwsWhenExceedsMaxSeats() {
+            val seatId2 = UUID.randomUUID()
+            setUpTokenValid()
+            setUpLockObjects(listOf(seatId1, seatId2))
+            setUpUserLockSuccess()
+            setUpMultiLockSuccess()
+            val existingReservationId = UUID.randomUUID()
+            val existingReservation = mockk<Reservation> { every { id } returns existingReservationId }
+            every {
+                reservationRepository.findByUserIdAndScheduleIdAndStatus(userId, scheduleId, ReservationStatus.PENDING)
+            } returns listOf(existingReservation)
+            every { reservationSeatRepository.countByReservationIdIn(listOf(existingReservationId)) } returns 3
+
+            val ex = assertThrows<ReservationException> {
+                reservationService.holdSeats(userId, HoldRequest(scheduleId, listOf(seatId1, seatId2)), validToken)
+            }
+            ex.errorCode shouldBe ErrorCode.MAX_SEATS_EXCEEDED
+            verify { multiLock.unlock() }
+            verify { userLock.unlock() }
+        }
+    }
+
+    @Nested
+    @DisplayName("분산 락 및 좌석 상태 검증")
+    inner class LockAndSeatValidation {
+        @Test
+        @DisplayName("사용자 락 획득 실패 시 RATE_LIMIT_EXCEEDED 예외를 던진다")
+        fun throwsWhenUserLockFails() {
+            setUpTokenValid()
+            setUpLockObjects()
+            every { userLock.tryLock(0, any(), any()) } returns false
+
+            val ex = assertThrows<ReservationException> {
+                reservationService.holdSeats(userId, holdRequest(), validToken)
+            }
+            ex.errorCode shouldBe ErrorCode.RATE_LIMIT_EXCEEDED
+        }
+
+        @Test
+        @DisplayName("MultiLock 획득 실패 시 SEAT_ALREADY_HELD 예외를 던지고 사용자 락을 해제한다")
+        fun throwsWhenMultiLockFails() {
+            setUpTokenValid()
+            setUpLockObjects()
+            setUpUserLockSuccess()
+            every { multiLock.tryLock(0, any(), any()) } returns false
+
+            val ex = assertThrows<ReservationException> {
+                reservationService.holdSeats(userId, holdRequest(), validToken)
+            }
+            ex.errorCode shouldBe ErrorCode.SEAT_ALREADY_HELD
+            verify { userLock.unlock() }
+        }
+    }
+
+    @Nested
+    @DisplayName("좌석 선점 성공")
+    inner class HoldSuccess {
+        @Test
+        @DisplayName("정상 선점 시 HoldResponse를 반환하고 모든 락을 해제한다")
+        fun returnsHoldResponse() {
+            setUpTokenValid()
+            setUpLockObjects()
+            setUpUserLockSuccess()
+            setUpMultiLockSuccess()
+            setUpNoPendingReservation()
+            every { setOps.isMember(any(), any()) } returns false
+            setUpSoldAndDetails()
+            setUpSaveSuccess()
+
+            val response = reservationService.holdSeats(userId, holdRequest(), validToken)
+
+            response.status shouldBe ReservationStatus.PENDING
+            verify { multiLock.unlock() }
+            verify { userLock.unlock() }
+        }
+    }
+
+    private fun holdRequest() = HoldRequest(scheduleId, listOf(seatId1))
+
+    private fun setUpTokenValid() {
+        every { valueOps.get("queue:token:$validToken") } returns tokenJson
+    }
+
+    /**
+     * getLock 이 키에 따라 다른 mock 객체를 반환하도록 정확한 키로 등록한다.
+     * - "user:hold:lock:..." → userLock
+     * - "seat:hold:..."      → seatLock
+     * - getMultiLock(...)    → multiLock
+     *
+     * seatIds 를 명시하면 해당 좌석 키들을 모두 등록한다 (기본값: [seatId1]).
+     */
+    private fun setUpLockObjects(seatIds: List<UUID> = listOf(seatId1)) {
+        every { redissonClient.getLock("user:hold:lock:$userId:$scheduleId") } returns userLock
+        seatIds.forEach { id ->
+            every { redissonClient.getLock("seat:hold:$scheduleId:$id") } returns seatLock
+        }
+        every { redissonClient.getMultiLock(*varargAny { true }) } returns multiLock
+    }
+
+    private fun setUpUserLockSuccess() {
+        every { userLock.tryLock(0, any(), TimeUnit.SECONDS) } returns true
+        every { userLock.isHeldByCurrentThread } returns true
+        justRun { userLock.unlock() }
+        every { userLock.name } returns "userLock"
+    }
+
+    private fun setUpMultiLockSuccess() {
+        every { multiLock.tryLock(0, any(), TimeUnit.SECONDS) } returns true
+        every { multiLock.isHeldByCurrentThread } returns true
+        justRun { multiLock.unlock() }
+        every { multiLock.name } returns "multiLock"
+    }
+
+    private fun setUpNoPendingReservation() {
+        every {
+            reservationRepository.findByUserIdAndScheduleIdAndStatus(userId, scheduleId, ReservationStatus.PENDING)
+        } returns emptyList()
+    }
+
+    private fun setUpSoldAndDetails() {
+        every { eventServiceClient.getSoldSeats(scheduleId) } returns
+            EventServiceClient.SoldSeatsResponse(scheduleId, emptyList())
+        every { eventServiceClient.getSeatDetails(scheduleId, any()) } returns
+            EventServiceClient.SeatDetailsResponse(
+                scheduleId = scheduleId,
+                eventId = eventId,
+                seats = listOf(
+                    EventServiceClient.SeatDetailsResponse.SeatDetail(
+                        seatId = seatId1,
+                        seatNumber = "A-1",
+                        grade = "VIP",
+                        price = BigDecimal("300000")
+                    )
+                )
+            )
+    }
+
+    private fun setUpSaveSuccess() {
+        val savedReservation = Reservation(
+            id = UUID.randomUUID(),
+            userId = userId,
+            scheduleId = scheduleId,
+            eventId = eventId,
+            totalAmount = BigDecimal("300000"),
+            holdExpiresAt = LocalDateTime.now().plusMinutes(5)
+        )
+        every { transactionTemplate.execute<Reservation>(any()) } answers {
+            firstArg<TransactionCallback<Reservation>>().doInTransaction(mockk<TransactionStatus>(relaxed = true))
+        }
+        every { reservationRepository.save(any()) } returns savedReservation
+        every { reservationSeatRepository.saveAll(any<List<ReservationSeat>>()) } returns emptyList()
+        every { setOps.add(any(), *anyVararg<String>()) } returns 1L
+        val rKeys = mockk<RKeys>()
+        every { redissonClient.keys } returns rKeys
+        every { rKeys.expire(any<String>(), any<Long>(), any()) } returns true
+    }
+}

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ReservationServiceTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ReservationServiceTest.kt
@@ -1,6 +1,7 @@
 package com.ticketqueue.reservation.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.reservation.client.EventServiceClient
 import com.ticketqueue.reservation.dto.ReservationDto.HoldRequest
@@ -20,7 +21,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.redisson.api.RKeys
 import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
 import org.springframework.data.redis.core.SetOperations
@@ -28,6 +28,7 @@ import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.data.redis.core.ValueOperations
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -70,7 +71,7 @@ class ReservationServiceTest {
         eventServiceClient = mockk()
         reservationRepository = mockk()
         reservationSeatRepository = mockk()
-        objectMapper = ObjectMapper()
+        objectMapper = jacksonObjectMapper()
         transactionTemplate = mockk()
 
         every { stringRedisTemplate.opsForValue() } returns valueOps
@@ -132,7 +133,7 @@ class ReservationServiceTest {
     @DisplayName("분산 락 및 좌석 상태 검증")
     inner class LockAndSeatValidation {
         @Test
-        @DisplayName("사용자 락 획득 실패 시 RATE_LIMIT_EXCEEDED 예외를 던진다")
+        @DisplayName("사용자 락 획득 실패 시 RESERVATION_IN_PROGRESS 예외를 던진다")
         fun throwsWhenUserLockFails() {
             setUpTokenValid()
             setUpLockObjects()
@@ -141,7 +142,7 @@ class ReservationServiceTest {
             val ex = assertThrows<ReservationException> {
                 reservationService.holdSeats(userId, holdRequest(), validToken)
             }
-            ex.errorCode shouldBe ErrorCode.RATE_LIMIT_EXCEEDED
+            ex.errorCode shouldBe ErrorCode.RESERVATION_IN_PROGRESS
         }
 
         @Test
@@ -226,8 +227,6 @@ class ReservationServiceTest {
     }
 
     private fun setUpSoldAndDetails() {
-        every { eventServiceClient.getSoldSeats(scheduleId) } returns
-            EventServiceClient.SoldSeatsResponse(scheduleId, emptyList())
         every { eventServiceClient.getSeatDetails(scheduleId, any()) } returns
             EventServiceClient.SeatDetailsResponse(
                 scheduleId = scheduleId,
@@ -252,14 +251,17 @@ class ReservationServiceTest {
             totalAmount = BigDecimal("300000"),
             holdExpiresAt = LocalDateTime.now().plusMinutes(5)
         )
+        // afterCommit 콜백이 TransactionSynchronizationManager를 사용하므로 동기화 컨텍스트를 활성화한다.
+        // 단위 테스트에서는 afterCommit 콜백 실행 없이 컨텍스트만 초기화하여 예외를 방지한다.
         every { transactionTemplate.execute<Reservation>(any()) } answers {
-            firstArg<TransactionCallback<Reservation>>().doInTransaction(mockk<TransactionStatus>(relaxed = true))
+            TransactionSynchronizationManager.initSynchronization()
+            try {
+                firstArg<TransactionCallback<Reservation>>().doInTransaction(mockk<TransactionStatus>(relaxed = true))
+            } finally {
+                TransactionSynchronizationManager.clearSynchronization()
+            }
         }
         every { reservationRepository.save(any()) } returns savedReservation
         every { reservationSeatRepository.saveAll(any<List<ReservationSeat>>()) } returns emptyList()
-        every { setOps.add(any(), *anyVararg<String>()) } returns 1L
-        val rKeys = mockk<RKeys>()
-        every { redissonClient.keys } returns rKeys
-        every { rKeys.expire(any<String>(), any<Long>(), any()) } returns true
     }
 }

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ReservationServiceTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ReservationServiceTest.kt
@@ -26,6 +26,7 @@ import org.redisson.api.RedissonClient
 import org.springframework.data.redis.core.SetOperations
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.data.redis.core.ValueOperations
+import org.springframework.data.redis.core.script.RedisScript
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.TransactionCallback
 import org.springframework.transaction.support.TransactionSynchronizationManager
@@ -181,6 +182,39 @@ class ReservationServiceTest {
             response.status shouldBe ReservationStatus.PENDING
             verify { multiLock.unlock() }
             verify { userLock.unlock() }
+        }
+
+        @Test
+        @DisplayName("트랜잭션 롤백 시 Redis hold_seats SET을 갱신하지 않는다")
+        fun doesNotUpdateRedisOnRollback() {
+            setUpTokenValid()
+            setUpLockObjects()
+            setUpUserLockSuccess()
+            setUpMultiLockSuccess()
+            setUpNoPendingReservation()
+            every { setOps.isMember(any(), any()) } returns false
+            setUpSoldAndDetails()
+
+            // 트랜잭션 콜백 실행 중 예외 발생 — afterCommit 호출 없이 롤백
+            every { transactionTemplate.execute<Reservation>(any()) } answers {
+                TransactionSynchronizationManager.initSynchronization()
+                try {
+                    firstArg<TransactionCallback<Reservation>>().doInTransaction(
+                        mockk<TransactionStatus>(relaxed = true)
+                    )
+                    throw RuntimeException("forced rollback")
+                } finally {
+                    TransactionSynchronizationManager.clearSynchronization()
+                }
+            }
+            every { reservationRepository.save(any()) } returns mockk(relaxed = true)
+            every { reservationSeatRepository.saveAll(any<List<ReservationSeat>>()) } returns emptyList()
+
+            assertThrows<RuntimeException> {
+                reservationService.holdSeats(userId, holdRequest(), validToken)
+            }
+
+            verify(exactly = 0) { stringRedisTemplate.execute(any<RedisScript<Long>>(), any<List<String>>(), *anyVararg()) }
         }
     }
 

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ReservationServiceTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ReservationServiceTest.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
+import org.springframework.data.redis.core.RedisCallback
 import org.springframework.data.redis.core.SetOperations
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.data.redis.core.ValueOperations
@@ -173,7 +174,7 @@ class ReservationServiceTest {
             setUpUserLockSuccess()
             setUpMultiLockSuccess()
             setUpNoPendingReservation()
-            every { setOps.isMember(any(), any()) } returns false
+            every { stringRedisTemplate.execute(any<RedisCallback<*>>()) } returns listOf(false)
             setUpSoldAndDetails()
             setUpSaveSuccess()
 
@@ -182,6 +183,7 @@ class ReservationServiceTest {
             response.status shouldBe ReservationStatus.PENDING
             verify { multiLock.unlock() }
             verify { userLock.unlock() }
+            verify { stringRedisTemplate.execute(any<RedisScript<Long>>(), any<List<String>>(), *anyVararg()) }
         }
 
         @Test
@@ -192,7 +194,7 @@ class ReservationServiceTest {
             setUpUserLockSuccess()
             setUpMultiLockSuccess()
             setUpNoPendingReservation()
-            every { setOps.isMember(any(), any()) } returns false
+            every { stringRedisTemplate.execute(any<RedisCallback<*>>()) } returns listOf(false)
             setUpSoldAndDetails()
 
             // 트랜잭션 콜백 실행 중 예외 발생 — afterCommit 호출 없이 롤백
@@ -285,12 +287,13 @@ class ReservationServiceTest {
             totalAmount = BigDecimal("300000"),
             holdExpiresAt = LocalDateTime.now().plusMinutes(5)
         )
-        // afterCommit 콜백이 TransactionSynchronizationManager를 사용하므로 동기화 컨텍스트를 활성화한다.
-        // 단위 테스트에서는 afterCommit 콜백 실행 없이 컨텍스트만 초기화하여 예외를 방지한다.
+        every { stringRedisTemplate.execute(any<RedisScript<Long>>(), any<List<String>>(), *anyVararg()) } returns 1L
         every { transactionTemplate.execute<Reservation>(any()) } answers {
             TransactionSynchronizationManager.initSynchronization()
             try {
-                firstArg<TransactionCallback<Reservation>>().doInTransaction(mockk<TransactionStatus>(relaxed = true))
+                val result = firstArg<TransactionCallback<Reservation>>().doInTransaction(mockk<TransactionStatus>(relaxed = true))
+                TransactionSynchronizationManager.getSynchronizations().forEach { it.afterCommit() }
+                result
             } finally {
                 TransactionSynchronizationManager.clearSynchronization()
             }

--- a/backend/reservation-service/src/test/resources/application-test.yml
+++ b/backend/reservation-service/src/test/resources/application-test.yml
@@ -1,0 +1,38 @@
+spring:
+  config:
+    import: ""   # aws-secretsmanager import 비활성화
+  cloud:
+    aws:
+      secretsmanager:
+        enabled: false
+  # Kafka auto-configuration 제외 (테스트에서 Kafka 브로커 불필요)
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        default_schema: reservation_service
+
+feign:
+  client:
+    config:
+      event-service:
+        url: http://localhost:8082
+
+internal:
+  api:
+    key: test-internal-api-key
+
+# Outbox 폴러 및 정리 배치 비활성화
+outbox:
+  poller:
+    enabled: false
+  cleanup:
+    enabled: false
+
+processed-event:
+  cleanup:
+    enabled: false

--- a/backend/reservation-service/src/test/resources/db/init.sql
+++ b/backend/reservation-service/src/test/resources/db/init.sql
@@ -1,0 +1,74 @@
+-- 테스트용 스키마 및 테이블 초기화 (TestContainers PostgreSQL)
+
+-- Schemas
+CREATE SCHEMA IF NOT EXISTS common;
+CREATE SCHEMA IF NOT EXISTS reservation_service;
+
+-- update_timestamp 함수 (trigger용)
+CREATE OR REPLACE FUNCTION reservation_service.update_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- common.outbox_events
+CREATE TABLE IF NOT EXISTS common.outbox_events (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    aggregate_type VARCHAR(50)  NOT NULL,
+    aggregate_id   UUID         NOT NULL,
+    event_type     VARCHAR(100) NOT NULL,
+    payload        JSONB        NOT NULL,
+    created_at     TIMESTAMP    NOT NULL DEFAULT now(),
+    published      BOOLEAN               DEFAULT false,
+    published_at   TIMESTAMP,
+    retry_count    INT                   DEFAULT 0,
+    last_error     TEXT,
+    CONSTRAINT chk_outbox_retry CHECK (retry_count >= 0 AND retry_count <= 10)
+);
+
+-- common.processed_events
+CREATE TABLE IF NOT EXISTS common.processed_events (
+    event_id         UUID         NOT NULL,
+    consumer_service VARCHAR(50)  NOT NULL,
+    aggregate_id     UUID         NOT NULL,
+    event_type       VARCHAR(100) NOT NULL,
+    processed_at     TIMESTAMP    NOT NULL DEFAULT now(),
+    PRIMARY KEY (event_id, consumer_service)
+);
+
+-- reservation_service.reservations
+CREATE TABLE IF NOT EXISTS reservation_service.reservations (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id        UUID         NOT NULL,
+    schedule_id    UUID         NOT NULL,
+    event_id       UUID         NOT NULL,
+    status         VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    total_amount   DECIMAL(10,0) NOT NULL,
+    hold_expires_at TIMESTAMP   NOT NULL,
+    ticket_number  VARCHAR(50)  UNIQUE,
+    payment_id     UUID,
+    created_at     TIMESTAMP    NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMP    NOT NULL DEFAULT now(),
+    CONSTRAINT chk_reservations_status CHECK (status IN ('PENDING','CONFIRMED','CANCELLED')),
+    CONSTRAINT chk_reservations_amount CHECK (total_amount >= 0)
+);
+
+CREATE OR REPLACE TRIGGER trg_reservations_updated_at
+BEFORE UPDATE ON reservation_service.reservations
+FOR EACH ROW EXECUTE FUNCTION reservation_service.update_timestamp();
+
+-- reservation_service.reservation_seats
+CREATE TABLE IF NOT EXISTS reservation_service.reservation_seats (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    reservation_id UUID         NOT NULL REFERENCES reservation_service.reservations(id) ON DELETE CASCADE,
+    seat_id        UUID         NOT NULL,
+    seat_number    VARCHAR(20)  NOT NULL,
+    grade          VARCHAR(10)  NOT NULL,
+    price          DECIMAL(10,0) NOT NULL,
+    created_at     TIMESTAMP    NOT NULL DEFAULT now(),
+    CONSTRAINT chk_reservation_seats_grade CHECK (grade IN ('VIP','S','A','B')),
+    CONSTRAINT chk_reservation_seats_price CHECK (price >= 0),
+    CONSTRAINT uk_reservation_seats UNIQUE (reservation_id, seat_id)
+);

--- a/backend/reservation-service/src/test/resources/logback-test.xml
+++ b/backend/reservation-service/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+    <logger name="com.ticketqueue" level="DEBUG" additivity="false">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+</configuration>

--- a/docs/architecture/04_data.md
+++ b/docs/architecture/04_data.md
@@ -1165,40 +1165,19 @@ EXISTS queue:active:user-abc
 
 #### 1.3.4 좌석 선점 (Reservation Service)
 
-**분산 락 - Redisson**
+**분산 락 전략 - Redisson MultiLock**
 
-**Key:** `seat:hold:{scheduleId}:{seatId}`
-**Value:** `userId`
-**TTL:** 5분
+대규모 동시 요청 시 발생할 수 있는 데이터 정합성 문제와 데드락을 방지하기 위해 복합 락 전략을 사용합니다.
 
-<details>
-<summary>java code</summary>
+1. **사용자 락 (`user:hold:lock:{userId}:{scheduleId}`)**: 
+   - **목적**: 동일 사용자가 여러 요청을 동시에 보내 최대 선점 수량(4매) 제한을 우회하는 TOCTOU(Time-of-Check Time-of-Use) 경쟁 조건을 방지합니다.
+   - **정책**: `waitTime = 0`으로 설정하여 중복 클릭이나 비정상적인 다중 요청 발생 시 즉시 실패(`RATE_LIMIT_EXCEEDED`) 처리합니다.
+2. **좌석 락 (`seat:hold:{scheduleId}:{seatId}`)**: 
+   - **목적**: 특정 좌석에 대한 중복 선점을 차단합니다.
+   - **정책**: 요청된 좌석 ID들을 `UUID` 순으로 **정렬**한 후 `MultiLock`으로 묶어 원자적으로 획득함으로써 데드락을 원천 차단합니다.
 
-```java
-// Redisson 분산 락
-RLock lock = redissonClient.getLock("seat:hold:schedule-001:seat-456");
-
-boolean acquired = lock.tryLock(15, 300, TimeUnit.SECONDS);  // waitTime: 15초, leaseTime: 300초
-
-if (acquired) {
-    try {
-        redisTemplate.opsForSet().add("hold_seats:schedule-001", "seat-456");
-
-        // 좌석 선점 로직
-        // 예매 정보 DB 저장 (PENDING)
-    } finally {
-        lock.unlock();
-        redisTemplate.opsForSet().remove("hold_seats:schedule-001", "seat-456");
-    }
-} else {
-    throw new SeatAlreadyHoldException();
-}
-
-// HOLD 상태 조회 (KEYS 대신 SET 사용)
-Set<String> holdSeatIds = redisTemplate.opsForSet().members("hold_seats:schedule-001");
-```
-</details>
-
+**락 획득/해제 흐름:**
+- 사용자 락 시도 → 좌석 MultiLock 시도 → 비즈니스 로직(수량 검증, DB 저장) → `finally` 블록에서 모든 락 안전 해제.
 
 **수동 락 관리 (대안):**
 ```redis

--- a/docs/architecture/04_data.md
+++ b/docs/architecture/04_data.md
@@ -1171,7 +1171,7 @@ EXISTS queue:active:user-abc
 
 1. **사용자 락 (`user:hold:lock:{userId}:{scheduleId}`)**: 
    - **목적**: 동일 사용자가 여러 요청을 동시에 보내 최대 선점 수량(4매) 제한을 우회하는 TOCTOU(Time-of-Check Time-of-Use) 경쟁 조건을 방지합니다.
-   - **정책**: `waitTime = 0`으로 설정하여 중복 클릭이나 비정상적인 다중 요청 발생 시 즉시 실패(`RATE_LIMIT_EXCEEDED`) 처리합니다.
+   - **정책**: `waitTime = 0`으로 설정하여 중복 클릭이나 비정상적인 다중 요청 발생 시 즉시 실패(`RESERVATION_IN_PROGRESS`) 처리합니다.
 2. **좌석 락 (`seat:hold:{scheduleId}:{seatId}`)**: 
    - **목적**: 특정 좌석에 대한 중복 선점을 차단합니다.
    - **정책**: 요청된 좌석 ID들을 `UUID` 순으로 **정렬**한 후 `MultiLock`으로 묶어 원자적으로 획득함으로써 데드락을 원천 차단합니다.

--- a/docs/contributions/임현정.md
+++ b/docs/contributions/임현정.md
@@ -14,8 +14,10 @@
 ### Reservation Service
 - **역할**: 좌석 선점, 예매 관리, Redisson 분산 락, Outbox Pattern
 - **핵심 구현**:
-  - Redisson 분산 락 기반 좌석 선점 (Pub/Sub 방식)
-  - `hold_seats:{scheduleId}` SET 관리 (HOLD 좌석 목록)
+  - **Redisson MultiLock 기반 원자적 선점**: 사용자별 요청 락과 다중 좌석 락을 통합 관리하여 선점 로직 보호.
+  - **데드락(Deadlock) 방지**: 다중 좌석 락 획득 시 좌석 ID를 정렬하여 순환 대기 조건 제거.
+  - **TOCTOU 경쟁 조건 해결**: 사용자-회차별 분산 락을 통해 최대 예매 수량 검증 로직의 원자성 보장.
+  - `hold_seats:{scheduleId}` SET 관리 (HOLD 좌석 목록 실시간 오버레이)
   - Transactional Outbox Pattern (`ReservationCancelled` 이벤트 발행)
 
 ### Payment Service


### PR DESCRIPTION
## Summary
- 좌석 선점(HOLD) API 전체 구현 (REQ-RSV-001, REQ-RSV-005, REQ-RSV-008)
- Redisson 분산 락, Redis hold_seats SET, Event Service 내부 API 연동, 통합/동시성 테스트 포함

## Changes

### Reservation Service
- `ReservationController` — `POST /api/reservations/hold` 엔드포인트 추가
- `ReservationService` — 선점 프로세스 구현
  - QueueToken Redis 직접 검증 (`queue:token:{token}`)
  - Redisson MultiLock (`user:hold:lock:{userId}:{scheduleId}` + `seat:hold:{scheduleId}:{seatId}`)
  - PENDING 예매 좌석 수 합산으로 최대 4장 제한 (TOCTOU 방지)
  - Redis `hold_seats` SET 중복 확인
  - `afterCommit` 콜백으로 Redis 업데이트 분리 — DB 롤백 시 오염 방지
  - Lua 스크립트로 `SADD` + `EXPIRE` 단일 RTT 원자적 처리
  - `QueueTokenPayload.issuedAt` `String?` 타입으로 선언 (Lua `cjson.encode` 직렬화 형식 반영)
  - `holdExpiresAt` UTC 기준 통일
- `EventServiceClient` — `getSeatDetails` 내부 API Feign 클라이언트 추가
- `ReservationDto` — `HoldRequest` / `HoldResponse` 추가
- `HoldSeatsIntegrationTest` — TestContainers 기반 통합 테스트
- `HoldSeatsConcurrencyTest` — 동시 선점 시나리오 동시성 테스트
- `ReservationServiceTest` — 단위 테스트

### Event Service
- `InternalSeatController` — `GET /internal/seats/details` 엔드포인트 추가
- `SeatService.getSeatDetails()` — 스냅샷 조회 + `AVAILABLE` 상태 검증 (`HOLD`/`SOLD` 조기 차단)
- `SeatDto.SeatDetailsResponse` — 응답 DTO 추가
- `SeatRepository` — `findByEventScheduleIdAndIdIn` 쿼리 메서드 추가

### Common
- `ErrorCode.RESERVATION_IN_PROGRESS` 추가 (user:hold:lock 획득 실패 시 `409 Conflict`)

### Docs
- `docs/architecture/04_data.md` — 좌석 선점 Redis 키 패턴 및 분산 락 전략 최신화

## Test plan
- [x] `ReservationServiceTest` 단위 테스트 전체 통과
- [x] `HoldSeatsIntegrationTest` — 인프라(PostgreSQL, Valkey) 기동 후 통합 테스트 실행
- [x] `HoldSeatsConcurrencyTest` — 동시 선점 시나리오 검증

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added POST /reservations/hold with queue-token auth, request validation (1–4 seats) and detailed hold response including expiration.
  * New internal seat-details support to reliably fetch seat metadata for holds.

* **Bug Fixes**
  * Stronger concurrency controls: immediate user-lock conflicts return conflict; prevents duplicate/over-hold per user/seat.

* **Tests**
  * Extensive unit and integration tests for concurrency, token validation, validation errors, and transactional behavior.

* **Documentation**
  * Updated architecture and contribution docs describing locking and hold management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->