### PR TITLE
feat: [Payment] PortOne 연동 구현 (#60)

### DIFF
--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/config/FeignConfig.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/config/FeignConfig.kt
@@ -1,30 +1,18 @@
 package com.ticketqueue.common.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.ticketqueue.common.security.InternalApiKeyValidator
 import feign.Logger
 import feign.RequestInterceptor
 import feign.Retryer
 import feign.codec.ErrorDecoder
 import org.slf4j.MDC
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 @ConditionalOnClass(RequestInterceptor::class)
-class FeignConfig(
-    @Value("\${internal.api.key}")
-    private val internalApiKey: String
-) {
-
-    @Bean
-    fun internalApiKeyRequestInterceptor(): RequestInterceptor {
-        return RequestInterceptor { template ->
-            template.header(InternalApiKeyValidator.HEADER_NAME, internalApiKey)
-        }
-    }
+class FeignConfig {
 
     @Bean
     fun traceIdRequestInterceptor(): RequestInterceptor {

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/config/InternalFeignConfig.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/config/InternalFeignConfig.kt
@@ -1,0 +1,19 @@
+package com.ticketqueue.common.config
+
+import com.ticketqueue.common.security.InternalApiKeyValidator
+import feign.RequestInterceptor
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+
+class InternalFeignConfig(
+    @Value("\${internal.api.key}")
+    private val internalApiKey: String
+) {
+
+    @Bean
+    fun internalApiKeyRequestInterceptor(): RequestInterceptor {
+        return RequestInterceptor { template ->
+            template.header(InternalApiKeyValidator.HEADER_NAME, internalApiKey)
+        }
+    }
+}

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneDto.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneDto.kt
@@ -1,7 +1,5 @@
 package com.ticketqueue.common.external.portone
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import java.math.BigDecimal
 import java.time.OffsetDateTime
 
 /**
@@ -71,8 +69,8 @@ data class PortoneIdentityV2Response(
 /** 결제 사전 등록 요청 */
 data class PortonePreRegisterRequest(
     val storeId: String,
-    val totalAmount: BigDecimal,
-    val taxFreeAmount: BigDecimal? = null
+    val totalAmount: Long,
+    val taxFreeAmount: Long? = null
 )
 
 /** 결제 단건 조회 응답 */
@@ -83,12 +81,13 @@ data class PortonePaymentResponse(
     val amount: PortonePaymentAmount,
     val paidAt: OffsetDateTime? = null,
     val failure: PortonePaymentFailure? = null,
-    val pgTxId: String? = null
+    val pgTxId: String? = null,
+    val storeId: String? = null
 )
 
 /** 결제 금액 상세 */
 data class PortonePaymentAmount(
-    val total: BigDecimal
+    val total: Long
 )
 
 /** 결제 실패 상세 */

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneDto.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneDto.kt
@@ -70,25 +70,42 @@ data class PortoneIdentityV2Response(
 data class PortonePreRegisterRequest(
     val storeId: String,
     val totalAmount: Long,
-    val taxFreeAmount: Long? = null
+    val taxFreeAmount: Long? = null,
+    val currency: String? = null
 )
 
 /** 결제 단건 조회 응답 */
 data class PortonePaymentResponse(
     val id: String,
-    val transactionId: String? = null,
-    val status: String,
+    val transactionId: String,
+    val merchantId: String,
+    val storeId: String,
+    val status: String, // READY, PENDING, PAID, VIRTUAL_ACCOUNT_ISSUED, PARTIALLY_CANCELLED, CANCELLED, FAILED
     val amount: PortonePaymentAmount,
-    val currency: String? = null,
+    val currency: String,
+    val channel: PortoneSelectedChannel,
+    val version: String,
+    val requestedAt: OffsetDateTime,
+    val updatedAt: OffsetDateTime,
+    val statusChangedAt: OffsetDateTime,
+    val orderName: String,
+    val customer: PortoneCustomer,
+    val method: Map<String, Any?>? = null,
     val paidAt: OffsetDateTime? = null,
     val failure: PortonePaymentFailure? = null,
-    val pgTxId: String? = null,
-    val storeId: String? = null
+    val pgTxId: String? = null
 )
 
 /** 결제 금액 상세 */
 data class PortonePaymentAmount(
-    val total: Long
+    val total: Long,
+    val taxFree: Long,
+    val vat: Long? = null,
+    val supply: Long? = null,
+    val discount: Long,
+    val paid: Long,
+    val cancelled: Long,
+    val cancelledTaxFree: Long
 )
 
 /** 결제 실패 상세 */
@@ -96,4 +113,25 @@ data class PortonePaymentFailure(
     val reason: String? = null,
     val pgCode: String? = null,
     val pgMessage: String? = null
+)
+
+/** 선택된 채널 정보 */
+data class PortoneSelectedChannel(
+    val type: String, // LIVE, TEST
+    val pgProvider: String,
+    val pgMerchantId: String,
+    val id: String? = null,
+    val key: String? = null,
+    val name: String? = null
+)
+
+/** 고객 정보 */
+data class PortoneCustomer(
+    val id: String? = null,
+    val name: String? = null,
+    val birthYear: String? = null,
+    val gender: String? = null,
+    val email: String? = null,
+    val phoneNumber: String? = null,
+    val zipcode: String? = null
 )

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneDto.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneDto.kt
@@ -79,6 +79,7 @@ data class PortonePaymentResponse(
     val transactionId: String? = null,
     val status: String,
     val amount: PortonePaymentAmount,
+    val currency: String? = null,
     val paidAt: OffsetDateTime? = null,
     val failure: PortonePaymentFailure? = null,
     val pgTxId: String? = null,

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneDto.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneDto.kt
@@ -1,6 +1,7 @@
 package com.ticketqueue.common.external.portone
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.math.BigDecimal
 import java.time.OffsetDateTime
 
 /**
@@ -66,3 +67,33 @@ data class PortoneIdentityV2Response(
         val message: String? = null
     )
 }
+
+/** 결제 사전 등록 요청 */
+data class PortonePreRegisterRequest(
+    val storeId: String,
+    val totalAmount: BigDecimal,
+    val taxFreeAmount: BigDecimal? = null
+)
+
+/** 결제 단건 조회 응답 */
+data class PortonePaymentResponse(
+    val id: String,
+    val transactionId: String? = null,
+    val status: String,
+    val amount: PortonePaymentAmount,
+    val paidAt: OffsetDateTime? = null,
+    val failure: PortonePaymentFailure? = null,
+    val pgTxId: String? = null
+)
+
+/** 결제 금액 상세 */
+data class PortonePaymentAmount(
+    val total: BigDecimal
+)
+
+/** 결제 실패 상세 */
+data class PortonePaymentFailure(
+    val reason: String? = null,
+    val pgCode: String? = null,
+    val pgMessage: String? = null
+)

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneFeignClient.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneFeignClient.kt
@@ -55,6 +55,7 @@ interface PortoneFeignClient {
     @GetMapping("/payments/{paymentId}")
     fun getPayment(
         @PathVariable("paymentId") paymentId: String,
+        @RequestParam("storeId") storeId: String?,
         @RequestHeader("Authorization") token: String
     ): PortonePaymentResponse
 }

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneFeignClient.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneFeignClient.kt
@@ -33,4 +33,28 @@ interface PortoneFeignClient {
         @RequestParam("storeId") storeId: String?,
         @RequestHeader("Authorization") token: String
     ): PortoneIdentityV2Response
+
+    /**
+     * 결제 사전 등록 (Prepare) — 금액 위변조 방지용 사전 검증 등록
+     * @param paymentId 가맹점 결제 ID (paymentKey)
+     * @param request 사전 등록 요청 (storeId, totalAmount 등)
+     * @param token Authorization: Bearer {ACCESS_TOKEN}
+     */
+    @PostMapping("/payments/{paymentId}/pre-register")
+    fun preRegisterPayment(
+        @PathVariable("paymentId") paymentId: String,
+        @RequestBody request: PortonePreRegisterRequest,
+        @RequestHeader("Authorization") token: String
+    )
+
+    /**
+     * 결제 단건 조회 — 클라이언트 결제 완료 후 서버에서 결과 검증
+     * @param paymentId 가맹점 결제 ID (paymentKey)
+     * @param token Authorization: Bearer {ACCESS_TOKEN}
+     */
+    @GetMapping("/payments/{paymentId}")
+    fun getPayment(
+        @PathVariable("paymentId") paymentId: String,
+        @RequestHeader("Authorization") token: String
+    ): PortonePaymentResponse
 }

--- a/backend/common-web/src/test/kotlin/com/ticketqueue/common/config/FeignConfigTest.kt
+++ b/backend/common-web/src/test/kotlin/com/ticketqueue/common/config/FeignConfigTest.kt
@@ -9,12 +9,12 @@ import io.kotest.matchers.shouldNotBe
 class FeignConfigTest : DescribeSpec({
 
     val apiKey = "test-internal-api-key-for-unit-test"
-    val feignConfig = FeignConfig(apiKey)
+    val internalFeignConfig = InternalFeignConfig(apiKey)
 
-    describe("FeignConfig - RequestInterceptor") {
-        context("Feign 요청 전송 시") {
-            it("모든 요청에 X-Service-Api-Key 헤더가 자동으로 추가된다") {
-                val interceptor = feignConfig.internalApiKeyRequestInterceptor()
+    describe("InternalFeignConfig - RequestInterceptor") {
+        context("내부 서비스 간 Feign 요청 전송 시") {
+            it("X-Service-Api-Key 헤더가 자동으로 추가된다") {
+                val interceptor = internalFeignConfig.internalApiKeyRequestInterceptor()
                 val template = RequestTemplate()
 
                 interceptor.apply(template)
@@ -25,7 +25,7 @@ class FeignConfigTest : DescribeSpec({
             }
 
             it("헤더 이름은 X-Service-Api-Key 상수와 일치한다") {
-                val interceptor = feignConfig.internalApiKeyRequestInterceptor()
+                val interceptor = internalFeignConfig.internalApiKeyRequestInterceptor()
                 val template = RequestTemplate()
 
                 interceptor.apply(template)

--- a/backend/payment-service/src/main/resources/application-local.yml
+++ b/backend/payment-service/src/main/resources/application-local.yml
@@ -11,4 +11,7 @@ spring:
 
 external:
   portone:
-    enabled: false
+    enabled: true
+    api-secret: ${portone_api_secret:}
+    store-id: ${portone_store_id:}
+    channel-key: ${portone_channel_key:}

--- a/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/client/EventServiceClient.kt
+++ b/backend/queue-service/src/main/kotlin/com/ticketqueue/queue/client/EventServiceClient.kt
@@ -1,11 +1,16 @@
 package com.ticketqueue.queue.client
 
+import com.ticketqueue.common.config.InternalFeignConfig
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import java.util.UUID
 
-@FeignClient(name = "event-service", url = "\${spring.cloud.openfeign.client.config.event-service.url}")
+@FeignClient(
+    name = "event-service",
+    url = "\${spring.cloud.openfeign.client.config.event-service.url}",
+    configuration = [InternalFeignConfig::class]
+)
 interface EventServiceClient {
 
     @GetMapping("/internal/schedules/{scheduleId}/sellable")

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClient.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClient.kt
@@ -1,5 +1,6 @@
 package com.ticketqueue.reservation.client
 
+import com.ticketqueue.common.config.InternalFeignConfig
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -10,7 +11,8 @@ import java.util.UUID
 @FeignClient(
     name = "event-service",
     url = "\${feign.client.config.event-service.url}",
-    fallbackFactory = EventServiceClientFallbackFactory::class
+    fallbackFactory = EventServiceClientFallbackFactory::class,
+    configuration = [InternalFeignConfig::class]
 )
 interface EventServiceClient {
 


### PR DESCRIPTION
## Summary
- `PortoneFeignClient`에 결제 사전 등록(Prepare) API 및 결제 단건 조회 API 메서드 추가
- 결제용 DTO(`PortonePreRegisterRequest`, `PortonePaymentResponse`, `PortonePaymentAmount`, `PortonePaymentFailure`) 추가
- `payment-service` 로컬 환경에서 PortOne 연동 활성화(`enabled=true`)

## Changes
- `common-web/PortoneFeignClient.kt`: `preRegisterPayment()`, `getPayment()` 메서드 추가
- `common-web/PortoneDto.kt`: 결제 DTO 3개 추가, 실패 상세 필드를 PortOne V2 명세에 맞게 `failure` 객체(`reason`, `pgCode`, `pgMessage`)로 구성
- `payment-service/application-local.yml`: `external.portone.enabled=true` 및 시크릿 환경변수 플레이스홀더 설정

## Test plan
- [x] `./gradlew :common-web:build :payment-service:build` 빌드 통과 확인

Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PortOne payment pre-registration and single-payment lookup; payment responses now include merchant/store/channel metadata, customer and selected-channel details, richer amount/tax/cancellation fields, and optional timestamps.

* **Chores / Configuration**
  * PortOne integration enabled for local profile using environment-configurable settings.
  * Internal service-call header handling moved to a dedicated internal-feign configuration and applied to internal clients.

* **Tests**
  * Updated configuration tests to reflect the new internal-feign setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->