### PR TITLE
chore: [Docker] 로컬 테스트용 초기 데이터(Seed Data) 스크립트 작성

### DIFF
--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/EventController.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/EventController.kt
@@ -71,12 +71,6 @@ class EventController(
         return eventService.getEvent(eventId)
     }
 
-    /** 회차별 좌석 정보 조회 (REQ-EVT-006) - 공개 API, 등급별 그룹핑 + Redis 캐싱 */
-    @GetMapping("/schedules/{scheduleId}/seats")
-    fun getSeats(@PathVariable scheduleId: UUID): SeatDto.SeatsResponse {
-        return seatService.getSeats(scheduleId)
-    }
-
     /** 공연 수정 (REQ-EVT-002) - ADMIN 권한 필요, 판매 후 artist 변경 불가 */
     @PatchMapping("/{eventId}")
     fun updateEvent(

--- a/docker/db_init/6_seed_data.sql
+++ b/docker/db_init/6_seed_data.sql
@@ -18,7 +18,6 @@
 --   schedule-2(UPCOMING) : a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a31
 --   schedule-3(ENDED)    : a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a32
 --   user-a    : b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b01
---   user-b    : b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b02
 --   res-1(PENDING)    : c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c01
 --   res-2(CONFIRMED)  : c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c02
 --   res-3(CANCELLED)  : c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c03
@@ -126,14 +125,14 @@ SELECT
 FROM generate_series(1, 20) AS n
 ON CONFLICT (event_schedule_id, seat_number) DO NOTHING;
 
--- B행: S 120,000원 (B-1·B-2 SOLD, 나머지 AVAILABLE)
+-- B행: S 120,000원 (B-1 SOLD, 나머지 AVAILABLE)
 INSERT INTO event_service.seats (event_schedule_id, seat_number, grade, price, status)
 SELECT
     'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30',
     'B-' || n,
     'S',
     120000,
-    CASE WHEN n <= 2 THEN 'SOLD' ELSE 'AVAILABLE' END
+    CASE WHEN n = 1 THEN 'SOLD' ELSE 'AVAILABLE' END
 FROM generate_series(1, 20) AS n
 ON CONFLICT (event_schedule_id, seat_number) DO NOTHING;
 
@@ -190,7 +189,7 @@ VALUES
     (
         -- res-2: CONFIRMED (결제 완료, B-1 좌석 SOLD)
         'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c02',
-        'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b02',
+        'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b01',
         'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30',
         'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a20',
         'CONFIRMED', 120000, NOW() + INTERVAL '5 minutes',
@@ -204,7 +203,7 @@ VALUES
         'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30',
         'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a20',
         'CANCELLED', 70000, NOW() - INTERVAL '1 hour',
-        NULL, NULL
+        NULL, 'd0eebc99-9c0b-4ef8-bb6d-6bb9bd380d02'
     )
 ON CONFLICT (id) DO NOTHING;
 
@@ -253,7 +252,7 @@ VALUES
         -- pay-1: SUCCESS (res-2)
         'd0eebc99-9c0b-4ef8-bb6d-6bb9bd380d01',
         'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c02',
-        'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b02',
+        'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b01',
         'pm-seed-test-001',
         120000, 'CARD', 'SUCCESS',
         'tx-seed-test-001',
@@ -289,7 +288,7 @@ VALUES
         'Payment',
         'd0eebc99-9c0b-4ef8-bb6d-6bb9bd380d01',
         'PaymentSuccess',
-        '{"paymentId":"d0eebc99-9c0b-4ef8-bb6d-6bb9bd380d01","reservationId":"c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c02","userId":"b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b02","amount":120000}'::jsonb,
+        '{"paymentId":"d0eebc99-9c0b-4ef8-bb6d-6bb9bd380d01","reservationId":"c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c02","userId":"b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b01","amount":120000}'::jsonb,
         true,
         NOW() - INTERVAL '59 minutes'
     ),

--- a/docker/db_init/6_seed_data.sql
+++ b/docker/db_init/6_seed_data.sql
@@ -1,0 +1,318 @@
+-- ============================================================
+-- Local Test Seed Data
+-- ============================================================
+-- docker-compose up 시 DDL 스크립트(1~5번) 이후 자동 실행됨.
+-- docker-compose down -v && up -d 반복 실행에도 안전하도록
+-- INSERT ... ON CONFLICT DO NOTHING 사용.
+--
+-- User Service 데이터는 AES 암호화 복잡성으로 제외.
+-- user_id는 아래 고정 UUID 사용. 실제 테스트 시 API로 가입한
+-- 사용자의 UUID로 UPDATE하거나 그대로 참조해도 무방.
+--
+-- 고정 UUID 참조표:
+--   venue     : a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+--   hall      : a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+--   event(OPEN)       : a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a20
+--   event(PREPARING)  : a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a21
+--   schedule-1(ONGOING)  : a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30
+--   schedule-2(UPCOMING) : a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a31
+--   schedule-3(ENDED)    : a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a32
+--   user-a    : b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b01
+--   user-b    : b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b02
+--   res-1(PENDING)    : c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c01
+--   res-2(CONFIRMED)  : c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c02
+--   res-3(CANCELLED)  : c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c03
+--   pay-1(SUCCESS)    : d0eebc99-9c0b-4ef8-bb6d-6bb9bd380d01
+--   pay-2(FAILED)     : d0eebc99-9c0b-4ef8-bb6d-6bb9bd380d02
+--   outbox-1(published)   : e0eebc99-9c0b-4ef8-bb6d-6bb9bd380e01
+--   outbox-2(unpublished) : e0eebc99-9c0b-4ef8-bb6d-6bb9bd380e02
+-- ============================================================
+
+
+-- ============================================================
+-- 1. Event Service
+-- ============================================================
+
+INSERT INTO event_service.venues (id, name, address, city)
+VALUES (
+    'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+    '잠실 주경기장',
+    '서울특별시 송파구 올림픽로 25',
+    '서울'
+) ON CONFLICT (id) DO NOTHING;
+
+
+INSERT INTO event_service.halls (id, venue_id, name, capacity, seat_template)
+VALUES (
+    'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12',
+    'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+    '메인홀',
+    5000,
+    '{"rows":["A","B","C","D","E"],"seatsPerRow":20,"gradeMapping":{"A":"VIP","B":"S","C":"A","D":"B","E":"B"}}'
+) ON CONFLICT (id) DO NOTHING;
+
+
+INSERT INTO event_service.events (id, title, artist, description, venue_id, hall_id, status)
+VALUES
+    (
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a20',
+        '2026 K-POP 월드 투어 서울',
+        'STELLAR',
+        '최정상 K-POP 아티스트의 단독 콘서트.',
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12',
+        'OPEN'
+    ),
+    (
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a21',
+        '2026 여름 페스티벌',
+        'NOVA',
+        '준비 중인 신규 공연입니다.',
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12',
+        'PREPARING'
+    )
+ON CONFLICT (id) DO NOTHING;
+
+
+-- schedule-1: 현재 판매 중 (ONGOING) — 공연은 30일 후
+-- schedule-2: 7일 후부터 판매 예정 (UPCOMING) — 공연은 31일 후
+-- schedule-3: 판매 종료된 지난 회차 (ENDED) — 공연은 30일 전
+INSERT INTO event_service.event_schedules
+    (id, event_id, play_sequence, event_start_at, event_end_at, sale_start_at, sale_end_at, status)
+VALUES
+    (
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30',
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a20',
+        1,
+        NOW() + INTERVAL '30 days',
+        NOW() + INTERVAL '30 days' + INTERVAL '3 hours',
+        NOW() - INTERVAL '30 days',
+        NOW() + INTERVAL '29 days',
+        'ONGOING'
+    ),
+    (
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a31',
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a20',
+        2,
+        NOW() + INTERVAL '31 days',
+        NOW() + INTERVAL '31 days' + INTERVAL '3 hours',
+        NOW() + INTERVAL '7 days',
+        NOW() + INTERVAL '30 days',
+        'UPCOMING'
+    ),
+    (
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a32',
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a20',
+        3,
+        NOW() - INTERVAL '30 days',
+        NOW() - INTERVAL '30 days' + INTERVAL '3 hours',
+        NOW() - INTERVAL '60 days',
+        NOW() - INTERVAL '31 days',
+        'ENDED'
+    )
+ON CONFLICT (id) DO NOTHING;
+
+
+-- schedule-1 좌석 100개 (A~E행 각 20개)
+-- A행: VIP 150,000원 (전체 AVAILABLE)
+INSERT INTO event_service.seats (event_schedule_id, seat_number, grade, price, status)
+SELECT
+    'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30',
+    'A-' || n,
+    'VIP',
+    150000,
+    'AVAILABLE'
+FROM generate_series(1, 20) AS n
+ON CONFLICT (event_schedule_id, seat_number) DO NOTHING;
+
+-- B행: S 120,000원 (B-1·B-2 SOLD, 나머지 AVAILABLE)
+INSERT INTO event_service.seats (event_schedule_id, seat_number, grade, price, status)
+SELECT
+    'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30',
+    'B-' || n,
+    'S',
+    120000,
+    CASE WHEN n <= 2 THEN 'SOLD' ELSE 'AVAILABLE' END
+FROM generate_series(1, 20) AS n
+ON CONFLICT (event_schedule_id, seat_number) DO NOTHING;
+
+-- C행: A등급 99,000원 (전체 AVAILABLE)
+INSERT INTO event_service.seats (event_schedule_id, seat_number, grade, price, status)
+SELECT
+    'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30',
+    'C-' || n,
+    'A',
+    99000,
+    'AVAILABLE'
+FROM generate_series(1, 20) AS n
+ON CONFLICT (event_schedule_id, seat_number) DO NOTHING;
+
+-- D행: B등급 70,000원 (전체 AVAILABLE)
+INSERT INTO event_service.seats (event_schedule_id, seat_number, grade, price, status)
+SELECT
+    'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30',
+    'D-' || n,
+    'B',
+    70000,
+    'AVAILABLE'
+FROM generate_series(1, 20) AS n
+ON CONFLICT (event_schedule_id, seat_number) DO NOTHING;
+
+-- E행: B등급 70,000원 (전체 AVAILABLE)
+INSERT INTO event_service.seats (event_schedule_id, seat_number, grade, price, status)
+SELECT
+    'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30',
+    'E-' || n,
+    'B',
+    70000,
+    'AVAILABLE'
+FROM generate_series(1, 20) AS n
+ON CONFLICT (event_schedule_id, seat_number) DO NOTHING;
+
+
+-- ============================================================
+-- 2. Reservation Service
+-- ============================================================
+
+INSERT INTO reservation_service.reservations
+    (id, user_id, schedule_id, event_id, status, total_amount, hold_expires_at, ticket_number, payment_id)
+VALUES
+    (
+        -- res-1: PENDING (결제 대기 중, A-3 좌석 hold)
+        'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c01',
+        'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b01',
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30',
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a20',
+        'PENDING', 150000, NOW() + INTERVAL '5 minutes',
+        NULL, NULL
+    ),
+    (
+        -- res-2: CONFIRMED (결제 완료, B-1 좌석 SOLD)
+        'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c02',
+        'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b02',
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30',
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a20',
+        'CONFIRMED', 120000, NOW() + INTERVAL '5 minutes',
+        'T20260601-TEST001',
+        'd0eebc99-9c0b-4ef8-bb6d-6bb9bd380d01'
+    ),
+    (
+        -- res-3: CANCELLED (결제 실패로 취소, D-1 좌석 반환)
+        'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c03',
+        'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b01',
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30',
+        'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a20',
+        'CANCELLED', 70000, NOW() - INTERVAL '1 hour',
+        NULL, NULL
+    )
+ON CONFLICT (id) DO NOTHING;
+
+
+-- seat_id는 event_service.seats를 참조 (직접 FK 없음, seat_number로 조회)
+INSERT INTO reservation_service.reservation_seats
+    (reservation_id, seat_id, seat_number, grade, price)
+SELECT
+    'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c01',
+    s.id, 'A-3', 'VIP', 150000
+FROM event_service.seats s
+WHERE s.event_schedule_id = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30'
+  AND s.seat_number = 'A-3'
+ON CONFLICT (reservation_id, seat_id) DO NOTHING;
+
+INSERT INTO reservation_service.reservation_seats
+    (reservation_id, seat_id, seat_number, grade, price)
+SELECT
+    'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c02',
+    s.id, 'B-1', 'S', 120000
+FROM event_service.seats s
+WHERE s.event_schedule_id = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30'
+  AND s.seat_number = 'B-1'
+ON CONFLICT (reservation_id, seat_id) DO NOTHING;
+
+INSERT INTO reservation_service.reservation_seats
+    (reservation_id, seat_id, seat_number, grade, price)
+SELECT
+    'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c03',
+    s.id, 'D-1', 'B', 70000
+FROM event_service.seats s
+WHERE s.event_schedule_id = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30'
+  AND s.seat_number = 'D-1'
+ON CONFLICT (reservation_id, seat_id) DO NOTHING;
+
+
+-- ============================================================
+-- 3. Payment Service
+-- ============================================================
+
+INSERT INTO payment_service.payments
+    (id, reservation_id, user_id, payment_key, amount, payment_method, status,
+     portone_transaction_id, portone_response, failure_reason, paid_at)
+VALUES
+    (
+        -- pay-1: SUCCESS (res-2)
+        'd0eebc99-9c0b-4ef8-bb6d-6bb9bd380d01',
+        'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c02',
+        'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b02',
+        'pm-seed-test-001',
+        120000, 'CARD', 'SUCCESS',
+        'tx-seed-test-001',
+        '{"code":"0","message":"success","transactionId":"tx-seed-test-001","amount":120000,"status":"PAID","method":"CARD"}'::jsonb,
+        NULL,
+        NOW() - INTERVAL '1 hour'
+    ),
+    (
+        -- pay-2: FAILED (res-3)
+        'd0eebc99-9c0b-4ef8-bb6d-6bb9bd380d02',
+        'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c03',
+        'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b01',
+        'pm-seed-test-002',
+        70000, 'CARD', 'FAILED',
+        NULL, NULL,
+        '카드 한도 초과',
+        NULL
+    )
+ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================
+-- 4. Common Schema
+-- ============================================================
+
+-- outbox-1: PaymentSuccess (발행 완료)
+-- outbox-2: ReservationCancelled (미발행 — Poller 동작 테스트용)
+INSERT INTO common.outbox_events
+    (id, aggregate_type, aggregate_id, event_type, payload, published, published_at)
+VALUES
+    (
+        'e0eebc99-9c0b-4ef8-bb6d-6bb9bd380e01',
+        'Payment',
+        'd0eebc99-9c0b-4ef8-bb6d-6bb9bd380d01',
+        'PaymentSuccess',
+        '{"paymentId":"d0eebc99-9c0b-4ef8-bb6d-6bb9bd380d01","reservationId":"c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c02","userId":"b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b02","amount":120000}'::jsonb,
+        true,
+        NOW() - INTERVAL '59 minutes'
+    ),
+    (
+        'e0eebc99-9c0b-4ef8-bb6d-6bb9bd380e02',
+        'Reservation',
+        'c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c03',
+        'ReservationCancelled',
+        '{"reservationId":"c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c03","userId":"b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b01","scheduleId":"a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30","reason":"payment_failed"}'::jsonb,
+        false,
+        NULL
+    )
+ON CONFLICT (id) DO NOTHING;
+
+
+-- reservation-service가 PaymentSuccess 이벤트 처리 완료한 기록
+INSERT INTO common.processed_events
+    (event_id, consumer_service, aggregate_id, event_type)
+VALUES
+    (
+        'e0eebc99-9c0b-4ef8-bb6d-6bb9bd380e01',
+        'reservation',
+        'd0eebc99-9c0b-4ef8-bb6d-6bb9bd380d01',
+        'PaymentSuccess'
+    )
+ON CONFLICT (event_id, consumer_service) DO NOTHING;

--- a/docker/scripts/valkey_seed.sh
+++ b/docker/scripts/valkey_seed.sh
@@ -34,7 +34,7 @@ if [ -f "docker/secrets/valkey_pw.txt" ]; then
 fi
 
 if [ -n "$VALKEY_PW" ]; then
-    CLI="docker exec $CONTAINER valkey-cli --no-auth-warning -a $VALKEY_PW"
+    CLI="docker exec -e REDISCLI_AUTH=$VALKEY_PW $CONTAINER valkey-cli --no-auth-warning"
 else
     CLI="docker exec $CONTAINER valkey-cli"
 fi
@@ -63,10 +63,21 @@ $CLI SADD "queue:active-schedules" "$SCHEDULE_ID"
 echo "[3/4] 좌석 선점 hold 키 삽입 (TTL 300s)..."
 
 DB_CONTAINER="ticket-postgres"
-SEAT_ID=$(docker exec "$DB_CONTAINER" psql -U ticket -d ticket_queue -t -c \
+if ! docker exec "$DB_CONTAINER" pg_isready -U ticket -d ticket_queue -q; then
+    echo "[ERROR] DB 컨테이너($DB_CONTAINER)에 연결할 수 없습니다." >&2
+    exit 1
+fi
+
+SEAT_ID_RAW=$(docker exec "$DB_CONTAINER" psql -U ticket -d ticket_queue -t -c \
     "SELECT id FROM event_service.seats \
-     WHERE event_schedule_id = '${SCHEDULE_ID}' AND seat_number = 'A-3';" \
-    2>/dev/null | tr -d ' \n')
+     WHERE event_schedule_id = '${SCHEDULE_ID}' AND seat_number = 'A-3';")
+PSQL_EXIT=$?
+SEAT_ID=$(echo "$SEAT_ID_RAW" | tr -d ' \n')
+
+if [ $PSQL_EXIT -ne 0 ]; then
+    echo "[ERROR] DB 쿼리 실패 (컨테이너: $DB_CONTAINER, SCHEDULE_ID: $SCHEDULE_ID)" >&2
+    exit 1
+fi
 
 if [ -n "$SEAT_ID" ]; then
     $CLI SET "seat:hold:${SCHEDULE_ID}:${SEAT_ID}" "$USER_A_ID" EX 300

--- a/docker/scripts/valkey_seed.sh
+++ b/docker/scripts/valkey_seed.sh
@@ -79,10 +79,11 @@ if [ $PSQL_EXIT -ne 0 ]; then
     exit 1
 fi
 
+HOLD_TTL=300
 if [ -n "$SEAT_ID" ]; then
-    $CLI SET "seat:hold:${SCHEDULE_ID}:${SEAT_ID}" "$USER_A_ID" EX 300
+    $CLI SET "seat:hold:${SCHEDULE_ID}:${SEAT_ID}" "$USER_A_ID" EX $HOLD_TTL
     $CLI SADD "hold_seats:${SCHEDULE_ID}" "$SEAT_ID"
-    $CLI EXPIRE "hold_seats:${SCHEDULE_ID}" 600
+    $CLI EXPIRE "hold_seats:${SCHEDULE_ID}" $HOLD_TTL
     echo "    A-3 좌석 hold 완료 (seat_id: ${SEAT_ID})"
 else
     echo "    [SKIP] A-3 seat_id를 DB에서 찾을 수 없습니다. DB seed가 완료됐는지 확인하세요."

--- a/docker/scripts/valkey_seed.sh
+++ b/docker/scripts/valkey_seed.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# ============================================================
+# Valkey(Redis) 로컬 테스트용 시드 데이터 삽입 스크립트
+# ============================================================
+# 사전 조건:
+#   1. docker-compose up -d 로 인프라가 기동된 상태
+#   2. docker/db_init/6_seed_data.sql 이 적용된 상태 (DB seed 완료)
+#
+# 실행 방법:
+#   bash docker/scripts/valkey_seed.sh
+#
+# 삽입되는 데이터:
+#   - schedule-1 대기열 (queue:a0eebc99-...-a30)
+#   - user-a Queue Token (queue:token:{token})
+#   - A-3 좌석 선점 hold (seat:hold:{scheduleId}:{seatId})
+#   - hold_seats SET
+#
+# 참고: seat_id(A-3)는 DB에서 동적으로 조회합니다.
+#       DB seed가 완료되지 않은 상태에서 실행하면 A-3 hold는 스킵됩니다.
+# ============================================================
+
+set -e
+
+CONTAINER="ticket-valkey"
+SCHEDULE_ID="a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a30"
+USER_A_ID="b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b01"
+USER_B_ID="b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b02"
+TOKEN_USER_A="qr-seed-token-user-a-001"
+
+# Valkey 비밀번호 읽기 (secrets 파일이 없으면 빈 값으로 진행)
+VALKEY_PW=""
+if [ -f "docker/secrets/valkey_pw.txt" ]; then
+    VALKEY_PW=$(cat docker/secrets/valkey_pw.txt)
+fi
+
+if [ -n "$VALKEY_PW" ]; then
+    CLI="docker exec $CONTAINER valkey-cli --no-auth-warning -a $VALKEY_PW"
+else
+    CLI="docker exec $CONTAINER valkey-cli"
+fi
+
+echo "=== Valkey 시드 데이터 삽입 시작 ==="
+
+# ── 1. schedule-1 대기열 (Sorted Set)
+# Score: Unix timestamp (진입 순서 보장)
+echo "[1/4] 대기열(queue:${SCHEDULE_ID}) 삽입..."
+NOW_TS=$(date +%s)
+$CLI ZADD "queue:${SCHEDULE_ID}" \
+    $((NOW_TS - 60)) "$USER_A_ID" \
+    $((NOW_TS - 30)) "$USER_B_ID"
+
+# ── 2. Queue Token (user-a 전용, TTL 600초)
+echo "[2/4] Queue Token 삽입 (TTL 600s)..."
+TOKEN_PAYLOAD="{\"userId\":\"${USER_A_ID}\",\"scheduleId\":\"${SCHEDULE_ID}\",\"type\":\"RESERVATION\",\"issuedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}"
+$CLI SET "queue:token:${TOKEN_USER_A}" "$TOKEN_PAYLOAD" EX 600
+$CLI SET "queue:user-token:${USER_A_ID}" "$TOKEN_USER_A" EX 600
+$CLI SET "queue:active:${USER_A_ID}" "$SCHEDULE_ID" EX 600
+
+# ── 3. 활성 schedule SET
+$CLI SADD "queue:active-schedules" "$SCHEDULE_ID"
+
+# ── 4. A-3 좌석 선점 hold (seat_id는 DB에서 조회)
+echo "[3/4] 좌석 선점 hold 키 삽입 (TTL 300s)..."
+
+DB_CONTAINER="ticket-postgres"
+SEAT_ID=$(docker exec "$DB_CONTAINER" psql -U ticket -d ticket_queue -t -c \
+    "SELECT id FROM event_service.seats \
+     WHERE event_schedule_id = '${SCHEDULE_ID}' AND seat_number = 'A-3';" \
+    2>/dev/null | tr -d ' \n')
+
+if [ -n "$SEAT_ID" ]; then
+    $CLI SET "seat:hold:${SCHEDULE_ID}:${SEAT_ID}" "$USER_A_ID" EX 300
+    $CLI SADD "hold_seats:${SCHEDULE_ID}" "$SEAT_ID"
+    $CLI EXPIRE "hold_seats:${SCHEDULE_ID}" 600
+    echo "    A-3 좌석 hold 완료 (seat_id: ${SEAT_ID})"
+else
+    echo "    [SKIP] A-3 seat_id를 DB에서 찾을 수 없습니다. DB seed가 완료됐는지 확인하세요."
+fi
+
+# ── 5. 결과 확인
+echo ""
+echo "[4/4] 삽입 결과 확인..."
+echo "--- 대기열 (queue:${SCHEDULE_ID}) ---"
+$CLI ZRANGE "queue:${SCHEDULE_ID}" 0 -1 WITHSCORES
+
+echo "--- Queue Token ---"
+$CLI GET "queue:token:${TOKEN_USER_A}"
+
+echo "--- hold_seats:${SCHEDULE_ID} ---"
+$CLI SMEMBERS "hold_seats:${SCHEDULE_ID}"
+
+echo ""
+echo "=== Valkey 시드 데이터 삽입 완료 ==="


### PR DESCRIPTION
## Summary
- `docker-compose up -d` 이후 즉시 의미 있는 상태에서 테스트를 시작할 수 있도록 초기 데이터 삽입 스크립트 추가

## Changes
- `docker/db_init/6_seed_data.sql`: PostgreSQL 초기화 시 자동 실행 (DDL 스크립트 이후 알파벳 순)
  - Event Service: venue 1개(잠실), hall 1개, event 2개(OPEN/PREPARING), schedule 3개(ONGOING/UPCOMING/ENDED), schedule-1 좌석 100개(A~E행, B-1·B-2 SOLD)
  - Reservation Service: 예매 3건(PENDING/CONFIRMED/CANCELLED) + reservation_seats
  - Payment Service: 결제 2건(SUCCESS/FAILED)
  - Common: outbox_events 2건(발행완료/미발행), processed_events 1건
  - `INSERT ... ON CONFLICT DO NOTHING` 으로 멱등성 보장, 고정 UUID 사용
- `docker/scripts/valkey_seed.sh`: Valkey 기동 후 수동 실행하는 Redis 시드 스크립트
  - schedule-1 대기열(Sorted Set), Queue Token(TTL 600s), A-3 좌석 선점 hold 키(TTL 300s)

## Test plan
- [ ] `cd docker && docker-compose down -v && docker-compose up -d` 실행 후 DB 데이터 확인
- [ ] `bash docker/scripts/valkey_seed.sh` 실행 후 Redis 키 확인
- [ ] `docker exec -it ticket-valkey valkey-cli ZRANGE queue:{scheduleId} 0 -1 WITHSCORES`

Closes #222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a database seed that pre-populates venues, halls, events, schedules, seats, reservations, payments, and outbox/process records
  * Added a cache/queue seed that populates schedule queue entries, tokens, and seat-hold keys for testing/verification

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paircoders/ticket-queue/pull/223)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->