### PR TITLE
feat: [Reservation] 좌석 상태 조회 API 구현 (#49)

### DIFF
--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/SeatDto.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/SeatDto.kt
@@ -50,7 +50,7 @@ class SeatDto {
     data class SoldSeatsResponse(
         val scheduleId: UUID,
         val soldSeatIds: List<UUID>,
-        val totalSeats: Int
+        val totalSeats: Long
     )
 
     /** 내부 API 응답 - Reservation Service가 좌석 선점 시 스냅샷 저장용으로 사용 */

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/SeatDto.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/SeatDto.kt
@@ -49,7 +49,8 @@ class SeatDto {
     /** 내부 API 응답 - Reservation Service가 SOLD 좌석 조회 시 사용 */
     data class SoldSeatsResponse(
         val scheduleId: UUID,
-        val soldSeatIds: List<UUID>
+        val soldSeatIds: List<UUID>,
+        val totalSeats: Int
     )
 
     /** 내부 API 응답 - Reservation Service가 좌석 선점 시 스냅샷 저장용으로 사용 */

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepository.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/SeatRepository.kt
@@ -10,4 +10,5 @@ import java.util.UUID
 interface SeatRepository : JpaRepository<Seat, UUID>, SeatRepositoryCustom {
     fun existsByEventScheduleIdAndStatus(eventScheduleId: UUID, status: SeatStatus): Boolean
     fun findByEventScheduleIdAndIdIn(eventScheduleId: UUID, ids: List<UUID>): List<Seat>
+    fun countByEventScheduleId(eventScheduleId: UUID): Long
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
@@ -122,7 +122,8 @@ class SeatService(
         }
 
         val soldSeatIds = seatRepository.findSoldSeatIdsByScheduleId(scheduleId)
-        return SeatDto.SoldSeatsResponse(scheduleId = scheduleId, soldSeatIds = soldSeatIds)
+        val totalSeats = seatRepository.countByEventScheduleId(scheduleId)
+        return SeatDto.SoldSeatsResponse(scheduleId = scheduleId, soldSeatIds = soldSeatIds, totalSeats = totalSeats.toInt())
     }
 
     /**

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/SeatService.kt
@@ -123,7 +123,7 @@ class SeatService(
 
         val soldSeatIds = seatRepository.findSoldSeatIdsByScheduleId(scheduleId)
         val totalSeats = seatRepository.countByEventScheduleId(scheduleId)
-        return SeatDto.SoldSeatsResponse(scheduleId = scheduleId, soldSeatIds = soldSeatIds, totalSeats = totalSeats.toInt())
+        return SeatDto.SoldSeatsResponse(scheduleId = scheduleId, soldSeatIds = soldSeatIds, totalSeats = totalSeats)
     }
 
     /**

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalSeatControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalSeatControllerTest.kt
@@ -53,7 +53,7 @@ class InternalSeatControllerTest {
             val response = SeatDto.SoldSeatsResponse(
                 scheduleId = scheduleId,
                 soldSeatIds = listOf(soldId),
-                totalSeats = 1
+                totalSeats = 1L
             )
             every { seatService.getSoldSeatIds(scheduleId) } returns response
 
@@ -61,6 +61,7 @@ class InternalSeatControllerTest {
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.scheduleId").value(scheduleId.toString()))
                 .andExpect(jsonPath("$.soldSeatIds[0]").value(soldId.toString()))
+                .andExpect(jsonPath("$.totalSeats").value(1L))
         }
 
         @Test
@@ -69,7 +70,7 @@ class InternalSeatControllerTest {
             val response = SeatDto.SoldSeatsResponse(
                 scheduleId = scheduleId,
                 soldSeatIds = emptyList(),
-                totalSeats = 0
+                totalSeats = 0L
             )
             every { seatService.getSoldSeatIds(scheduleId) } returns response
 
@@ -77,6 +78,7 @@ class InternalSeatControllerTest {
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.soldSeatIds").isArray)
                 .andExpect(jsonPath("$.soldSeatIds").isEmpty)
+                .andExpect(jsonPath("$.totalSeats").value(0L))
         }
 
         @Test

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalSeatControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalSeatControllerTest.kt
@@ -52,7 +52,8 @@ class InternalSeatControllerTest {
             val soldId = UUID.randomUUID()
             val response = SeatDto.SoldSeatsResponse(
                 scheduleId = scheduleId,
-                soldSeatIds = listOf(soldId)
+                soldSeatIds = listOf(soldId),
+                totalSeats = 1
             )
             every { seatService.getSoldSeatIds(scheduleId) } returns response
 
@@ -67,7 +68,8 @@ class InternalSeatControllerTest {
         fun noSoldSeats() {
             val response = SeatDto.SoldSeatsResponse(
                 scheduleId = scheduleId,
-                soldSeatIds = emptyList()
+                soldSeatIds = emptyList(),
+                totalSeats = 0
             )
             every { seatService.getSoldSeatIds(scheduleId) } returns response
 

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
@@ -313,13 +313,13 @@ class SeatServiceTest {
             val soldIds = listOf(UUID.randomUUID(), UUID.randomUUID())
             every { eventScheduleRepository.existsById(scheduleId) } returns true
             every { seatRepository.findSoldSeatIdsByScheduleId(scheduleId) } returns soldIds
-            every { seatRepository.countByEventScheduleId(scheduleId) } returns soldIds.size.toLong()
+            every { seatRepository.countByEventScheduleId(scheduleId) } returns (soldIds.size + 3).toLong()
 
             val response = seatService.getSoldSeatIds(scheduleId)
 
             assertEquals(scheduleId, response.scheduleId)
             assertEquals(soldIds, response.soldSeatIds)
-            assertEquals(soldIds.size, response.totalSeats)
+            assertEquals((soldIds.size + 3).toLong(), response.totalSeats)
         }
 
         @Test
@@ -327,13 +327,13 @@ class SeatServiceTest {
         fun returnsEmptyListWhenNoSoldSeats() {
             every { eventScheduleRepository.existsById(scheduleId) } returns true
             every { seatRepository.findSoldSeatIdsByScheduleId(scheduleId) } returns emptyList()
-            every { seatRepository.countByEventScheduleId(scheduleId) } returns 0L
+            every { seatRepository.countByEventScheduleId(scheduleId) } returns 5L
 
             val response = seatService.getSoldSeatIds(scheduleId)
 
             assertEquals(scheduleId, response.scheduleId)
             assertTrue(response.soldSeatIds.isEmpty())
-            assertEquals(0, response.totalSeats)
+            assertEquals(5L, response.totalSeats)
         }
 
         @Test

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
@@ -313,11 +313,13 @@ class SeatServiceTest {
             val soldIds = listOf(UUID.randomUUID(), UUID.randomUUID())
             every { eventScheduleRepository.existsById(scheduleId) } returns true
             every { seatRepository.findSoldSeatIdsByScheduleId(scheduleId) } returns soldIds
+            every { seatRepository.countByEventScheduleId(scheduleId) } returns soldIds.size.toLong()
 
             val response = seatService.getSoldSeatIds(scheduleId)
 
             assertEquals(scheduleId, response.scheduleId)
             assertEquals(soldIds, response.soldSeatIds)
+            assertEquals(soldIds.size, response.totalSeats)
         }
 
         @Test
@@ -325,11 +327,13 @@ class SeatServiceTest {
         fun returnsEmptyListWhenNoSoldSeats() {
             every { eventScheduleRepository.existsById(scheduleId) } returns true
             every { seatRepository.findSoldSeatIdsByScheduleId(scheduleId) } returns emptyList()
+            every { seatRepository.countByEventScheduleId(scheduleId) } returns 0L
 
             val response = seatService.getSoldSeatIds(scheduleId)
 
             assertEquals(scheduleId, response.scheduleId)
             assertTrue(response.soldSeatIds.isEmpty())
+            assertEquals(0, response.totalSeats)
         }
 
         @Test

--- a/backend/reservation-service/build.gradle.kts
+++ b/backend/reservation-service/build.gradle.kts
@@ -19,6 +19,10 @@ dependencies {
     // Redis with Redisson for distributed locks
     implementation(libs.redisson.spring.boot.starter)
 
+    // Resilience4j (Circuit Breaker, Retry, TimeLimiter for EventServiceClient)
+    implementation(libs.spring.cloud.starter.circuitbreaker.resilience4j)
+    implementation(libs.bundles.resilience4j)
+
     // Test
     testImplementation(libs.bundles.test.base)
     testImplementation(libs.bundles.testcontainers)

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClient.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClient.kt
@@ -21,7 +21,8 @@ interface EventServiceClient {
 
     data class SoldSeatsResponse(
         val scheduleId: UUID,
-        val soldSeatIds: List<UUID>
+        val soldSeatIds: List<UUID>,
+        val totalSeats: Int
     )
 
     data class SeatDetailsResponse(

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClient.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClient.kt
@@ -7,7 +7,11 @@ import org.springframework.web.bind.annotation.RequestParam
 import java.math.BigDecimal
 import java.util.UUID
 
-@FeignClient(name = "event-service", url = "\${feign.client.config.event-service.url}")
+@FeignClient(
+    name = "event-service",
+    url = "\${feign.client.config.event-service.url}",
+    fallbackFactory = EventServiceClientFallbackFactory::class
+)
 interface EventServiceClient {
 
     @GetMapping("/internal/seats/status/{scheduleId}")
@@ -22,7 +26,7 @@ interface EventServiceClient {
     data class SoldSeatsResponse(
         val scheduleId: UUID,
         val soldSeatIds: List<UUID>,
-        val totalSeats: Int
+        val totalSeats: Long
     )
 
     data class SeatDetailsResponse(

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClientFallbackFactory.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClientFallbackFactory.kt
@@ -1,0 +1,21 @@
+package com.ticketqueue.reservation.client
+
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.reservation.exception.ReservationException
+import org.springframework.cloud.openfeign.FallbackFactory
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class EventServiceClientFallbackFactory : FallbackFactory<EventServiceClient> {
+    override fun create(cause: Throwable): EventServiceClient = object : EventServiceClient {
+        override fun getSoldSeats(scheduleId: UUID): EventServiceClient.SoldSeatsResponse =
+            throw ReservationException(ErrorCode.INTERNAL_SERVER_ERROR, "Event Service 응답 실패", cause)
+
+        override fun getSeatDetails(
+            scheduleId: UUID,
+            seatIds: List<UUID>
+        ): EventServiceClient.SeatDetailsResponse =
+            throw ReservationException(ErrorCode.INTERNAL_SERVER_ERROR, "Event Service 응답 실패", cause)
+    }
+}

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClientFallbackFactory.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClientFallbackFactory.kt
@@ -1,5 +1,6 @@
 package com.ticketqueue.reservation.client
 
+import com.ticketqueue.common.exception.BusinessException
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.reservation.exception.ReservationException
 import org.springframework.cloud.openfeign.FallbackFactory
@@ -10,12 +11,21 @@ import java.util.UUID
 class EventServiceClientFallbackFactory : FallbackFactory<EventServiceClient> {
     override fun create(cause: Throwable): EventServiceClient = object : EventServiceClient {
         override fun getSoldSeats(scheduleId: UUID): EventServiceClient.SoldSeatsResponse =
-            throw ReservationException(ErrorCode.INTERNAL_SERVER_ERROR, "Event Service 응답 실패", cause)
+            throw mapToReservationException(cause)
 
         override fun getSeatDetails(
             scheduleId: UUID,
             seatIds: List<UUID>
         ): EventServiceClient.SeatDetailsResponse =
-            throw ReservationException(ErrorCode.INTERNAL_SERVER_ERROR, "Event Service 응답 실패", cause)
+            throw mapToReservationException(cause)
+    }
+
+    private fun mapToReservationException(cause: Throwable): ReservationException = when {
+        cause is BusinessException && cause.errorCode == ErrorCode.RESOURCE_NOT_FOUND ->
+            ReservationException(ErrorCode.SCHEDULE_NOT_FOUND, cause.message ?: ErrorCode.SCHEDULE_NOT_FOUND.message, cause)
+        cause is BusinessException ->
+            ReservationException(cause.errorCode, cause.message ?: cause.errorCode.message, cause)
+        else ->
+            ReservationException(ErrorCode.INTERNAL_SERVER_ERROR, "Event Service 응답 실패", cause)
     }
 }

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/controller/ReservationController.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/controller/ReservationController.kt
@@ -26,7 +26,7 @@ class ReservationController(
     private val log = KotlinLogging.logger {}
 
     /**
-     * 좌석 선점 (REQ-RSV-001)
+     * 좌석 상태 조회 (REQ-RSV-003)
      *
      * Gateway가 JWT를 검증하고 X-User-Id 헤더로 userId를 주입한다.
      * Queue Token은 X-Queue-Token 헤더로 전달되며, Reservation Service에서 Redis 직접 조회로 검증한다.
@@ -40,6 +40,12 @@ class ReservationController(
         return reservationService.getSeatStatus(userId, scheduleId, queueToken)
     }
 
+    /**
+     * 좌석 선점 (REQ-RSV-001)
+     *
+     * Gateway가 JWT를 검증하고 X-User-Id 헤더로 userId를 주입한다.
+     * Queue Token은 X-Queue-Token 헤더로 전달되며, Reservation Service에서 Redis 직접 조회로 검증한다.
+     */
     @PostMapping("/hold")
     @ResponseStatus(HttpStatus.CREATED)
     fun holdSeats(

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/controller/ReservationController.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/controller/ReservationController.kt
@@ -2,10 +2,13 @@ package com.ticketqueue.reservation.controller
 
 import com.ticketqueue.reservation.dto.ReservationDto.HoldRequest
 import com.ticketqueue.reservation.dto.ReservationDto.HoldResponse
+import com.ticketqueue.reservation.dto.ReservationDto.SeatStatusResponse
 import com.ticketqueue.reservation.service.ReservationService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -28,6 +31,15 @@ class ReservationController(
      * Gateway가 JWT를 검증하고 X-User-Id 헤더로 userId를 주입한다.
      * Queue Token은 X-Queue-Token 헤더로 전달되며, Reservation Service에서 Redis 직접 조회로 검증한다.
      */
+    @GetMapping("/seats/{scheduleId}")
+    fun getSeatStatus(
+        @RequestHeader("X-User-Id") userId: UUID,
+        @RequestHeader("X-Queue-Token") queueToken: String,
+        @PathVariable scheduleId: UUID
+    ): SeatStatusResponse {
+        return reservationService.getSeatStatus(userId, scheduleId, queueToken)
+    }
+
     @PostMapping("/hold")
     @ResponseStatus(HttpStatus.CREATED)
     fun holdSeats(

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationDto.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationDto.kt
@@ -21,4 +21,13 @@ class ReservationDto {
         val totalAmount: BigDecimal,
         val holdExpiresAt: OffsetDateTime
     )
+
+    data class SeatStatusResponse(
+        val scheduleId: UUID,
+        val seats: SeatSummary,
+        val sold: List<UUID>,
+        val hold: List<UUID>
+    ) {
+        data class SeatSummary(val total: Int, val available: Int, val sold: Int, val hold: Int)
+    }
 }

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationDto.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationDto.kt
@@ -28,6 +28,6 @@ class ReservationDto {
         val sold: List<UUID>,
         val hold: List<UUID>
     ) {
-        data class SeatSummary(val total: Int, val available: Int, val sold: Int, val hold: Int)
+        data class SeatSummary(val total: Long, val available: Int, val sold: Int, val hold: Int)
     }
 }

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationDto.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationDto.kt
@@ -28,6 +28,6 @@ class ReservationDto {
         val sold: List<UUID>,
         val hold: List<UUID>
     ) {
-        data class SeatSummary(val total: Long, val available: Int, val sold: Int, val hold: Int)
+        data class SeatSummary(val total: Long, val available: Long, val sold: Int, val hold: Int)
     }
 }

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
@@ -194,21 +194,18 @@ class ReservationService(
             ?: emptyList()
 
         val soldSet  = soldResponse.soldSeatIds.toSet()
-        val holdSet  = holdIds.toSet()
-        val overlap  = soldSet intersect holdSet
-        val soldUniq = soldSet - overlap
-        val holdUniq = holdSet - overlap
-        val available = maxOf(0L, soldResponse.totalSeats - soldUniq.size - holdUniq.size)
+        val holdUniq = holdIds.toSet() - soldSet
+        val available = maxOf(0L, soldResponse.totalSeats - (soldSet union holdUniq).size)
 
         return SeatStatusResponse(
             scheduleId = scheduleId,
             seats = SeatStatusResponse.SeatSummary(
                 total     = soldResponse.totalSeats,
-                available = available.toInt(),
-                sold      = soldUniq.size,
+                available = available,
+                sold      = soldSet.size,
                 hold      = holdUniq.size
             ),
-            sold = soldUniq.toList(),
+            sold = soldSet.toList(),
             hold = holdUniq.toList()
         )
     }

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
@@ -193,18 +193,23 @@ class ReservationService(
             ?.mapNotNull { runCatching { UUID.fromString(it) }.getOrNull() }
             ?: emptyList()
 
-        val availableCount = maxOf(0, soldResponse.totalSeats - soldResponse.soldSeatIds.size - holdIds.size)
+        val soldSet  = soldResponse.soldSeatIds.toSet()
+        val holdSet  = holdIds.toSet()
+        val overlap  = soldSet intersect holdSet
+        val soldUniq = soldSet - overlap
+        val holdUniq = holdSet - overlap
+        val available = maxOf(0L, soldResponse.totalSeats - soldUniq.size - holdUniq.size)
 
         return SeatStatusResponse(
             scheduleId = scheduleId,
             seats = SeatStatusResponse.SeatSummary(
-                total = soldResponse.totalSeats,
-                available = availableCount,
-                sold = soldResponse.soldSeatIds.size,
-                hold = holdIds.size
+                total     = soldResponse.totalSeats,
+                available = available.toInt(),
+                sold      = soldUniq.size,
+                hold      = holdUniq.size
             ),
-            sold = soldResponse.soldSeatIds,
-            hold = holdIds
+            sold = soldUniq.toList(),
+            hold = holdUniq.toList()
         )
     }
 

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
@@ -27,23 +27,6 @@ import java.time.ZoneOffset
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
-/**
- * 좌석 선점 서비스 (REQ-RSV-001, REQ-RSV-005, REQ-RSV-008)
- *
- * ## 선점 프로세스
- * 1. QueueToken 검증 — queue:token:{token} Redis 직접 조회
- * 2. Redisson 분산 락 획득 — user:hold:lock:{userId}:{scheduleId} + seat:hold:{scheduleId}:{seatId}
- * 3. 기존 선점 수량 검증 — PENDING 예매의 좌석 수 합산, 사용자 락 내부에서 TOCTOU 방지 (최대 4장)
- * 4. Redis hold_seats SET 확인 — 이미 선점된 좌석 중복 방지
- * 5. 좌석 상세 조회 — Event Service 내부 API, AVAILABLE 상태 검증 + 스냅샷(seatNumber, grade, price)
- * 6. DB 저장 (TransactionTemplate) + afterCommit 콜백으로 Redis hold_seats SET 업데이트
- *    — afterCommit 사용으로 DB commit 성공 후에만 Redis 갱신 (롤백 시 Redis 오염 없음)
- *    — Redis 갱신 실패 시 경고 로그만 남기고 전파하지 않음 (hold_seats TTL 배치가 보정)
- *
- * ## 락 설계
- * tryLock(waitTime=0, leaseTime=300s)으로 락이 이미 선점 중이면 즉시 실패한다.
- * 성공/실패 모두 finally 블록에서 즉시 해제 — 선점 마커는 hold_seats SET(600s TTL)이 담당.
- */
 @Service
 class ReservationService(
     private val stringRedisTemplate: StringRedisTemplate,
@@ -83,6 +66,23 @@ class ReservationService(
         private const val HOLD_SEATS_SET_TTL_SECONDS = 600L
     }
 
+    /**
+     * 좌석 선점 서비스 (REQ-RSV-001, REQ-RSV-005, REQ-RSV-008)
+     *
+     * ## 선점 프로세스
+     * 1. QueueToken 검증 — queue:token:{token} Redis 직접 조회
+     * 2. Redisson 분산 락 획득 — user:hold:lock:{userId}:{scheduleId} + seat:hold:{scheduleId}:{seatId}
+     * 3. 기존 선점 수량 검증 — PENDING 예매의 좌석 수 합산, 사용자 락 내부에서 TOCTOU 방지 (최대 4장)
+     * 4. Redis hold_seats SET 확인 — 이미 선점된 좌석 중복 방지
+     * 5. 좌석 상세 조회 — Event Service 내부 API, AVAILABLE 상태 검증 + 스냅샷(seatNumber, grade, price)
+     * 6. DB 저장 (TransactionTemplate) + afterCommit 콜백으로 Redis hold_seats SET 업데이트
+     *    — afterCommit 사용으로 DB commit 성공 후에만 Redis 갱신 (롤백 시 Redis 오염 없음)
+     *    — Redis 갱신 실패 시 경고 로그만 남기고 전파하지 않음 (hold_seats TTL 배치가 보정)
+     *
+     * ## 락 설계
+     * tryLock(waitTime=0, leaseTime=300s)으로 락이 이미 선점 중이면 즉시 실패한다.
+     * 성공/실패 모두 finally 블록에서 즉시 해제 — 선점 마커는 hold_seats SET(600s TTL)이 담당.
+     */
     fun holdSeats(userId: UUID, request: HoldRequest, queueToken: String): HoldResponse {
         // 1. QueueToken 검증
         validateQueueToken(queueToken, userId, request.scheduleId)
@@ -183,6 +183,9 @@ class ReservationService(
         }
     }
 
+    /**
+     *  좌석 상태 조회
+     */
     fun getSeatStatus(userId: UUID, scheduleId: UUID, queueToken: String): SeatStatusResponse {
         validateQueueToken(queueToken, userId, scheduleId)
 

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
@@ -5,6 +5,7 @@ import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.reservation.client.EventServiceClient
 import com.ticketqueue.reservation.dto.ReservationDto.HoldRequest
 import com.ticketqueue.reservation.dto.ReservationDto.HoldResponse
+import com.ticketqueue.reservation.dto.ReservationDto.SeatStatusResponse
 import com.ticketqueue.reservation.entity.Reservation
 import com.ticketqueue.reservation.entity.ReservationSeat
 import com.ticketqueue.reservation.entity.ReservationStatus
@@ -180,6 +181,31 @@ class ReservationService(
                 }
             }
         }
+    }
+
+    fun getSeatStatus(userId: UUID, scheduleId: UUID, queueToken: String): SeatStatusResponse {
+        validateQueueToken(queueToken, userId, scheduleId)
+
+        val soldResponse = eventServiceClient.getSoldSeats(scheduleId)
+
+        val holdIds = stringRedisTemplate.opsForSet()
+            .members("hold_seats:$scheduleId")
+            ?.mapNotNull { runCatching { UUID.fromString(it) }.getOrNull() }
+            ?: emptyList()
+
+        val availableCount = maxOf(0, soldResponse.totalSeats - soldResponse.soldSeatIds.size - holdIds.size)
+
+        return SeatStatusResponse(
+            scheduleId = scheduleId,
+            seats = SeatStatusResponse.SeatSummary(
+                total = soldResponse.totalSeats,
+                available = availableCount,
+                sold = soldResponse.soldSeatIds.size,
+                hold = holdIds.size
+            ),
+            sold = soldResponse.soldSeatIds,
+            hold = holdIds
+        )
     }
 
     private fun validateQueueToken(token: String, userId: UUID, scheduleId: UUID) {

--- a/backend/reservation-service/src/main/resources/application.yml
+++ b/backend/reservation-service/src/main/resources/application.yml
@@ -81,6 +81,8 @@ processed-event:
 # OpenFeign (서비스 간 내부 통신)
 # ============================================================
 feign:
+  circuitbreaker:
+    enabled: true
   client:
     config:
       default:
@@ -90,6 +92,29 @@ feign:
         url: http://localhost:8082
         connect-timeout: 2000
         read-timeout: 3000
+
+# ============================================================
+# Resilience4j (Event Service 연쇄 장애 방지)
+# ============================================================
+resilience4j:
+  circuitbreaker:
+    instances:
+      event-service:
+        failureRateThreshold: 50
+        waitDurationInOpenState: 10s
+        slidingWindowSize: 10
+        permittedNumberOfCallsInHalfOpenState: 3
+  retry:
+    instances:
+      event-service:
+        maxAttempts: 3
+        waitDuration: 500ms
+        retryExceptions:
+          - feign.RetryableException
+  timelimiter:
+    instances:
+      event-service:
+        timeoutDuration: 3s
 
 # ============================================================
 # 내부 서비스 API Key

--- a/backend/reservation-service/src/main/resources/application.yml
+++ b/backend/reservation-service/src/main/resources/application.yml
@@ -102,12 +102,12 @@ resilience4j:
       event-service:
         failureRateThreshold: 50
         waitDurationInOpenState: 10s
-        slidingWindowSize: 10
+        slidingWindowSize: 100
         permittedNumberOfCallsInHalfOpenState: 3
   retry:
     instances:
       event-service:
-        maxAttempts: 3
+        maxAttempts: 2
         waitDuration: 500ms
         retryExceptions:
           - feign.RetryableException

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsConcurrencyTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsConcurrencyTest.kt
@@ -116,7 +116,7 @@ class HoldSeatsConcurrencyTest {
      */
     private fun mockAllSeatsAvailable() {
         every { eventServiceClient.getSoldSeats(scheduleId) } returns
-            EventServiceClient.SoldSeatsResponse(scheduleId, emptyList())
+            EventServiceClient.SoldSeatsResponse(scheduleId, emptyList(), 0)
 
         every { eventServiceClient.getSeatDetails(scheduleId, any()) } answers {
             val requestedIds = arg<List<UUID>>(1)

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsIntegrationTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/HoldSeatsIntegrationTest.kt
@@ -107,7 +107,7 @@ class HoldSeatsIntegrationTest {
         justRun { multiLock.unlock() }
 
         every { eventServiceClient.getSoldSeats(scheduleId) } returns
-            EventServiceClient.SoldSeatsResponse(scheduleId, emptyList())
+            EventServiceClient.SoldSeatsResponse(scheduleId, emptyList(), 0)
         every { eventServiceClient.getSeatDetails(scheduleId, any()) } returns
             EventServiceClient.SeatDetailsResponse(
                 scheduleId = scheduleId,

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ReservationServiceTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ReservationServiceTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.reservation.client.EventServiceClient
 import com.ticketqueue.reservation.dto.ReservationDto.HoldRequest
+import com.ticketqueue.reservation.dto.ReservationDto.SeatStatusResponse
 import com.ticketqueue.reservation.entity.Reservation
 import com.ticketqueue.reservation.entity.ReservationSeat
 import com.ticketqueue.reservation.entity.ReservationStatus
@@ -217,6 +218,67 @@ class ReservationServiceTest {
             }
 
             verify(exactly = 0) { stringRedisTemplate.execute(any<RedisScript<Long>>(), any<List<String>>(), *anyVararg()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("좌석 상태 조회")
+    inner class SeatStatusQuery {
+
+        @Test
+        @DisplayName("Queue Token이 없으면 QUEUE_TOKEN_EXPIRED 예외를 던진다")
+        fun throwsWhenTokenExpired() {
+            every { valueOps.get("queue:token:$validToken") } returns null
+            val ex = assertThrows<ReservationException> {
+                reservationService.getSeatStatus(userId, scheduleId, validToken)
+            }
+            ex.errorCode shouldBe ErrorCode.QUEUE_TOKEN_EXPIRED
+        }
+
+        @Test
+        @DisplayName("SOLD와 HOLD 좌석을 합산하여 available을 정확히 계산한다")
+        fun returnsCorrectSeatStatus() {
+            val soldId1 = UUID.randomUUID()
+            val soldId2 = UUID.randomUUID()
+            val holdId1 = UUID.randomUUID()
+            setUpTokenValid()
+            every { eventServiceClient.getSoldSeats(scheduleId) } returns
+                EventServiceClient.SoldSeatsResponse(
+                    scheduleId = scheduleId,
+                    soldSeatIds = listOf(soldId1, soldId2),
+                    totalSeats = 100
+                )
+            every { stringRedisTemplate.opsForSet().members("hold_seats:$scheduleId") } returns setOf(holdId1.toString())
+
+            val result = reservationService.getSeatStatus(userId, scheduleId, validToken)
+
+            result.seats.total shouldBe 100
+            result.seats.sold shouldBe 2
+            result.seats.hold shouldBe 1
+            result.seats.available shouldBe 97
+            result.sold shouldBe listOf(soldId1, soldId2)
+            result.hold shouldBe listOf(holdId1)
+        }
+
+        @Test
+        @DisplayName("hold_seats SET이 Redis에 없으면 hold는 빈 리스트로 반환한다")
+        fun returnsEmptyHoldWhenSetAbsent() {
+            setUpTokenValid()
+            every { eventServiceClient.getSoldSeats(scheduleId) } returns
+                EventServiceClient.SoldSeatsResponse(
+                    scheduleId = scheduleId,
+                    soldSeatIds = emptyList(),
+                    totalSeats = 50
+                )
+            every { stringRedisTemplate.opsForSet().members("hold_seats:$scheduleId") } returns null
+
+            val result = reservationService.getSeatStatus(userId, scheduleId, validToken)
+
+            result.seats.total shouldBe 50
+            result.seats.sold shouldBe 0
+            result.seats.hold shouldBe 0
+            result.seats.available shouldBe 50
+            result.hold shouldBe emptyList<UUID>()
         }
     }
 


### PR DESCRIPTION
## Summary
- REQ-RSV-003: Queue Token을 보유한 사용자가 공연 회차의 실시간 좌석 상태(HOLD/SOLD/AVAILABLE)를 조회할 수 있는 API 구현

## Changes
- `GET /reservations/seats/{scheduleId}` 엔드포인트 추가 (Queue Token 필수)
- Redis `hold_seats:{scheduleId}` SET SMEMBERS로 HOLD 좌석 목록 조회
- Event Service 내부 API(`GET /internal/seats/status/{scheduleId}`) Feign 호출로 SOLD 좌석 목록 조회
- `SoldSeatsResponse`에 `totalSeats` 필드 추가 — Event Service DTO 및 Reservation Service Feign 클라이언트 동시 수정
- `SeatRepository.countByEventScheduleId()` JPA 파생 쿼리 추가

## Test plan
- [x] `ReservationServiceTest` — Queue Token 만료, 정상 조회(SOLD+HOLD+AVAILABLE 계산), HOLD 없는 케이스 3개 단위 테스트 통과
- [x] `SeatServiceTest` — `getSoldSeatIds()` totalSeats 포함 검증 2개 추가
- [x] `InternalSeatControllerTest` — SoldSeatsResponse totalSeats 필드 검증 적용
- [x] `HoldSeatsIntegrationTest` / `HoldSeatsConcurrencyTest` — SoldSeatsResponse 생성자 인자 호환성 수정

Closes #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to retrieve real-time seat status for a schedule, including total capacity, available seats, sold seats, and held seats.

* **Chores / Reliability**
  * Introduced client fallback and circuit-breaker/retry/time-limit configurations to improve resiliency when contacting the event service.

* **Tests**
  * Updated and added tests to validate seat-status behavior and new response fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->