### PR TITLE
feat: [Payment] payments 테이블 JPA Entity 구현 (#57)

### DIFF
--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/Payment.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/Payment.kt
@@ -1,0 +1,93 @@
+package com.ticketqueue.payment.entity
+
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.type.SqlTypes
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "payments", schema = "payment_service")
+class Payment(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID? = null,
+
+    @Column(name = "reservation_id", nullable = false)
+    val reservationId: UUID,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: UUID,
+
+    @Column(name = "payment_key", nullable = false, length = 200, unique = true)
+    val paymentKey: String,
+
+    @Column(name = "amount", nullable = false, precision = 10, scale = 0)
+    val amount: BigDecimal,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_method", nullable = false, length = 20)
+    val paymentMethod: PaymentMethod = PaymentMethod.CARD,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    var status: PaymentStatus = PaymentStatus.PENDING,
+
+    @Column(name = "portone_transaction_id", length = 100)
+    var portoneTransactionId: String? = null,
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "portone_response", columnDefinition = "jsonb")
+    var portoneResponse: String? = null,
+
+    @Column(name = "failure_reason", columnDefinition = "text")
+    var failureReason: String? = null,
+
+    @Column(name = "paid_at")
+    var paidAt: LocalDateTime? = null,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime? = null,
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime? = null,
+) {
+    fun markSuccess(transactionId: String, response: String, paidAt: LocalDateTime) {
+        require(status.canTransitionTo(PaymentStatus.SUCCESS)) {
+            "Cannot transition from $status to SUCCESS"
+        }
+        this.status = PaymentStatus.SUCCESS
+        this.portoneTransactionId = transactionId
+        this.portoneResponse = response
+        this.paidAt = paidAt
+    }
+
+    fun markFailed(reason: String, response: String? = null) {
+        require(status.canTransitionTo(PaymentStatus.FAILED)) {
+            "Cannot transition from $status to FAILED"
+        }
+        this.status = PaymentStatus.FAILED
+        this.failureReason = reason
+        response?.let { this.portoneResponse = it }
+    }
+
+    fun refund() {
+        require(status.canTransitionTo(PaymentStatus.REFUNDED)) {
+            "Cannot transition from $status to REFUNDED"
+        }
+        this.status = PaymentStatus.REFUNDED
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Payment) return false
+        return id != null && id == other.id
+    }
+
+    override fun hashCode(): Int = id?.hashCode() ?: 0
+}

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/Payment.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/Payment.kt
@@ -57,6 +57,12 @@ class Payment(
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime? = null,
 ) {
+    init {
+        require(paymentKey.isNotBlank()) { "paymentKey must not be blank" }
+        require(paymentKey.length <= 200) { "paymentKey must not exceed 200 characters" }
+        require(amount > BigDecimal.ZERO) { "amount must be positive" }
+    }
+
     fun markSuccess(transactionId: String, response: String, paidAt: LocalDateTime) {
         require(status.canTransitionTo(PaymentStatus.SUCCESS)) {
             "Cannot transition from $status to SUCCESS"

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/Payment.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/Payment.kt
@@ -64,6 +64,7 @@ class Payment(
     }
 
     fun markSuccess(transactionId: String, response: String, paidAt: LocalDateTime) {
+        if (status == PaymentStatus.SUCCESS) return
         require(status.canTransitionTo(PaymentStatus.SUCCESS)) {
             "Cannot transition from $status to SUCCESS"
         }
@@ -74,6 +75,7 @@ class Payment(
     }
 
     fun markFailed(reason: String, response: String? = null) {
+        if (status == PaymentStatus.FAILED) return
         require(status.canTransitionTo(PaymentStatus.FAILED)) {
             "Cannot transition from $status to FAILED"
         }

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/PaymentMethod.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/PaymentMethod.kt
@@ -1,0 +1,5 @@
+package com.ticketqueue.payment.entity
+
+enum class PaymentMethod {
+    CARD
+}

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/PaymentStatus.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/PaymentStatus.kt
@@ -6,8 +6,8 @@ enum class PaymentStatus {
     private companion object {
         val allowedTransitions = mapOf(
             PENDING to setOf(SUCCESS, FAILED),
-            SUCCESS to setOf(REFUNDED),
-            FAILED to emptySet<PaymentStatus>(),
+            SUCCESS to setOf(SUCCESS, REFUNDED),
+            FAILED to setOf(FAILED),
             REFUNDED to emptySet<PaymentStatus>(),
         )
     }

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/PaymentStatus.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/PaymentStatus.kt
@@ -1,0 +1,17 @@
+package com.ticketqueue.payment.entity
+
+enum class PaymentStatus {
+    PENDING, SUCCESS, FAILED, REFUNDED;
+
+    private companion object {
+        val allowedTransitions = mapOf(
+            PENDING to setOf(SUCCESS, FAILED),
+            SUCCESS to setOf(REFUNDED),
+            FAILED to emptySet<PaymentStatus>(),
+            REFUNDED to emptySet<PaymentStatus>(),
+        )
+    }
+
+    fun canTransitionTo(target: PaymentStatus): Boolean =
+        allowedTransitions[this]?.contains(target) ?: false
+}

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/repository/PaymentRepository.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/repository/PaymentRepository.kt
@@ -1,0 +1,7 @@
+package com.ticketqueue.payment.repository
+
+import com.ticketqueue.payment.entity.Payment
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface PaymentRepository : JpaRepository<Payment, UUID>

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/repository/PaymentRepository.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/repository/PaymentRepository.kt
@@ -2,6 +2,9 @@ package com.ticketqueue.payment.repository
 
 import com.ticketqueue.payment.entity.Payment
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
 import java.util.UUID
 
-interface PaymentRepository : JpaRepository<Payment, UUID>
+interface PaymentRepository : JpaRepository<Payment, UUID> {
+    fun findByPaymentKey(paymentKey: String): Optional<Payment>
+}


### PR DESCRIPTION
## Summary
- payments 테이블과 매핑되는 JPA Entity, Enum, Repository 구현

## Changes
- Payment JPA Entity 구현 (reservation_id, user_id, payment_key, amount, status, portone_transaction_id, portone_response, failure_reason, paid_at)
- PaymentStatus Enum 정의 (PENDING, SUCCESS, FAILED, REFUNDED) 및 상태 전이 검증 (`canTransitionTo`)
- PaymentMethod Enum 정의 (CARD)
- PaymentRepository 인터페이스 생성 (JpaRepository 기본 틀, 메서드는 Service 구현 시 추가)
- payment_key Unique Constraint 적용

## Test plan
- [x] `./gradlew :payment-service:build -x test` 빌드 성공 확인

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced payment handling with card support and end-to-end transaction tracking
  * Added explicit payment states with validated transitions (pending, success, failed, refunded)
  * Records gateway responses for auditing and troubleshooting
  * Captures failure reasons for clearer error visibility
  * Adds refund capability with state validation
  * Enforces validation on payment identifiers and amounts for data integrity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->