### PR TITLE
feat: [Reservation] 좌석 변경 API 구현 (#50)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 SPRING_CLOUD_AWS_REGION_STATIC=ap-northeast-2
 SPRING_CLOUD_AWS_CREDENTIALS_ACCESS_KEY=test
 SPRING_CLOUD_AWS_CREDENTIALS_SECRET_KEY=test
-SPRING_CLOUD_AWS_SECRETSMANAGER_ENDPOINT=http://192.168.50.111:4566
+SPRING_CLOUD_AWS_SECRETSMANAGER_ENDPOINT=http://localhost:4566
 INTERNAL_API_KEY=local-dev-internal-api-key
 ```
 

--- a/backend/common-core/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
+++ b/backend/common-core/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
@@ -41,6 +41,7 @@ enum class ErrorCode(
     HOLD_EXPIRED(HttpStatus.GONE, "HOLD_EXPIRED", "좌석 선점 시간이 만료되었습니다."),
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION_NOT_FOUND", "존재하지 않는 예매입니다."),
     RESERVATION_IN_PROGRESS(HttpStatus.CONFLICT, "RESERVATION_IN_PROGRESS", "이미 진행 중인 선점 요청이 있습니다. 잠시 후 다시 시도해주세요."),
+    RESERVATION_NOT_CHANGEABLE(HttpStatus.CONFLICT, "RESERVATION_NOT_CHANGEABLE", "PENDING 상태의 예매만 좌석을 변경할 수 있습니다."),
 
     // Payment
     PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT_FAILED", "결제에 실패했습니다."),

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/controller/ReservationController.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/controller/ReservationController.kt
@@ -1,5 +1,7 @@
 package com.ticketqueue.reservation.controller
 
+import com.ticketqueue.reservation.dto.ReservationDto.ChangeSeatsRequest
+import com.ticketqueue.reservation.dto.ReservationDto.ChangeSeatsResponse
 import com.ticketqueue.reservation.dto.ReservationDto.HoldRequest
 import com.ticketqueue.reservation.dto.ReservationDto.HoldResponse
 import com.ticketqueue.reservation.dto.ReservationDto.SeatStatusResponse
@@ -10,6 +12,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
@@ -25,6 +28,11 @@ class ReservationController(
 
     private val log = KotlinLogging.logger {}
 
+    companion object {
+        private const val HEADER_USER_ID = "X-User-Id"
+        private const val HEADER_QUEUE_TOKEN = "X-Queue-Token"
+    }
+
     /**
      * 좌석 상태 조회 (REQ-RSV-003)
      *
@@ -33,8 +41,8 @@ class ReservationController(
      */
     @GetMapping("/seats/{scheduleId}")
     fun getSeatStatus(
-        @RequestHeader("X-User-Id") userId: UUID,
-        @RequestHeader("X-Queue-Token") queueToken: String,
+        @RequestHeader(HEADER_USER_ID) userId: UUID,
+        @RequestHeader(HEADER_QUEUE_TOKEN) queueToken: String,
         @PathVariable scheduleId: UUID
     ): SeatStatusResponse {
         return reservationService.getSeatStatus(userId, scheduleId, queueToken)
@@ -49,11 +57,26 @@ class ReservationController(
     @PostMapping("/hold")
     @ResponseStatus(HttpStatus.CREATED)
     fun holdSeats(
-        @RequestHeader("X-User-Id") userId: UUID,
-        @RequestHeader("X-Queue-Token") queueToken: String,
+        @RequestHeader(HEADER_USER_ID) userId: UUID,
+        @RequestHeader(HEADER_QUEUE_TOKEN) queueToken: String,
         @RequestBody @Valid request: HoldRequest
     ): HoldResponse {
         log.info { "Request to hold seat $request" }
         return reservationService.holdSeats(userId, request, queueToken)
+    }
+
+    /**
+     * 선점 좌석 변경 (REQ-RSV-002)
+     *
+     * PENDING 상태 예매의 좌석을 교체한다.
+     */
+    @PutMapping("/hold/{reservationId}")
+    fun changeSeats(
+        @RequestHeader(HEADER_USER_ID) userId: UUID,
+        @RequestHeader(HEADER_QUEUE_TOKEN) queueToken: String,
+        @PathVariable reservationId: UUID,
+        @RequestBody @Valid request: ChangeSeatsRequest
+    ): ChangeSeatsResponse {
+        return reservationService.changeSeats(userId, reservationId, request, queueToken)
     }
 }

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationDto.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationDto.kt
@@ -1,7 +1,6 @@
 package com.ticketqueue.reservation.dto
 
 import com.ticketqueue.reservation.entity.ReservationStatus
-import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import java.math.BigDecimal
@@ -12,13 +11,24 @@ class ReservationDto {
 
     data class HoldRequest(
         @field:NotNull val scheduleId: UUID,
-        @field:NotEmpty @field:Size(min = 1, max = 4) val seatIds: List<UUID>
+        @field:Size(min = 1, max = 4) val seatIds: List<UUID>
     )
 
     data class HoldResponse(
         val reservationId: UUID,
         val status: ReservationStatus,
         val totalAmount: BigDecimal,
+        val holdExpiresAt: OffsetDateTime
+    )
+
+    data class ChangeSeatsRequest(
+        @field:Size(min = 1, max = 4) val newSeatIds: List<UUID>
+    )
+
+    data class ChangeSeatsResponse(
+        val reservationId: UUID,
+        val status: ReservationStatus,
+        val newTotalAmount: BigDecimal,
         val holdExpiresAt: OffsetDateTime
     )
 

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/entity/Reservation.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/entity/Reservation.kt
@@ -5,6 +5,7 @@ import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import java.math.BigDecimal
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 enum class ReservationStatus {
@@ -35,10 +36,10 @@ class Reservation(
     var status: ReservationStatus = ReservationStatus.PENDING,
 
     @Column(name = "total_amount", nullable = false, precision = 10, scale = 0)
-    val totalAmount: BigDecimal,
+    var totalAmount: BigDecimal,
 
     @Column(name = "hold_expires_at", nullable = false)
-    val holdExpiresAt: LocalDateTime,
+    var holdExpiresAt: LocalDateTime,
 
     @Column(name = "ticket_number", length = 50)
     var ticketNumber: String? = null,
@@ -54,6 +55,16 @@ class Reservation(
     @Column(name = "updated_at", nullable = false)
     val updatedAt: LocalDateTime? = null
 ) {
+    fun updateTotalAmount(newAmount: BigDecimal) {
+        require(newAmount >= BigDecimal.ZERO) { "totalAmount는 음수가 될 수 없습니다." }
+        this.totalAmount = newAmount
+    }
+
+    fun updateHoldExpiresAt(newExpiry: LocalDateTime) {
+        require(newExpiry.isAfter(LocalDateTime.now(ZoneOffset.UTC))) { "holdExpiresAt은 미래 시각이어야 합니다." }
+        this.holdExpiresAt = newExpiry
+    }
+
     fun confirm(paymentId: UUID, ticketNumber: String) {
         this.status = ReservationStatus.CONFIRMED
         this.paymentId = paymentId

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/repository/ReservationRepository.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/repository/ReservationRepository.kt
@@ -3,6 +3,7 @@ package com.ticketqueue.reservation.repository
 import com.ticketqueue.reservation.entity.Reservation
 import com.ticketqueue.reservation.entity.ReservationStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -12,4 +13,12 @@ interface ReservationRepository : JpaRepository<Reservation, UUID> {
     fun existsByUserIdAndScheduleIdAndStatusIn(userId: UUID, scheduleId: UUID, statuses: List<ReservationStatus>): Boolean
     fun findAllByStatusAndHoldExpiresAtBefore(status: ReservationStatus, now: LocalDateTime): List<Reservation>
     fun findByUserIdAndScheduleIdAndStatus(userId: UUID, scheduleId: UUID, status: ReservationStatus): List<Reservation>
+
+    @Query("SELECT r FROM Reservation r WHERE r.userId = :userId AND r.scheduleId = :scheduleId AND r.status = :status AND r.id <> :excludeId")
+    fun findByUserIdAndScheduleIdAndStatusExcluding(
+        userId: UUID,
+        scheduleId: UUID,
+        status: ReservationStatus,
+        excludeId: UUID
+    ): List<Reservation>
 }

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/repository/ReservationSeatRepository.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/repository/ReservationSeatRepository.kt
@@ -2,9 +2,15 @@ package com.ticketqueue.reservation.repository
 
 import com.ticketqueue.reservation.entity.ReservationSeat
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import java.util.UUID
 
 interface ReservationSeatRepository : JpaRepository<ReservationSeat, UUID> {
     fun findByReservationId(reservationId: UUID): List<ReservationSeat>
     fun countByReservationIdIn(reservationIds: List<UUID>): Int
+
+    @Modifying
+    @Query("DELETE FROM ReservationSeat rs WHERE rs.reservationId = :reservationId")
+    fun deleteAllByReservationId(reservationId: UUID)
 }

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/RedisKeys.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/RedisKeys.kt
@@ -1,0 +1,10 @@
+package com.ticketqueue.reservation.service
+
+import java.util.UUID
+
+internal object RedisKeys {
+    fun userHoldLock(userId: UUID, scheduleId: UUID) = "user:hold:lock:$userId:$scheduleId"
+    fun seatHold(scheduleId: UUID, seatId: UUID) = "seat:hold:$scheduleId:$seatId"
+    fun holdSeatsSet(scheduleId: UUID) = "hold_seats:$scheduleId"
+    fun queueToken(token: String) = "queue:token:$token"
+}

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
@@ -231,20 +231,7 @@ class ReservationService(
 
                 // DB commit 성공 후에만 Redis 갱신
                 registerAfterCommit {
-                    if (seatsToRelease.isNotEmpty()) {
-                        try {
-                            removeFromHoldSeatsSet(reservation.scheduleId, seatsToRelease)
-                        } catch (e: Exception) {
-                            log.warn(e) { "hold_seats SREM 실패 (scheduleId=${reservation.scheduleId}). 배치가 보정합니다." }
-                        }
-                    }
-                    if (seatsToAcquire.isNotEmpty()) {
-                        try {
-                            updateHoldSeatsSet(reservation.scheduleId, seatsToAcquire)
-                        } catch (e: Exception) {
-                            log.warn(e) { "hold_seats SADD 실패 (scheduleId=${reservation.scheduleId}). 배치가 보정합니다." }
-                        }
-                    }
+                    scheduleHoldSeatsReconciliation(reservation.scheduleId, seatsToRelease, seatsToAcquire)
                 }
             }
 
@@ -391,6 +378,27 @@ class ReservationService(
         val detail = seatDetailMap[seatId]
             ?: throw ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "좌석 상세 정보 없음: $seatId")
         return ReservationSeat(reservationId = reservationId, seatId = seatId, seatNumber = detail.seatNumber, grade = detail.grade, price = detail.price)
+    }
+
+    private fun scheduleHoldSeatsReconciliation(
+        scheduleId: UUID,
+        seatsToRelease: List<UUID>,
+        seatsToAcquire: List<UUID>
+    ) {
+        if (seatsToRelease.isNotEmpty()) {
+            try {
+                removeFromHoldSeatsSet(scheduleId, seatsToRelease)
+            } catch (e: Exception) {
+                log.warn(e) { "hold_seats SREM 실패 (scheduleId=$scheduleId). 배치가 보정합니다." }
+            }
+        }
+        if (seatsToAcquire.isNotEmpty()) {
+            try {
+                updateHoldSeatsSet(scheduleId, seatsToAcquire)
+            } catch (e: Exception) {
+                log.warn(e) { "hold_seats SADD 실패 (scheduleId=$scheduleId). 배치가 보정합니다." }
+            }
+        }
     }
 
     private fun registerAfterCommit(action: () -> Unit) {

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
@@ -3,6 +3,8 @@ package com.ticketqueue.reservation.service
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.reservation.client.EventServiceClient
+import com.ticketqueue.reservation.dto.ReservationDto.ChangeSeatsRequest
+import com.ticketqueue.reservation.dto.ReservationDto.ChangeSeatsResponse
 import com.ticketqueue.reservation.dto.ReservationDto.HoldRequest
 import com.ticketqueue.reservation.dto.ReservationDto.HoldResponse
 import com.ticketqueue.reservation.dto.ReservationDto.SeatStatusResponse
@@ -84,14 +86,13 @@ class ReservationService(
      * 성공/실패 모두 finally 블록에서 즉시 해제 — 선점 마커는 hold_seats SET(600s TTL)이 담당.
      */
     fun holdSeats(userId: UUID, request: HoldRequest, queueToken: String): HoldResponse {
-        // 1. QueueToken 검증
         validateQueueToken(queueToken, userId, request.scheduleId)
 
         // 락 목록 준비 (사용자 락 + 좌석 MultiLock)
-        val userLock = redissonClient.getLock("user:hold:lock:$userId:${request.scheduleId}")
+        val userLock = redissonClient.getLock(RedisKeys.userHoldLock(userId, request.scheduleId))
         val multiSeatLock = redissonClient.getMultiLock(
-            *request.seatIds.sorted().map { 
-                redissonClient.getLock("seat:hold:${request.scheduleId}:$it") 
+            *request.seatIds.sorted().map {
+                redissonClient.getLock(RedisKeys.seatHold(request.scheduleId, it))
             }.toTypedArray()
         )
 
@@ -100,31 +101,19 @@ class ReservationService(
             userLock to ErrorCode.RESERVATION_IN_PROGRESS,
             multiSeatLock to ErrorCode.SEAT_ALREADY_HELD
         )
-        val acquiredLocks = mutableListOf<RLock>()
-
-        try {
-            // 모든 락 획득 시도 (waitTime=0)
-            for ((lock, errorCode) in lockTargets) {
-                if (!lock.tryLock(0, HOLD_TTL_SECONDS, TimeUnit.SECONDS)) {
-                    throw ReservationException(errorCode)
-                }
-                acquiredLocks.add(lock)
-            }
-
-            // 3. 수량 검증 (사용자 락 안에서 수행하여 TOCTOU 방지)
+        return withSeatLocks(lockTargets) {
+            // 수량 검증 (사용자 락 안에서 수행하여 TOCTOU 방지)
             validateSeatCount(userId, request.scheduleId, request.seatIds.size)
 
-            // 4. Redis hold_seats SET 중복 확인
             checkHoldSeatsSet(request.scheduleId, request.seatIds)
 
-            // 5. 좌석 상세 조회 — AVAILABLE 상태 검증 + 스냅샷 (getSeatDetails 내부에서 SOLD/HOLD 거부)
+            // 좌석 상세 조회 — AVAILABLE 상태 검증 + 스냅샷 (getSeatDetails 내부에서 SOLD/HOLD 거부)
             val seatDetailsResponse = eventServiceClient.getSeatDetails(request.scheduleId, request.seatIds)
             val seatDetailMap = seatDetailsResponse.seats.associateBy { it.seatId }
             if (seatDetailMap.size != request.seatIds.size) {
                 throw ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "요청한 좌석 정보를 찾을 수 없습니다.")
             }
 
-            // 6. DB 저장 후 afterCommit 콜백으로 Redis hold_seats SET 업데이트
             val holdExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(HOLD_MINUTES)
             val totalAmount = seatDetailsResponse.seats.sumOf { it.price }
             val reservation = transactionTemplate.execute {
@@ -138,53 +127,140 @@ class ReservationService(
                     )
                 )
                 reservationSeatRepository.saveAll(
-                    request.seatIds.map { seatId ->
-                        val detail = seatDetailMap[seatId]
-                            ?: throw ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "좌석 상세 정보 없음: $seatId")
-                        ReservationSeat(
-                            reservationId = saved.id!!,
-                            seatId = seatId,
-                            seatNumber = detail.seatNumber,
-                            grade = detail.grade,
-                            price = detail.price
-                        )
-                    }
+                    request.seatIds.map { seatId -> buildReservationSeat(saved.id!!, seatId, seatDetailMap = seatDetailMap) }
                 )
                 // DB commit 성공 후에만 Redis 갱신 — 롤백 시 Redis 오염 없음
-                TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-                    override fun afterCommit() {
-                        try {
-                            updateHoldSeatsSet(request.scheduleId, request.seatIds)
-                        } catch (e: Exception) {
-                            log.warn(e) { "hold_seats SET 업데이트 실패 (scheduleId=${request.scheduleId}). 배치가 보정합니다." }
-                        }
+                registerAfterCommit {
+                    try {
+                        updateHoldSeatsSet(request.scheduleId, request.seatIds)
+                    } catch (e: Exception) {
+                        log.warn(e) { "hold_seats SET 업데이트 실패 (scheduleId=${request.scheduleId}). 배치가 보정합니다." }
                     }
-                })
+                }
                 saved
             } ?: throw ReservationException(ErrorCode.INTERNAL_SERVER_ERROR, "좌석 선점 저장에 실패했습니다.")
 
             log.info { "Seats held: userId=$userId, scheduleId=${request.scheduleId}, seatIds=${request.seatIds}, reservationId=${reservation.id}" }
 
-            return HoldResponse(
+            HoldResponse(
                 reservationId = reservation.id!!,
                 status = reservation.status,
                 totalAmount = reservation.totalAmount,
-                holdExpiresAt = reservation.holdExpiresAt.atOffset(ZoneOffset.UTC)
+                holdExpiresAt = reservation.holdExpiresAt.toUtcOffset()
             )
-        } finally {
-            // 획득한 락을 역순으로 안전하게 해제
-            acquiredLocks.reversed().forEach { lock ->
-                try {
-                    if (lock.isHeldByCurrentThread) lock.unlock()
-                } catch (e: Exception) {
-                    log.warn(e) { "Failed to release lock: ${lock.name}" }
-                }
-            }
         }
     }
 
     /**
-     *  좌석 상태 조회
+     * 좌석 변경 서비스 (REQ-RSV-002)
+     *
+     * ## 변경 프로세스
+     * 1. 기존 + 신규 좌석 전체를 정렬하여 MultiLock 획득 — 데드락 방지
+     * 2. 신규 좌석(seatsToAcquire)만 hold_seats SET 중복 확인 — 기존 좌석 오탐 방지
+     * 3. DB 트랜잭션 + afterCommit 콜백으로 Redis hold_seats SET 갱신 — DB 롤백 시 Redis 오염 없음
+     */
+    fun changeSeats(userId: UUID, reservationId: UUID, request: ChangeSeatsRequest, queueToken: String): ChangeSeatsResponse {
+        val reservation = reservationRepository.findByIdAndUserId(reservationId, userId)
+            ?: throw ReservationException(ErrorCode.RESERVATION_NOT_FOUND)
+
+        validateForChange(reservation)
+        validateQueueToken(queueToken, userId, reservation.scheduleId)
+
+        val oldSeats = reservationSeatRepository.findByReservationId(reservationId)
+        val oldSeatIds = oldSeats.map { it.seatId }
+        val newSeatIds = request.newSeatIds
+
+        if (newSeatIds.size > MAX_HOLD_SEATS) {
+            throw ReservationException(ErrorCode.MAX_SEATS_EXCEEDED)
+        }
+
+        // 변경 대상 분류
+        val seatsToRelease = oldSeatIds.filterNot { it in newSeatIds }
+        val seatsToAcquire = newSeatIds.filterNot { it in oldSeatIds }
+
+        // 락 획득 전 수행하여 락 점유 시간 최소화 — 락 후 checkHoldSeatsSet이 Redis 상태를 재검증하므로 TOCTOU 위험 없음
+        val newSeatDetailMap = fetchNewSeatDetails(reservation.scheduleId, seatsToAcquire)
+
+        val keptSeatMap = oldSeats.filter { it.seatId in newSeatIds }.associateBy { it.seatId }
+        val newTotalAmount = newSeatIds.sumOf { seatId ->
+            keptSeatMap[seatId]?.price
+                ?: newSeatDetailMap[seatId]?.price
+                ?: throw ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "좌석 상세 정보 없음: $seatId")
+        }
+
+        // 락 목록 준비 — 기존 + 신규 전체 정렬하여 데드락 방지
+        val userLock = redissonClient.getLock(RedisKeys.userHoldLock(userId, reservation.scheduleId))
+        // distinct: 유지 좌석이 old/new 양쪽에 포함되어 MultiLock에 중복 키가 전달되는 것을 방지
+        val allSeatIds = (oldSeatIds + newSeatIds).distinct().sorted()
+        val multiSeatLock = redissonClient.getMultiLock(
+            *allSeatIds.map { redissonClient.getLock(RedisKeys.seatHold(reservation.scheduleId, it)) }.toTypedArray()
+        )
+
+        val lockTargets = listOf(
+            userLock to ErrorCode.RESERVATION_IN_PROGRESS,
+            multiSeatLock to ErrorCode.SEAT_ALREADY_HELD
+        )
+        return withSeatLocks(lockTargets) {
+            // 다른 PENDING 예매와 합산한 좌석 한도 검증 (사용자 락 내부에서 수행)
+            validateSeatCount(userId, reservation.scheduleId, newSeatIds.size, excludeReservationId = reservationId)
+
+            // 신규 좌석만 hold_seats SET 중복 확인 (기존 좌석은 이미 보유 중이므로 제외)
+            if (seatsToAcquire.isNotEmpty()) {
+                checkHoldSeatsSet(reservation.scheduleId, seatsToAcquire)
+            }
+
+            val newHoldExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(HOLD_MINUTES)
+
+            transactionTemplate.executeWithoutResult {
+                // 락 획득 후 예매 상태 재검증 (TOCTOU 방지) + dirty checking 겸용 — SELECT 1회로 통합
+                val freshReservation = reservationRepository.findByIdAndUserId(reservationId, userId)
+                    ?: throw ReservationException(ErrorCode.RESERVATION_NOT_FOUND)
+                if (freshReservation.status != ReservationStatus.PENDING) {
+                    throw ReservationException(ErrorCode.RESERVATION_NOT_CHANGEABLE)
+                }
+                if (LocalDateTime.now(ZoneOffset.UTC).isAfter(freshReservation.holdExpiresAt)) {
+                    throw ReservationException(ErrorCode.HOLD_EXPIRED)
+                }
+
+                reservationSeatRepository.deleteAllByReservationId(reservationId)
+                reservationSeatRepository.saveAll(
+                    newSeatIds.map { seatId -> buildReservationSeat(reservationId, seatId, keptSeatMap, newSeatDetailMap) }
+                )
+                freshReservation.updateTotalAmount(newTotalAmount)
+                freshReservation.updateHoldExpiresAt(newHoldExpiresAt)
+
+                // DB commit 성공 후에만 Redis 갱신
+                registerAfterCommit {
+                    if (seatsToRelease.isNotEmpty()) {
+                        try {
+                            removeFromHoldSeatsSet(reservation.scheduleId, seatsToRelease)
+                        } catch (e: Exception) {
+                            log.warn(e) { "hold_seats SREM 실패 (scheduleId=${reservation.scheduleId}). 배치가 보정합니다." }
+                        }
+                    }
+                    if (seatsToAcquire.isNotEmpty()) {
+                        try {
+                            updateHoldSeatsSet(reservation.scheduleId, seatsToAcquire)
+                        } catch (e: Exception) {
+                            log.warn(e) { "hold_seats SADD 실패 (scheduleId=${reservation.scheduleId}). 배치가 보정합니다." }
+                        }
+                    }
+                }
+            }
+
+            log.info { "Seats changed: userId=$userId, reservationId=$reservationId, oldSeatIds=$oldSeatIds, newSeatIds=$newSeatIds" }
+
+            ChangeSeatsResponse(
+                reservationId = reservationId,
+                status = ReservationStatus.PENDING,
+                newTotalAmount = newTotalAmount,
+                holdExpiresAt = newHoldExpiresAt.toUtcOffset()
+            )
+        }
+    }
+
+    /**
+     * 좌석 상태 조회
      */
     fun getSeatStatus(userId: UUID, scheduleId: UUID, queueToken: String): SeatStatusResponse {
         validateQueueToken(queueToken, userId, scheduleId)
@@ -192,7 +268,7 @@ class ReservationService(
         val soldResponse = eventServiceClient.getSoldSeats(scheduleId)
 
         val holdIds = stringRedisTemplate.opsForSet()
-            .members("hold_seats:$scheduleId")
+            .members(RedisKeys.holdSeatsSet(scheduleId))
             ?.mapNotNull { runCatching { UUID.fromString(it) }.getOrNull() }
             ?: emptyList()
 
@@ -213,8 +289,29 @@ class ReservationService(
         )
     }
 
+    private fun validateForChange(reservation: Reservation) {
+        if (reservation.status != ReservationStatus.PENDING) {
+            throw ReservationException(ErrorCode.RESERVATION_NOT_CHANGEABLE)
+        }
+        if (LocalDateTime.now(ZoneOffset.UTC).isAfter(reservation.holdExpiresAt)) {
+            throw ReservationException(ErrorCode.HOLD_EXPIRED)
+        }
+    }
+
+    private fun fetchNewSeatDetails(
+        scheduleId: UUID,
+        seatsToAcquire: List<UUID>
+    ): Map<UUID, EventServiceClient.SeatDetailsResponse.SeatDetail> {
+        if (seatsToAcquire.isEmpty()) return emptyMap()
+        val response = eventServiceClient.getSeatDetails(scheduleId, seatsToAcquire)
+        if (response.seats.size != seatsToAcquire.size) {
+            throw ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "요청한 좌석 정보를 찾을 수 없습니다.")
+        }
+        return response.seats.associateBy { it.seatId }
+    }
+
     private fun validateQueueToken(token: String, userId: UUID, scheduleId: UUID) {
-        val tokenJson = stringRedisTemplate.opsForValue().get("queue:token:$token")
+        val tokenJson = stringRedisTemplate.opsForValue().get(RedisKeys.queueToken(token))
             ?: throw ReservationException(ErrorCode.QUEUE_TOKEN_EXPIRED)
 
         val payload = try {
@@ -228,13 +325,20 @@ class ReservationService(
         }
     }
 
-    private fun validateSeatCount(userId: UUID, scheduleId: UUID, requestedCount: Int) {
+    private fun validateSeatCount(
+        userId: UUID,
+        scheduleId: UUID,
+        requestedCount: Int,
+        excludeReservationId: UUID? = null
+    ) {
         if (requestedCount > MAX_HOLD_SEATS) {
             throw ReservationException(ErrorCode.MAX_SEATS_EXCEEDED)
         }
-        val pendingReservations = reservationRepository.findByUserIdAndScheduleIdAndStatus(
-            userId, scheduleId, ReservationStatus.PENDING
-        )
+        val pendingReservations = if (excludeReservationId != null)
+            reservationRepository.findByUserIdAndScheduleIdAndStatusExcluding(userId, scheduleId, ReservationStatus.PENDING, excludeReservationId)
+        else
+            reservationRepository.findByUserIdAndScheduleIdAndStatus(userId, scheduleId, ReservationStatus.PENDING)
+
         if (pendingReservations.isEmpty()) return
 
         val existingCount = reservationSeatRepository.countByReservationIdIn(
@@ -246,7 +350,7 @@ class ReservationService(
     }
 
     private fun checkHoldSeatsSet(scheduleId: UUID, seatIds: List<UUID>) {
-        val holdSeatsKey = "hold_seats:$scheduleId"
+        val holdSeatsKey = RedisKeys.holdSeatsSet(scheduleId)
         val result: List<Boolean>? = stringRedisTemplate.execute { conn ->
             conn.setCommands().sMIsMember(
                 holdSeatsKey.toByteArray(Charsets.UTF_8),
@@ -258,6 +362,11 @@ class ReservationService(
         }
     }
 
+    private fun removeFromHoldSeatsSet(scheduleId: UUID, seatIds: List<UUID>) {
+        stringRedisTemplate.opsForSet()
+            .remove(RedisKeys.holdSeatsSet(scheduleId), *seatIds.map { it.toString() }.toTypedArray())
+    }
+
     /**
      * hold_seats Redis SET에 좌석 ID를 추가하고 TTL을 설정한다.
      *
@@ -265,9 +374,53 @@ class ReservationService(
      * DB commit 성공 후 afterCommit 콜백에서 호출되므로 DB 롤백 시 Redis 오염이 발생하지 않는다.
      */
     private fun updateHoldSeatsSet(scheduleId: UUID, seatIds: List<UUID>) {
-        val holdSeatsKey = "hold_seats:$scheduleId"
+        val holdSeatsKey = RedisKeys.holdSeatsSet(scheduleId)
         val args = (listOf(HOLD_SEATS_SET_TTL_SECONDS.toString()) + seatIds.map { it.toString() }).toTypedArray()
         stringRedisTemplate.execute(holdSeatsSetScript, listOf(holdSeatsKey), *args)
     }
 
+    private fun buildReservationSeat(
+        reservationId: UUID,
+        seatId: UUID,
+        keptSeatMap: Map<UUID, ReservationSeat> = emptyMap(),
+        seatDetailMap: Map<UUID, EventServiceClient.SeatDetailsResponse.SeatDetail>
+    ): ReservationSeat {
+        keptSeatMap[seatId]?.let { kept ->
+            return ReservationSeat(reservationId = reservationId, seatId = seatId, seatNumber = kept.seatNumber, grade = kept.grade, price = kept.price)
+        }
+        val detail = seatDetailMap[seatId]
+            ?: throw ReservationException(ErrorCode.RESOURCE_NOT_FOUND, "좌석 상세 정보 없음: $seatId")
+        return ReservationSeat(reservationId = reservationId, seatId = seatId, seatNumber = detail.seatNumber, grade = detail.grade, price = detail.price)
+    }
+
+    private fun registerAfterCommit(action: () -> Unit) {
+        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+            override fun afterCommit() { action() }
+        })
+    }
+
+    // lockTargets 순서대로 tryLock(waitTime=0) 획득 후 block 실행, finally에서 역순 해제
+    private inline fun <T> withSeatLocks(lockTargets: List<Pair<RLock, ErrorCode>>, block: () -> T): T {
+        val acquiredLocks = mutableListOf<RLock>()
+        try {
+            for ((lock, errorCode) in lockTargets) {
+                if (!lock.tryLock(0, HOLD_TTL_SECONDS, TimeUnit.SECONDS)) {
+                    throw ReservationException(errorCode)
+                }
+                acquiredLocks.add(lock)
+            }
+            return block()
+        } finally {
+            acquiredLocks.reversed().forEach { lock ->
+                try {
+                    if (lock.isHeldByCurrentThread) lock.unlock()
+                } catch (e: Exception) {
+                    log.warn(e) { "Failed to release lock: ${lock.name}" }
+                }
+            }
+        }
+    }
+
 }
+
+private fun LocalDateTime.toUtcOffset(): OffsetDateTime = atOffset(ZoneOffset.UTC)

--- a/backend/reservation-service/src/main/resources/application-local.yml
+++ b/backend/reservation-service/src/main/resources/application-local.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: local
 
   datasource:
-    url: jdbc:postgresql://192.168.50.111:5432/ticket_queue?currentSchema=reservation_service,common
+    url: jdbc:postgresql://localhost:5432/ticket_queue?currentSchema=reservation_service,common
     username: reservation_svc_user
     password: ${db_password}
     driver-class-name: org.postgresql.Driver

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/ChangeSeatsConcurrencyTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/ChangeSeatsConcurrencyTest.kt
@@ -68,7 +68,7 @@ class ChangeSeatsConcurrencyTest {
 
         @Container
         @JvmStatic
-        val valkey = GenericContainer("valkey/valkey:8.1-alpine")
+        val valkey = GenericContainer("valkey/valkey:8.1.5-alpine3.23")
             .withExposedPorts(6379)
 
         @DynamicPropertySource
@@ -188,8 +188,8 @@ class ChangeSeatsConcurrencyTest {
         }, executor)
 
         startLatch.countDown()
-        val statusA = futureA.get()
-        val statusB = futureB.get()
+        val statusA = futureA.get(10, TimeUnit.SECONDS)
+        val statusB = futureB.get(10, TimeUnit.SECONDS)
         executor.shutdown()
         executor.awaitTermination(5, TimeUnit.SECONDS)
 
@@ -250,8 +250,8 @@ class ChangeSeatsConcurrencyTest {
         }, executor)
 
         startLatch.countDown()
-        val changeStatus = changeFuture.get()
-        val holdStatus = holdFuture.get()
+        val changeStatus = changeFuture.get(10, TimeUnit.SECONDS)
+        val holdStatus = holdFuture.get(10, TimeUnit.SECONDS)
         executor.shutdown()
         executor.awaitTermination(5, TimeUnit.SECONDS)
 
@@ -263,5 +263,8 @@ class ChangeSeatsConcurrencyTest {
         stringRedisTemplate.opsForSet().size("hold_seats:$scheduleId") shouldBe
             if (changeStatus == 200) 1L  // initialSeatId 제거됨
             else 2L  // initialSeatId + contestedSeatId
+
+        stringRedisTemplate.opsForSet().isMember("hold_seats:$scheduleId", contestedSeatId.toString()) shouldBe true
+        stringRedisTemplate.opsForSet().isMember("hold_seats:$scheduleId", initialSeatId.toString()) shouldBe (changeStatus != 200)
     }
 }

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/ChangeSeatsConcurrencyTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/ChangeSeatsConcurrencyTest.kt
@@ -1,0 +1,267 @@
+package com.ticketqueue.reservation.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.ticketqueue.reservation.client.EventServiceClient
+import com.ticketqueue.reservation.repository.ReservationRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.math.BigDecimal
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * 좌석 변경 동시성 테스트
+ *
+ * HoldSeatsConcurrencyTest 와 동일하게 RedissonClient를 mock하지 않고
+ * 실제 Valkey 컨테이너에 연결하여 분산 락 경합을 검증한다.
+ *
+ * 보호 레이어:
+ *   1차 — user:hold:lock 의 tryLock(waitTime=0): 동일 예매 동시 변경 요청 직렬화
+ *   2차 — hold_seats SET: 신규 좌석 중복 차단
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "spring.config.import=",
+        "spring.cloud.aws.region.static=us-east-1",
+        "spring.cloud.aws.credentials.access-key=test",
+        "spring.cloud.aws.credentials.secret-key=test",
+        "spring.cloud.aws.secretsmanager.enabled=false"
+    ]
+)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("좌석 변경 동시성 테스트")
+class ChangeSeatsConcurrencyTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("ticketing")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("db/init.sql")
+
+        @Container
+        @JvmStatic
+        val valkey = GenericContainer("valkey/valkey:8.1-alpine")
+            .withExposedPorts(6379)
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
+            registry.add("spring.datasource.username") { postgres.username }
+            registry.add("spring.datasource.password") { postgres.password }
+            registry.add("spring.data.redis.host") { valkey.host }
+            registry.add("spring.data.redis.port") { valkey.getMappedPort(6379) }
+        }
+    }
+
+    @Autowired private lateinit var mockMvc: MockMvc
+    @Autowired private lateinit var stringRedisTemplate: StringRedisTemplate
+    @Autowired private lateinit var objectMapper: ObjectMapper
+    @Autowired private lateinit var reservationRepository: ReservationRepository
+
+    @MockkBean private lateinit var eventServiceClient: EventServiceClient
+
+    private val scheduleId = UUID.randomUUID()
+    private val eventId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        stringRedisTemplate.connectionFactory?.connection?.serverCommands()?.flushAll()
+        reservationRepository.deleteAll()
+    }
+
+    private fun seedQueueToken(userId: UUID, token: String) {
+        stringRedisTemplate.opsForValue().set(
+            "queue:token:$token",
+            """{"userId":"$userId","scheduleId":"$scheduleId","issuedAt":"1234567890"}"""
+        )
+    }
+
+    private fun mockAllSeatsAvailable() {
+        every { eventServiceClient.getSoldSeats(scheduleId) } returns
+            EventServiceClient.SoldSeatsResponse(scheduleId, emptyList(), 0)
+
+        every { eventServiceClient.getSeatDetails(scheduleId, any()) } answers {
+            val requestedIds = arg<List<UUID>>(1)
+            EventServiceClient.SeatDetailsResponse(
+                scheduleId = scheduleId,
+                eventId = eventId,
+                seats = requestedIds.map { id ->
+                    EventServiceClient.SeatDetailsResponse.SeatDetail(
+                        seatId = id,
+                        seatNumber = "A-${id.toString().take(4)}",
+                        grade = "VIP",
+                        price = BigDecimal("150000")
+                    )
+                }
+            )
+        }
+    }
+
+    private fun holdSeat(userId: UUID, token: String, seatId: UUID): String {
+        val body = objectMapper.writeValueAsString(
+            mapOf("scheduleId" to scheduleId, "seatIds" to listOf(seatId))
+        )
+        val result = mockMvc.perform(
+            post("/reservations/hold")
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+                .header("X-Queue-Token", token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+        ).andReturn()
+        check(result.response.status == 201) { "holdSeat failed: ${result.response.contentAsString}" }
+        return objectMapper.readTree(result.response.contentAsString)["reservationId"].asText()
+    }
+
+    private fun changeSeats(userId: UUID, token: String, reservationId: String, newSeatIds: List<UUID>): Int {
+        val body = objectMapper.writeValueAsString(mapOf("newSeatIds" to newSeatIds))
+        return mockMvc.perform(
+            put("/reservations/hold/$reservationId")
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+                .header("X-Queue-Token", token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+        ).andReturn().response.status
+    }
+
+    /**
+     * 동일 예매에 2개 스레드가 동시에 다른 좌석으로 변경 요청
+     *
+     * user:hold:lock waitTime=0 정책으로 동일 사용자의 동시 변경 요청이 직렬화된다:
+     * - 락을 먼저 획득한 1건만 성공(200)
+     * - 나머지 1건은 즉시 409 RESERVATION_IN_PROGRESS
+     */
+    @Test
+    @DisplayName("동일 예매에 2개 스레드가 동시 변경하면 1개만 성공하고 나머지는 409를 반환한다")
+    fun onlyOneChangeSucceedsForSameReservation() {
+        val userId = UUID.randomUUID()
+        val token = "token-${UUID.randomUUID()}"
+        val initialSeatId = UUID.randomUUID()
+        val targetSeatA = UUID.randomUUID()
+        val targetSeatB = UUID.randomUUID()
+        mockAllSeatsAvailable()
+        seedQueueToken(userId, token)
+
+        val reservationId = holdSeat(userId, token, initialSeatId)
+
+        val executor = Executors.newFixedThreadPool(2)
+        val startLatch = CountDownLatch(1)
+
+        val futureA = CompletableFuture.supplyAsync({
+            startLatch.await()
+            changeSeats(userId, token, reservationId, listOf(targetSeatA))
+        }, executor)
+
+        val futureB = CompletableFuture.supplyAsync({
+            startLatch.await()
+            changeSeats(userId, token, reservationId, listOf(targetSeatB))
+        }, executor)
+
+        startLatch.countDown()
+        val statusA = futureA.get()
+        val statusB = futureB.get()
+        executor.shutdown()
+        executor.awaitTermination(5, TimeUnit.SECONDS)
+
+        val statuses = listOf(statusA, statusB)
+        statuses.count { it == 200 } shouldBe 1
+        statuses.count { it == 409 } shouldBe 1
+
+        // DB — 예매 레코드는 여전히 1건
+        reservationRepository.findAll().size shouldBe 1
+    }
+
+    /**
+     * 좌석 변경과 좌석 선점이 동일 신규 좌석을 동시에 타겟
+     *
+     * hold_seats SET이 2차 방어선 역할:
+     * - 선점이 먼저 완료되면: 변경 시 checkHoldSeatsSet → 409
+     * - 변경이 먼저 완료되면: 선점 시 checkHoldSeatsSet → 409
+     */
+    @Test
+    @DisplayName("좌석 변경과 다른 사용자 선점이 동일 좌석을 동시에 타겟하면 1개만 성공한다")
+    fun changeAndHoldConflictOnSameSeat() {
+        val userId1 = UUID.randomUUID()
+        val token1 = "token-${UUID.randomUUID()}"
+        val userId2 = UUID.randomUUID()
+        val token2 = "token-${UUID.randomUUID()}"
+        val initialSeatId = UUID.randomUUID()
+        val contestedSeatId = UUID.randomUUID()
+        mockAllSeatsAvailable()
+
+        // userId1이 initialSeatId 선점
+        seedQueueToken(userId1, token1)
+        seedQueueToken(userId2, token2)
+        val reservationId = holdSeat(userId1, token1, initialSeatId)
+
+        val executor = Executors.newFixedThreadPool(2)
+        val startLatch = CountDownLatch(1)
+
+        // userId1: initialSeatId → contestedSeatId 변경
+        val changeFuture = CompletableFuture.supplyAsync({
+            startLatch.await()
+            changeSeats(userId1, token1, reservationId, listOf(contestedSeatId))
+        }, executor)
+
+        // userId2: contestedSeatId 직접 선점
+        val holdFuture = CompletableFuture.supplyAsync({
+            startLatch.await()
+            val body = objectMapper.writeValueAsString(
+                mapOf("scheduleId" to scheduleId, "seatIds" to listOf(contestedSeatId))
+            )
+            mockMvc.perform(
+                post("/reservations/hold")
+                    .header("X-User-Id", userId2)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", token2)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body)
+            ).andReturn().response.status
+        }, executor)
+
+        startLatch.countDown()
+        val changeStatus = changeFuture.get()
+        val holdStatus = holdFuture.get()
+        executor.shutdown()
+        executor.awaitTermination(5, TimeUnit.SECONDS)
+
+        // 둘 중 정확히 하나만 성공
+        val successCount = listOf(changeStatus, holdStatus).count { it == 200 || it == 201 }
+        successCount shouldBe 1
+
+        // contestedSeatId가 hold_seats에 정확히 1번만 존재
+        stringRedisTemplate.opsForSet().size("hold_seats:$scheduleId") shouldBe
+            if (changeStatus == 200) 1L  // initialSeatId 제거됨
+            else 2L  // initialSeatId + contestedSeatId
+    }
+}

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/ChangeSeatsIntegrationTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/ChangeSeatsIntegrationTest.kt
@@ -1,0 +1,363 @@
+package com.ticketqueue.reservation.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.ninjasquad.springmockk.SpykBean
+import com.ticketqueue.reservation.client.EventServiceClient
+import com.ticketqueue.reservation.repository.ReservationRepository
+import com.ticketqueue.reservation.repository.ReservationSeatRepository
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.math.BigDecimal
+import java.util.UUID
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "spring.config.import=",
+        "spring.cloud.aws.region.static=us-east-1",
+        "spring.cloud.aws.credentials.access-key=test",
+        "spring.cloud.aws.credentials.secret-key=test",
+        "spring.cloud.aws.secretsmanager.enabled=false"
+    ]
+)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("좌석 변경 API 통합 테스트 (PUT /reservations/hold/{reservationId})")
+class ChangeSeatsIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("ticketing")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("db/init.sql")
+
+        @Container
+        @JvmStatic
+        val valkey = GenericContainer("valkey/valkey:8.1.5-alpine3.23")
+            .withExposedPorts(6379)
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
+            registry.add("spring.datasource.username") { postgres.username }
+            registry.add("spring.datasource.password") { postgres.password }
+            registry.add("spring.data.redis.host") { valkey.host }
+            registry.add("spring.data.redis.port") { valkey.getMappedPort(6379) }
+        }
+    }
+
+    @Autowired private lateinit var mockMvc: MockMvc
+    @Autowired private lateinit var stringRedisTemplate: StringRedisTemplate
+    @Autowired private lateinit var objectMapper: ObjectMapper
+    @Autowired private lateinit var reservationRepository: ReservationRepository
+    @Autowired private lateinit var reservationSeatRepository: ReservationSeatRepository
+
+    @SpykBean private lateinit var redissonClient: RedissonClient
+    @MockkBean private lateinit var eventServiceClient: EventServiceClient
+
+    private val userId = UUID.randomUUID()
+    private val scheduleId = UUID.randomUUID()
+    private val eventId = UUID.randomUUID()
+    private val oldSeatId = UUID.randomUUID()
+    private val newSeatId = UUID.randomUUID()
+    private val validToken = "test-queue-token-${UUID.randomUUID()}"
+
+    private lateinit var rLock: RLock
+    private lateinit var multiLock: RLock
+
+    @BeforeEach
+    fun setUp() {
+        stringRedisTemplate.connectionFactory?.connection?.serverCommands()?.flushAll()
+        reservationRepository.deleteAll()
+
+        rLock = mockk()
+        multiLock = mockk()
+        every { redissonClient.getLock(any<String>()) } returns rLock
+        every { redissonClient.getMultiLock(*varargAny { true }) } returns multiLock
+        every { rLock.tryLock(any<Long>(), any<Long>(), any()) } returns true
+        every { rLock.isHeldByCurrentThread } returns true
+        justRun { rLock.unlock() }
+        every { multiLock.tryLock(any<Long>(), any<Long>(), any()) } returns true
+        every { multiLock.isHeldByCurrentThread } returns true
+        justRun { multiLock.unlock() }
+
+        every { eventServiceClient.getSoldSeats(scheduleId) } returns
+            EventServiceClient.SoldSeatsResponse(scheduleId, emptyList(), 0)
+        every { eventServiceClient.getSeatDetails(scheduleId, any()) } answers {
+            val requestedIds = arg<List<UUID>>(1)
+            EventServiceClient.SeatDetailsResponse(
+                scheduleId = scheduleId,
+                eventId = eventId,
+                seats = requestedIds.map { id ->
+                    EventServiceClient.SeatDetailsResponse.SeatDetail(
+                        seatId = id,
+                        seatNumber = "A-${id.toString().take(4)}",
+                        grade = "VIP",
+                        price = BigDecimal("150000")
+                    )
+                }
+            )
+        }
+    }
+
+    private fun seedQueueToken(token: String = validToken) {
+        stringRedisTemplate.opsForValue()
+            .set("queue:token:$token", """{"userId":"$userId","scheduleId":"$scheduleId","issuedAt":"1234567890"}""")
+    }
+
+    private fun holdSeat(seatId: UUID = oldSeatId): String {
+        val body = objectMapper.writeValueAsString(mapOf("scheduleId" to scheduleId, "seatIds" to listOf(seatId)))
+        val result = mockMvc.perform(
+            post("/reservations/hold")
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+                .header("X-Queue-Token", validToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+        ).andExpect(status().isCreated).andReturn()
+        return objectMapper.readTree(result.response.contentAsString)["reservationId"].asText()
+    }
+
+    private fun changeSeatsBody(seatIds: List<UUID>) =
+        objectMapper.writeValueAsString(mapOf("newSeatIds" to seatIds))
+
+    // ─────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("성공 시나리오")
+    inner class Success {
+
+        @Test
+        @DisplayName("좌석 변경 시 200과 PENDING 상태, 신규 총액을 반환한다")
+        fun returns200WithUpdatedAmount() {
+            seedQueueToken()
+            val reservationId = holdSeat()
+
+            mockMvc.perform(
+                put("/reservations/hold/$reservationId")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(changeSeatsBody(listOf(newSeatId)))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.reservationId").value(reservationId))
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andExpect(jsonPath("$.newTotalAmount").value(150000))
+                .andExpect(jsonPath("$.holdExpiresAt").isNotEmpty)
+        }
+
+        @Test
+        @DisplayName("변경 후 Redis hold_seats SET에 기존 좌석이 제거되고 신규 좌석이 추가된다")
+        fun updatesHoldSeatsSetCorrectly() {
+            seedQueueToken()
+            val reservationId = holdSeat()
+
+            // 선점 후 Redis 상태: oldSeatId 존재
+            stringRedisTemplate.opsForSet().members("hold_seats:$scheduleId")!!
+                .shouldContain(oldSeatId.toString())
+
+            mockMvc.perform(
+                put("/reservations/hold/$reservationId")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(changeSeatsBody(listOf(newSeatId)))
+            ).andExpect(status().isOk)
+
+            val members = stringRedisTemplate.opsForSet().members("hold_seats:$scheduleId")!!
+            members.shouldContain(newSeatId.toString())
+            members.shouldNotContain(oldSeatId.toString())
+        }
+
+        @Test
+        @DisplayName("변경 후 DB reservation_seats가 신규 좌석으로 교체된다")
+        fun updatesReservationSeatsInDb() {
+            seedQueueToken()
+            val reservationId = holdSeat()
+            val resId = UUID.fromString(reservationId)
+
+            mockMvc.perform(
+                put("/reservations/hold/$reservationId")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(changeSeatsBody(listOf(newSeatId)))
+            ).andExpect(status().isOk)
+
+            val seats = reservationSeatRepository.findByReservationId(resId)
+            seats.size shouldBe 1
+            seats[0].seatId shouldBe newSeatId
+        }
+
+        @Test
+        @DisplayName("일부 좌석 유지 + 일부 변경 시 유지 좌석은 기존 스냅샷을 보존한다")
+        fun partialChangeKeepsOldSeatSnapshot() {
+            seedQueueToken()
+            val keepSeatId = UUID.randomUUID()
+            val anotherNewSeatId = UUID.randomUUID()
+
+            // 2개 좌석 선점 (keepSeatId, oldSeatId)
+            val body2 = objectMapper.writeValueAsString(
+                mapOf("scheduleId" to scheduleId, "seatIds" to listOf(keepSeatId, oldSeatId))
+            )
+            val holdResult = mockMvc.perform(
+                post("/reservations/hold")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body2)
+            ).andExpect(status().isCreated).andReturn()
+            val reservationId = objectMapper.readTree(holdResult.response.contentAsString)["reservationId"].asText()
+
+            // keepSeatId 유지 + anotherNewSeatId 신규
+            mockMvc.perform(
+                put("/reservations/hold/$reservationId")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(changeSeatsBody(listOf(keepSeatId, anotherNewSeatId)))
+            ).andExpect(status().isOk)
+
+            val seats = reservationSeatRepository.findByReservationId(UUID.fromString(reservationId))
+            seats.map { it.seatId }.shouldContain(keepSeatId)
+            seats.map { it.seatId }.shouldContain(anotherNewSeatId)
+            seats.map { it.seatId }.shouldNotContain(oldSeatId)
+            seats.size shouldBe 2
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("검증 실패")
+    inner class ValidationFailure {
+
+        @Test
+        @DisplayName("존재하지 않는 예매 ID면 404 RESERVATION_NOT_FOUND를 반환한다")
+        fun returns404WhenReservationNotFound() {
+            seedQueueToken()
+
+            mockMvc.perform(
+                put("/reservations/hold/${UUID.randomUUID()}")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(changeSeatsBody(listOf(newSeatId)))
+            )
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.code").value("RESERVATION_NOT_FOUND"))
+        }
+
+        @Test
+        @DisplayName("QueueToken이 없으면 401 QUEUE_TOKEN_EXPIRED를 반환한다")
+        fun returns401WhenTokenMissing() {
+            seedQueueToken()
+            val reservationId = holdSeat()
+
+            // 토큰 제거
+            stringRedisTemplate.delete("queue:token:$validToken")
+
+            mockMvc.perform(
+                put("/reservations/hold/$reservationId")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(changeSeatsBody(listOf(newSeatId)))
+            )
+                .andExpect(status().isUnauthorized)
+                .andExpect(jsonPath("$.code").value("QUEUE_TOKEN_EXPIRED"))
+        }
+
+        @Test
+        @DisplayName("이미 HOLD된 신규 좌석으로 변경하면 409 SEAT_ALREADY_HELD를 반환한다")
+        fun returns409WhenNewSeatAlreadyHeld() {
+            seedQueueToken()
+            val reservationId = holdSeat(oldSeatId)
+
+            // newSeatId를 다른 사용자가 이미 선점 — hold_seats SET에 직접 삽입
+            stringRedisTemplate.opsForSet().add("hold_seats:$scheduleId", newSeatId.toString())
+
+            mockMvc.perform(
+                put("/reservations/hold/$reservationId")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(changeSeatsBody(listOf(newSeatId)))
+            )
+                .andExpect(status().isConflict)
+                .andExpect(jsonPath("$.code").value("SEAT_ALREADY_HELD"))
+        }
+
+        @Test
+        @DisplayName("newSeatIds가 비어있으면 400을 반환한다")
+        fun returns400WhenNewSeatIdsEmpty() {
+            seedQueueToken()
+            val reservationId = holdSeat()
+
+            mockMvc.perform(
+                put("/reservations/hold/$reservationId")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(changeSeatsBody(emptyList()))
+            ).andExpect(status().isBadRequest)
+        }
+
+        @Test
+        @DisplayName("newSeatIds가 5개면 400 MAX_SEATS_EXCEEDED를 반환한다")
+        fun returns400WhenFiveSeatsRequested() {
+            seedQueueToken()
+            val reservationId = holdSeat()
+
+            mockMvc.perform(
+                put("/reservations/hold/$reservationId")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .header("X-Queue-Token", validToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(changeSeatsBody((1..5).map { UUID.randomUUID() }))
+            ).andExpect(status().isBadRequest)
+        }
+    }
+}

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/ChangeSeatsIntegrationTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/ChangeSeatsIntegrationTest.kt
@@ -261,6 +261,9 @@ class ChangeSeatsIntegrationTest {
             seats.map { it.seatId }.shouldContain(anotherNewSeatId)
             seats.map { it.seatId }.shouldNotContain(oldSeatId)
             seats.size shouldBe 2
+
+            val reservation = reservationRepository.findById(UUID.fromString(reservationId)).get()
+            reservation.totalAmount shouldBe BigDecimal("300000")
         }
     }
 


### PR DESCRIPTION
## Summary
- REQ-RSV-002: PENDING 상태 예매의 선점 좌석을 변경하는 API 구현
- Redisson MultiLock(기존 + 신규 좌석 전체 정렬), Redis hold_seats SET 갱신(afterCommit 콜백), TOCTOU 재검증 포함

## Changes

### Reservation Service
- \`ReservationController\` — \`PUT /reservations/hold/{reservationId}\` 엔드포인트 추가
- \`ReservationService\` — 좌석 변경 프로세스 구현
  - \`changeSeats()\`: 기존 + 신규 좌석 전체 정렬 MultiLock으로 데드락 방지
  - 신규 좌석만 \`hold_seats\` SET 중복 확인 (기존 좌석 오탐 방지)
  - \`deleteAllByReservationId\` + \`saveAll\`로 DB reservation_seats 교체
  - \`afterCommit\` 콜백으로 Redis SREM(해제) + Lua SADD+EXPIRE(추가) — DB 롤백 시 오염 방지
  - 락 획득 후 \`freshReservation\` 재조회로 TOCTOU 방지
  - \`withSeatLocks()\`, \`registerAfterCommit()\`, \`buildReservationSeat()\` 등 공통 헬퍼 추출 (holdSeats에도 적용)
  - \`hold_expires_at\` 변경 시 갱신 (선점 시간 리셋)
- \`RedisKeys\` — Redis 키 생성 함수 중앙화 (\`userHoldLock\`, \`seatHold\`, \`holdSeatsSet\`, \`queueToken\`)
- \`ReservationDto\` — \`ChangeSeatsRequest\` / \`ChangeSeatsResponse\` 추가
- \`Reservation\` — \`updateTotalAmount()\`, \`updateHoldExpiresAt()\` 메서드 추가 (\`totalAmount\`, \`holdExpiresAt\` val→var)
- \`ReservationRepository\` — \`findByUserIdAndScheduleIdAndStatusExcluding()\` JPQL 쿼리 추가 (좌석 수 한도 검증 시 현재 예매 제외)
- \`ReservationSeatRepository\` — \`deleteAllByReservationId()\` \`@Modifying\` 쿼리 추가
- \`ChangeSeatsIntegrationTest\` — TestContainers 기반 통합 테스트 (성공/검증 실패 시나리오)
- \`ChangeSeatsConcurrencyTest\` — 동시 변경 요청 및 변경+선점 충돌 시나리오 동시성 테스트

### Common
- \`ErrorCode.RESERVATION_NOT_CHANGEABLE\` 추가 (PENDING이 아닌 예매 변경 시도 시 \`409 Conflict\`)

## Test plan
- [x] \`ChangeSeatsIntegrationTest\` — 좌석 변경 성공, Redis SET 갱신, DB 교체, 일부 유지 케이스, 각종 검증 실패(404/401/409/400) 통합 테스트
- [x] \`ChangeSeatsConcurrencyTest\` — 동일 예매 동시 변경 시 1건만 성공(409), 변경+다른 사용자 선점 충돌 시 1건만 성공 검증
- [x] 기존 \`HoldSeatsIntegrationTest\` / \`HoldSeatsConcurrencyTest\` 회귀 없음

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now change seats for pending reservations, with support for partial seat modifications.
  * Added validation to ensure only reservations in pending state can have seats modified.

* **Tests**
  * Added comprehensive integration tests for seat-change functionality and concurrency scenarios.

* **Chores**
  * Updated local environment configuration for database and external service endpoints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paircoders/ticket-queue/pull/221)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->