### PR TITLE
feat: [Payment] 결제 요청 API 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 SPRING_CLOUD_AWS_REGION_STATIC=ap-northeast-2
 SPRING_CLOUD_AWS_CREDENTIALS_ACCESS_KEY=test
 SPRING_CLOUD_AWS_CREDENTIALS_SECRET_KEY=test
-SPRING_CLOUD_AWS_SECRETSMANAGER_ENDPOINT=http://192.168.50.111:4566
+SPRING_CLOUD_AWS_SECRETSMANAGER_ENDPOINT=http://localhost:4566
 INTERNAL_API_KEY=local-dev-internal-api-key
 ```
 

--- a/backend/api-gateway/src/main/resources/application.yml
+++ b/backend/api-gateway/src/main/resources/application.yml
@@ -71,7 +71,7 @@ spring:
               order: -1
 
             - id: user-service
-              uri: ${SERVICE_URI_USER:http://192.168.50.111:8081}
+              uri: ${SERVICE_URI_USER:http://localhost:8081}
               predicates:
                 - Path=/auth/**,/users/**
               filters:
@@ -84,7 +84,7 @@ spring:
                     maxSize: 10KB
 
             - id: event-service
-              uri: ${SERVICE_URI_EVENT:http://192.168.50.111:8082}
+              uri: ${SERVICE_URI_EVENT:http://localhost:8082}
               predicates:
                 - Path=/events/**,/venues/**
               filters:
@@ -94,7 +94,7 @@ spring:
                     fallbackUri: forward:/fallback/event
 
             - id: queue-service                          # 10초 타임아웃
-              uri: ${SERVICE_URI_QUEUE:http://192.168.50.111:8083}
+              uri: ${SERVICE_URI_QUEUE:http://localhost:8083}
               predicates:
                 - Path=/queue/**
               metadata:
@@ -106,7 +106,7 @@ spring:
                     fallbackUri: forward:/fallback/queue
 
             - id: reservation-service
-              uri: ${SERVICE_URI_RESERVATION:http://192.168.50.111:8084}
+              uri: ${SERVICE_URI_RESERVATION:http://localhost:8084}
               predicates:
                 - Path=/reservations/**
               filters:
@@ -116,7 +116,7 @@ spring:
                     fallbackUri: forward:/fallback/reservation
 
             - id: payment-service                        # 60초 타임아웃
-              uri: ${SERVICE_URI_PAYMENT:http://192.168.50.111:8085}
+              uri: ${SERVICE_URI_PAYMENT:http://localhost:8085}
               predicates:
                 - Path=/payments/**
               metadata:

--- a/backend/common-core/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
+++ b/backend/common-core/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
@@ -47,6 +47,7 @@ enum class ErrorCode(
     PAYMENT_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "PAYMENT_TIMEOUT", "결제 처리 시간이 초과되었습니다."),
     PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "PAYMENT_AMOUNT_MISMATCH", "결제 금액이 일치하지 않습니다."),
     REFUND_FAILED(HttpStatus.BAD_REQUEST, "REFUND_FAILED", "환불에 실패했습니다."),
+    PORTONE_PRE_REGISTER_FAILED(HttpStatus.BAD_GATEWAY, "PORTONE_PRE_REGISTER_FAILED", "PortOne 사전 결제 등록에 실패했습니다."),
     
     // PortOne (Identity Verification)
     PORTONE_VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "PORTONE_VERIFICATION_NOT_FOUND", "본인인증 기록을 찾을 수 없습니다."),

--- a/backend/common-core/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
+++ b/backend/common-core/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
@@ -43,6 +43,8 @@ enum class ErrorCode(
     RESERVATION_IN_PROGRESS(HttpStatus.CONFLICT, "RESERVATION_IN_PROGRESS", "이미 진행 중인 선점 요청이 있습니다. 잠시 후 다시 시도해주세요."),
 
     // Payment
+    RESERVATION_NOT_PAYABLE(HttpStatus.UNPROCESSABLE_ENTITY, "RESERVATION_NOT_PAYABLE", "결제 불가 상태의 예매입니다."),
+    PAYMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "PAYMENT_ALREADY_EXISTS", "이미 진행 중이거나 완료된 결제가 존재합니다."),
     PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT_FAILED", "결제에 실패했습니다."),
     PAYMENT_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "PAYMENT_TIMEOUT", "결제 처리 시간이 초과되었습니다."),
     PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "PAYMENT_AMOUNT_MISMATCH", "결제 금액이 일치하지 않습니다."),

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/config/PortoneFeignConfig.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/config/PortoneFeignConfig.kt
@@ -1,0 +1,21 @@
+package com.ticketqueue.common.config
+
+import com.ticketqueue.common.external.portone.PortoneFeignClient
+import feign.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Bean
+
+class PortoneFeignConfig {
+
+    @Bean
+    fun portoneLoggerLevel(): Logger.Level = Logger.Level.BASIC
+
+    @Bean
+    fun portoneLogger(): Logger = object : Logger() {
+        private val log = LoggerFactory.getLogger(PortoneFeignClient::class.java)
+
+        override fun log(configKey: String, format: String, vararg args: Any) {
+            log.info("[PortOne] {}", String.format(format, *args).trim())
+        }
+    }
+}

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/config/PortoneFeignConfig.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/config/PortoneFeignConfig.kt
@@ -17,5 +17,5 @@ class PortoneFeignConfig {
     }
 
     @Bean
-    fun feignLoggerLevel(): Logger.Level = Logger.Level.FULL
+    fun feignLoggerLevel(): Logger.Level = Logger.Level.BASIC
 }

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/config/PortoneFeignConfig.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/config/PortoneFeignConfig.kt
@@ -15,4 +15,7 @@ class PortoneFeignConfig {
             log.info("[PortOne] {}", String.format(format, *args).trim())
         }
     }
+
+    @Bean
+    fun feignLoggerLevel(): Logger.Level = Logger.Level.FULL
 }

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/config/PortoneFeignConfig.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/config/PortoneFeignConfig.kt
@@ -8,9 +8,6 @@ import org.springframework.context.annotation.Bean
 class PortoneFeignConfig {
 
     @Bean
-    fun portoneLoggerLevel(): Logger.Level = Logger.Level.BASIC
-
-    @Bean
     fun portoneLogger(): Logger = object : Logger() {
         private val log = LoggerFactory.getLogger(PortoneFeignClient::class.java)
 

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneFeignClient.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneFeignClient.kt
@@ -1,12 +1,17 @@
 package com.ticketqueue.common.external.portone
 
+import com.ticketqueue.common.config.PortoneFeignConfig
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.*
 
 /**
  * PortOne V2 API 연동을 위한 Feign Client
  */
-@FeignClient(name = "portone-v2-client", url = "\${external.portone.api-url:https://api.portone.io}")
+@FeignClient(
+    name = "portone-v2-client",
+    url = "\${external.portone.api-url:https://api.portone.io}",
+    configuration = [PortoneFeignConfig::class]
+)
 interface PortoneFeignClient {
 
     /**

--- a/backend/event-service/src/main/resources/application-local.yml
+++ b/backend/event-service/src/main/resources/application-local.yml
@@ -7,13 +7,13 @@ spring:
       on-profile: local
 
   datasource:
-    url: jdbc:postgresql://192.168.50.111:5432/ticket_queue?currentSchema=event_service,common
+    url: jdbc:postgresql://localhost:5432/ticket_queue?currentSchema=event_service,common
     username: event_svc_user
     password: ${db_password}
     driver-class-name: org.postgresql.Driver
 
   kafka:
-    bootstrap-servers: 192.168.50.111:9092
+    bootstrap-servers: localhost:9092
     consumer:
       # 기본값. 각 Consumer의 실제 group-id는 @KafkaListener(groupId=...) 어노테이션이 오버라이드함.
       # - event-reservation-consumer (ReservationEventConsumer)

--- a/backend/payment-service/build.gradle.kts
+++ b/backend/payment-service/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(project(":common-web"))
 
     // Spring Boot
+    implementation(libs.spring.boot.starter.security)
     implementation(libs.spring.boot.starter.webflux)  // For WebClient
 
     // Resilience4j for circuit breaker

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/PaymentServiceApplication.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/PaymentServiceApplication.kt
@@ -1,12 +1,16 @@
 package com.ticketqueue.payment
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.runApplication
 import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication(scanBasePackages = ["com.ticketqueue.payment", "com.ticketqueue.common"])
-@EnableFeignClients
+@EnableJpaRepositories(basePackages = ["com.ticketqueue.payment.repository"])
+@EntityScan(basePackages = ["com.ticketqueue.payment.entity"])
+@EnableFeignClients(basePackages = ["com.ticketqueue.payment", "com.ticketqueue.common"])
 @EnableScheduling
 class PaymentServiceApplication
 

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/client/ReservationServiceClient.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/client/ReservationServiceClient.kt
@@ -1,0 +1,30 @@
+package com.ticketqueue.payment.client
+
+import com.ticketqueue.common.config.InternalFeignConfig
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+@FeignClient(
+    name = "reservation-service",
+    url = "\${spring.cloud.openfeign.client.config.reservation-service.url}",
+    configuration = [InternalFeignConfig::class]
+)
+interface ReservationServiceClient {
+
+    @GetMapping("/internal/reservations/{reservationId}")
+    fun getReservation(@PathVariable reservationId: UUID): ReservationDetailResponse
+
+    data class ReservationDetailResponse(
+        val reservationId: UUID,
+        val userId: UUID,
+        val scheduleId: UUID,
+        val totalAmount: BigDecimal,
+        val status: String,
+        val holdExpiresAt: LocalDateTime,
+        val seatIds: List<UUID>
+    )
+}

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/client/ReservationServiceClient.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/client/ReservationServiceClient.kt
@@ -18,6 +18,8 @@ interface ReservationServiceClient {
     @GetMapping("/internal/reservations/{reservationId}")
     fun getReservation(@PathVariable reservationId: UUID): ReservationDetailResponse
 
+    enum class ReservationStatus { PENDING, CONFIRMED, CANCELLED, EXPIRED }
+
     data class ReservationDetailResponse(
         val reservationId: UUID,
         val userId: UUID,

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/client/ReservationServiceClient.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/client/ReservationServiceClient.kt
@@ -25,7 +25,7 @@ interface ReservationServiceClient {
         val userId: UUID,
         val scheduleId: UUID,
         val totalAmount: BigDecimal,
-        val status: String,
+        val status: ReservationStatus,
         val holdExpiresAt: LocalDateTime,
         val seatIds: List<UUID>
     )

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/config/SecurityConfig.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/config/SecurityConfig.kt
@@ -1,0 +1,38 @@
+package com.ticketqueue.payment.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.security.GatewayAuthFilter
+import com.ticketqueue.common.security.SecurityErrorHandlers
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig(
+    private val objectMapper: ObjectMapper
+) {
+
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        return http
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { auth ->
+                auth
+                    .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                    .anyRequest().authenticated()
+            }
+            .exceptionHandling { exceptions ->
+                exceptions
+                    .authenticationEntryPoint(SecurityErrorHandlers.authenticationEntryPoint(objectMapper))
+                    .accessDeniedHandler(SecurityErrorHandlers.accessDeniedHandler(objectMapper))
+            }
+            .addFilterBefore(GatewayAuthFilter(), UsernamePasswordAuthenticationFilter::class.java)
+            .build()
+    }
+}

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/controller/PaymentController.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/controller/PaymentController.kt
@@ -1,0 +1,27 @@
+package com.ticketqueue.payment.controller
+
+import com.ticketqueue.payment.dto.PaymentDto.CreateRequest
+import com.ticketqueue.payment.dto.PaymentDto.CreateResponse
+import com.ticketqueue.payment.service.PaymentService
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/payments")
+class PaymentController(
+    private val paymentService: PaymentService
+) {
+
+    @PostMapping
+    fun createPayment(
+        @RequestHeader("X-User-Id") userId: UUID,
+        @RequestBody @Valid request: CreateRequest
+    ): CreateResponse {
+        return paymentService.createPayment(userId, request)
+    }
+}

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/dto/PaymentDto.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/dto/PaymentDto.kt
@@ -1,0 +1,24 @@
+package com.ticketqueue.payment.dto
+
+import com.ticketqueue.payment.entity.PaymentMethod
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
+import java.util.UUID
+
+class PaymentDto {
+
+    data class CreateRequest(
+        @field:NotNull val reservationId: UUID,
+        @field:NotNull @field:Positive val amount: BigDecimal,
+        val paymentMethod: PaymentMethod = PaymentMethod.CARD
+    )
+
+    data class CreateResponse(
+        val paymentId: UUID,
+        val amount: BigDecimal,
+        val storeId: String,
+        val channelKey: String,
+        val paymentKey: String
+    )
+}

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/Payment.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/Payment.kt
@@ -85,6 +85,7 @@ class Payment(
     }
 
     fun refund() {
+        if (status == PaymentStatus.REFUNDED) return
         require(status.canTransitionTo(PaymentStatus.REFUNDED)) {
             "Cannot transition from $status to REFUNDED"
         }

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/PaymentMethod.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/PaymentMethod.kt
@@ -1,5 +1,5 @@
 package com.ticketqueue.payment.entity
 
 enum class PaymentMethod {
-    CARD
+    CARD  // TODO: VIRTUAL_ACCOUNT, MOBILE 결제수단 추가 예정
 }

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/PaymentStatus.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/entity/PaymentStatus.kt
@@ -6,8 +6,8 @@ enum class PaymentStatus {
     private companion object {
         val allowedTransitions = mapOf(
             PENDING to setOf(SUCCESS, FAILED),
-            SUCCESS to setOf(SUCCESS, REFUNDED),
-            FAILED to setOf(FAILED),
+            SUCCESS to setOf(REFUNDED),
+            FAILED to emptySet(),
             REFUNDED to emptySet<PaymentStatus>(),
         )
     }

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/repository/PaymentRepository.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/repository/PaymentRepository.kt
@@ -1,10 +1,12 @@
 package com.ticketqueue.payment.repository
 
 import com.ticketqueue.payment.entity.Payment
+import com.ticketqueue.payment.entity.PaymentStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.Optional
 import java.util.UUID
 
 interface PaymentRepository : JpaRepository<Payment, UUID> {
     fun findByPaymentKey(paymentKey: String): Optional<Payment>
+    fun existsByReservationIdAndStatusIn(reservationId: UUID, statuses: List<PaymentStatus>): Boolean
 }

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
@@ -6,11 +6,14 @@ import com.ticketqueue.common.external.portone.PortonePreRegisterRequest
 import com.ticketqueue.common.external.portone.PortoneProperties
 import com.ticketqueue.common.external.portone.PortoneTokenService
 import com.ticketqueue.payment.client.ReservationServiceClient
+import com.ticketqueue.payment.client.ReservationServiceClient.ReservationStatus
 import com.ticketqueue.payment.dto.PaymentDto.CreateRequest
 import com.ticketqueue.payment.dto.PaymentDto.CreateResponse
 import com.ticketqueue.payment.entity.Payment
+import com.ticketqueue.payment.entity.PaymentStatus
 import com.ticketqueue.payment.exception.PaymentException
 import com.ticketqueue.payment.repository.PaymentRepository
+import feign.FeignException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
@@ -27,16 +30,33 @@ class PaymentService(
 ) {
 
     private val log = KotlinLogging.logger {}
+    private val storeId: String = portoneProperties.storeId
+        ?: error("external.portone.store-id is required")
+    private val channelKey: String = portoneProperties.channelKey
+        ?: error("external.portone.channel-key is required")
 
     fun createPayment(userId: UUID, request: CreateRequest): CreateResponse {
-        val reservation = reservationServiceClient.getReservation(request.reservationId)
+        if (paymentRepository.existsByReservationIdAndStatusIn(
+                request.reservationId, listOf(PaymentStatus.PENDING, PaymentStatus.SUCCESS)
+            )
+        ) {
+            throw PaymentException(ErrorCode.PAYMENT_ALREADY_EXISTS)
+        }
+
+        val reservation = try {
+            reservationServiceClient.getReservation(request.reservationId)
+        } catch (e: FeignException.NotFound) {
+            throw PaymentException(ErrorCode.RESERVATION_NOT_FOUND)
+        } catch (e: FeignException) {
+            throw PaymentException(ErrorCode.INTERNAL_SERVER_ERROR)
+        }
 
         if (reservation.userId != userId) {
             throw PaymentException(ErrorCode.FORBIDDEN)
         }
 
-        if (reservation.status != "PENDING") {
-            throw PaymentException(ErrorCode.HOLD_EXPIRED)
+        if (reservation.status != ReservationStatus.PENDING.name) {
+            throw PaymentException(ErrorCode.RESERVATION_NOT_PAYABLE)
         }
 
         if (!LocalDateTime.now(ZoneOffset.UTC).isBefore(reservation.holdExpiresAt)) {
@@ -48,8 +68,6 @@ class PaymentService(
         }
 
         val paymentKey = UUID.randomUUID().toString()
-        val storeId = portoneProperties.storeId!!
-        val channelKey = portoneProperties.channelKey!!
 
         val payment = paymentRepository.save(
             Payment(

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
@@ -16,6 +16,7 @@ import com.ticketqueue.payment.repository.PaymentRepository
 import feign.FeignException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
+import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.util.UUID
@@ -51,21 +52,7 @@ class PaymentService(
             throw PaymentException(ErrorCode.INTERNAL_SERVER_ERROR)
         }
 
-        if (reservation.userId != userId) {
-            throw PaymentException(ErrorCode.FORBIDDEN)
-        }
-
-        if (reservation.status != ReservationStatus.PENDING.name) {
-            throw PaymentException(ErrorCode.RESERVATION_NOT_PAYABLE)
-        }
-
-        if (!LocalDateTime.now(ZoneOffset.UTC).isBefore(reservation.holdExpiresAt)) {
-            throw PaymentException(ErrorCode.HOLD_EXPIRED)
-        }
-
-        if (reservation.totalAmount.compareTo(request.amount) != 0) {
-            throw PaymentException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
-        }
+        validateReservation(reservation, userId, request.amount)
 
         val paymentKey = UUID.randomUUID().toString()
 
@@ -103,5 +90,16 @@ class PaymentService(
             channelKey = channelKey,
             paymentKey = paymentKey
         )
+    }
+
+    private fun validateReservation(
+        reservation: ReservationServiceClient.ReservationDetailResponse,
+        userId: UUID,
+        requestedAmount: BigDecimal
+    ) {
+        if (reservation.userId != userId) throw PaymentException(ErrorCode.FORBIDDEN)
+        if (reservation.status != ReservationStatus.PENDING.name) throw PaymentException(ErrorCode.RESERVATION_NOT_PAYABLE)
+        if (!LocalDateTime.now(ZoneOffset.UTC).isBefore(reservation.holdExpiresAt)) throw PaymentException(ErrorCode.HOLD_EXPIRED)
+        if (reservation.totalAmount.compareTo(requestedAmount) != 0) throw PaymentException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
     }
 }

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
@@ -15,6 +15,7 @@ import com.ticketqueue.payment.exception.PaymentException
 import com.ticketqueue.payment.repository.PaymentRepository
 import feign.FeignException
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -56,15 +57,19 @@ class PaymentService(
 
         val paymentKey = UUID.randomUUID().toString()
 
-        val payment = paymentRepository.save(
-            Payment(
-                reservationId = request.reservationId,
-                userId = userId,
-                paymentKey = paymentKey,
-                amount = request.amount,
-                paymentMethod = request.paymentMethod
+        val payment = try {
+            paymentRepository.save(
+                Payment(
+                    reservationId = request.reservationId,
+                    userId = userId,
+                    paymentKey = paymentKey,
+                    amount = request.amount,
+                    paymentMethod = request.paymentMethod
+                )
             )
-        )
+        } catch (e: DataIntegrityViolationException) {
+            throw PaymentException(ErrorCode.PAYMENT_ALREADY_EXISTS)
+        }
 
         try {
             portoneClient.preRegisterPayment(
@@ -98,7 +103,7 @@ class PaymentService(
         requestedAmount: BigDecimal
     ) {
         if (reservation.userId != userId) throw PaymentException(ErrorCode.FORBIDDEN)
-        if (reservation.status != ReservationStatus.PENDING.name) throw PaymentException(ErrorCode.RESERVATION_NOT_PAYABLE)
+        if (reservation.status != ReservationStatus.PENDING) throw PaymentException(ErrorCode.RESERVATION_NOT_PAYABLE)
         if (!LocalDateTime.now(ZoneOffset.UTC).isBefore(reservation.holdExpiresAt)) throw PaymentException(ErrorCode.HOLD_EXPIRED)
         if (reservation.totalAmount.compareTo(requestedAmount) != 0) throw PaymentException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
     }

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
@@ -1,0 +1,89 @@
+package com.ticketqueue.payment.service
+
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.external.portone.PortoneFeignClient
+import com.ticketqueue.common.external.portone.PortonePreRegisterRequest
+import com.ticketqueue.common.external.portone.PortoneProperties
+import com.ticketqueue.common.external.portone.PortoneTokenService
+import com.ticketqueue.payment.client.ReservationServiceClient
+import com.ticketqueue.payment.dto.PaymentDto.CreateRequest
+import com.ticketqueue.payment.dto.PaymentDto.CreateResponse
+import com.ticketqueue.payment.entity.Payment
+import com.ticketqueue.payment.exception.PaymentException
+import com.ticketqueue.payment.repository.PaymentRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+@Service
+class PaymentService(
+    private val paymentRepository: PaymentRepository,
+    private val reservationServiceClient: ReservationServiceClient,
+    private val portoneClient: PortoneFeignClient,
+    private val portoneTokenService: PortoneTokenService,
+    private val portoneProperties: PortoneProperties
+) {
+
+    private val log = KotlinLogging.logger {}
+
+    fun createPayment(userId: UUID, request: CreateRequest): CreateResponse {
+        val reservation = reservationServiceClient.getReservation(request.reservationId)
+
+        if (reservation.userId != userId) {
+            throw PaymentException(ErrorCode.FORBIDDEN)
+        }
+
+        if (reservation.status != "PENDING") {
+            throw PaymentException(ErrorCode.HOLD_EXPIRED)
+        }
+
+        if (!LocalDateTime.now(ZoneOffset.UTC).isBefore(reservation.holdExpiresAt)) {
+            throw PaymentException(ErrorCode.HOLD_EXPIRED)
+        }
+
+        if (reservation.totalAmount.compareTo(request.amount) != 0) {
+            throw PaymentException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
+        }
+
+        val paymentKey = UUID.randomUUID().toString()
+        val storeId = portoneProperties.storeId!!
+        val channelKey = portoneProperties.channelKey!!
+
+        val payment = paymentRepository.save(
+            Payment(
+                reservationId = request.reservationId,
+                userId = userId,
+                paymentKey = paymentKey,
+                amount = request.amount,
+                paymentMethod = request.paymentMethod
+            )
+        )
+
+        try {
+            portoneClient.preRegisterPayment(
+                paymentId = paymentKey,
+                request = PortonePreRegisterRequest(
+                    storeId = storeId,
+                    totalAmount = request.amount.toLong()
+                ),
+                token = portoneTokenService.getAccessToken()
+            )
+        } catch (e: Exception) {
+            payment.markFailed("PortOne pre-register failed: ${e.message}")
+            paymentRepository.save(payment)
+            throw PaymentException(ErrorCode.PORTONE_PRE_REGISTER_FAILED)
+        }
+
+        log.info { "Payment created: paymentId=${payment.id}, reservationId=${request.reservationId}, userId=$userId" }
+
+        return CreateResponse(
+            paymentId = payment.id!!,
+            amount = payment.amount,
+            storeId = storeId,
+            channelKey = channelKey,
+            paymentKey = paymentKey
+        )
+    }
+}

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
@@ -76,7 +76,7 @@ class PaymentService(
                 paymentId = paymentKey,
                 request = PortonePreRegisterRequest(
                     storeId = storeId,
-                    totalAmount = request.amount.toLong()
+                    totalAmount = request.amount.longValueExact()
                 ),
                 token = portoneTokenService.getAccessToken()
             )

--- a/backend/payment-service/src/main/resources/application-local.yml
+++ b/backend/payment-service/src/main/resources/application-local.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: local
 
   datasource:
-    url: jdbc:postgresql://192.168.50.111:5432/ticket_queue?currentSchema=payment_service,common
+    url: jdbc:postgresql://localhost:5432/ticket_queue?currentSchema=payment_service,common
     username: payment_svc_user
     password: ${db_password}
     driver-class-name: org.postgresql.Driver

--- a/backend/payment-service/src/main/resources/application.yml
+++ b/backend/payment-service/src/main/resources/application.yml
@@ -34,6 +34,20 @@ spring:
         spring.json.trusted.packages: com.ticketqueue.*
     listener:
       ack-mode: MANUAL_IMMEDIATE
+  cloud:
+    openfeign:
+      circuitbreaker:
+        enabled: true
+      client:
+        config:
+          default:
+            connect-timeout: 2000
+            read-timeout: 10000
+          portone-v2-client:
+            connect-timeout: 2000
+            read-timeout: 10000
+          reservation-service:
+            url: http://localhost:8084
 
 outbox:
   poller:
@@ -45,20 +59,6 @@ outbox:
     enabled: true
     aggregate-type: Payment
     retention-days: 7
-
-feign:
-  circuitbreaker:
-    enabled: true
-  client:
-    config:
-      default:
-        connect-timeout: 2000
-        read-timeout: 10000
-      portone-v2-client:
-        connect-timeout: 2000
-        read-timeout: 10000
-      reservation-service:
-        url: http://localhost:8084
 
 resilience4j:
   circuitbreaker:

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentControllerIntegrationTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentControllerIntegrationTest.kt
@@ -1,0 +1,263 @@
+package com.ticketqueue.payment.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.external.portone.PortoneFeignClient
+import com.ticketqueue.common.external.portone.PortoneTokenService
+import com.ticketqueue.payment.client.ReservationServiceClient
+import com.ticketqueue.payment.entity.PaymentStatus
+import com.ticketqueue.payment.repository.PaymentRepository
+import io.mockk.every
+import io.mockk.justRun
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "spring.config.import=",
+        "spring.cloud.aws.region.static=us-east-1",
+        "spring.cloud.aws.credentials.access-key=test",
+        "spring.cloud.aws.credentials.secret-key=test",
+        "spring.cloud.aws.secretsmanager.enabled=false"
+    ]
+)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("결제 요청 API 통합 테스트 (POST /payments)")
+class PaymentControllerIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:18-alpine")
+            .withDatabaseName("ticketing")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("db/init.sql")
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
+            registry.add("spring.datasource.username") { postgres.username }
+            registry.add("spring.datasource.password") { postgres.password }
+        }
+    }
+
+    @Autowired private lateinit var mockMvc: MockMvc
+    @Autowired private lateinit var objectMapper: ObjectMapper
+    @Autowired private lateinit var paymentRepository: PaymentRepository
+
+    @MockkBean private lateinit var reservationServiceClient: ReservationServiceClient
+    @MockkBean private lateinit var portoneClient: PortoneFeignClient
+    @MockkBean private lateinit var portoneTokenService: PortoneTokenService
+
+    private val userId = UUID.randomUUID()
+    private val reservationId = UUID.randomUUID()
+    private val amount = BigDecimal("300000")
+
+    @BeforeEach
+    fun setUp() {
+        paymentRepository.deleteAll()
+        every { portoneTokenService.getAccessToken() } returns "Bearer test-token"
+        justRun { portoneClient.preRegisterPayment(any(), any(), any()) }
+        every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()
+    }
+
+    private fun buildReservation(
+        ownerId: UUID = userId,
+        totalAmount: BigDecimal = amount,
+        status: String = "PENDING",
+        holdExpiresAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5)
+    ) = ReservationServiceClient.ReservationDetailResponse(
+        reservationId = reservationId,
+        userId = ownerId,
+        scheduleId = UUID.randomUUID(),
+        totalAmount = totalAmount,
+        status = status,
+        holdExpiresAt = holdExpiresAt,
+        seatIds = listOf(UUID.randomUUID())
+    )
+
+    private fun createRequestBody(
+        reservationId: UUID = this.reservationId,
+        amount: BigDecimal = this.amount
+    ) = mapOf("reservationId" to reservationId, "amount" to amount, "paymentMethod" to "CARD")
+
+    @Nested
+    @DisplayName("정상 요청")
+    inner class SuccessCase {
+
+        @Test
+        @DisplayName("200 OK와 paymentId, paymentKey, storeId, channelKey를 반환한다")
+        fun createPaymentSuccess() {
+            mockMvc.perform(
+                post("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequestBody()))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.paymentId").isNotEmpty)
+                .andExpect(jsonPath("$.amount").value(300000))
+                .andExpect(jsonPath("$.storeId").value("test-store-id"))
+                .andExpect(jsonPath("$.channelKey").value("test-channel-key"))
+                .andExpect(jsonPath("$.paymentKey").isNotEmpty)
+        }
+
+        @Test
+        @DisplayName("Payment 엔티티가 DB에 PENDING 상태로 저장된다")
+        fun paymentPersistedAsPending() {
+            mockMvc.perform(
+                post("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequestBody()))
+            ).andExpect(status().isOk)
+
+            val payments = paymentRepository.findAll()
+            assert(payments.size == 1)
+            assert(payments[0].status == PaymentStatus.PENDING)
+            assert(payments[0].userId == userId)
+            assert(payments[0].reservationId == reservationId)
+        }
+    }
+
+    @Nested
+    @DisplayName("입력 검증 실패")
+    inner class ValidationFailure {
+
+        @Test
+        @DisplayName("X-User-Id 헤더 없으면 401 반환")
+        fun missingUserId() {
+            mockMvc.perform(
+                post("/payments")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequestBody()))
+            ).andExpect(status().isUnauthorized)
+        }
+
+        @Test
+        @DisplayName("amount가 음수면 400 반환")
+        fun negativeAmount() {
+            mockMvc.perform(
+                post("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequestBody(amount = BigDecimal("-1"))))
+            ).andExpect(status().isBadRequest)
+        }
+
+        @Test
+        @DisplayName("reservationId 누락 시 400 반환")
+        fun missingReservationId() {
+            val body = mapOf("amount" to amount, "paymentMethod" to "CARD")
+            mockMvc.perform(
+                post("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(body))
+            ).andExpect(status().isBadRequest)
+        }
+    }
+
+    @Nested
+    @DisplayName("비즈니스 검증 실패")
+    inner class BusinessFailure {
+
+        @Test
+        @DisplayName("요청 금액과 예매 금액 불일치 시 400 반환")
+        fun amountMismatch() {
+            every { reservationServiceClient.getReservation(reservationId) } returns
+                buildReservation(totalAmount = BigDecimal("200000"))
+
+            mockMvc.perform(
+                post("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequestBody()))
+            )
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value(ErrorCode.PAYMENT_AMOUNT_MISMATCH.code))
+        }
+
+        @Test
+        @DisplayName("타인의 예매 결제 시도 시 403 반환")
+        fun forbidden() {
+            every { reservationServiceClient.getReservation(reservationId) } returns
+                buildReservation(ownerId = UUID.randomUUID())
+
+            mockMvc.perform(
+                post("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequestBody()))
+            )
+                .andExpect(status().isForbidden)
+                .andExpect(jsonPath("$.code").value(ErrorCode.FORBIDDEN.code))
+        }
+
+        @Test
+        @DisplayName("예매 상태가 PENDING이 아니면 410과 HOLD_EXPIRED 반환")
+        fun holdExpiredByStatus() {
+            every { reservationServiceClient.getReservation(reservationId) } returns
+                buildReservation(status = "CONFIRMED")
+
+            mockMvc.perform(
+                post("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequestBody()))
+            )
+                .andExpect(status().isGone)
+                .andExpect(jsonPath("$.code").value(ErrorCode.HOLD_EXPIRED.code))
+        }
+
+        @Test
+        @DisplayName("holdExpiresAt이 경과하면 410과 HOLD_EXPIRED 반환")
+        fun holdExpiredByTime() {
+            every { reservationServiceClient.getReservation(reservationId) } returns
+                buildReservation(holdExpiresAt = LocalDateTime.now(ZoneOffset.UTC).minusSeconds(1))
+
+            mockMvc.perform(
+                post("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequestBody()))
+            )
+                .andExpect(status().isGone)
+                .andExpect(jsonPath("$.code").value(ErrorCode.HOLD_EXPIRED.code))
+        }
+    }
+}

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentControllerIntegrationTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentControllerIntegrationTest.kt
@@ -227,7 +227,7 @@ class PaymentControllerIntegrationTest {
         }
 
         @Test
-        @DisplayName("예매 상태가 PENDING이 아니면 410과 HOLD_EXPIRED 반환")
+        @DisplayName("예매 상태가 PENDING이 아니면 422와 RESERVATION_NOT_PAYABLE 반환")
         fun holdExpiredByStatus() {
             every { reservationServiceClient.getReservation(reservationId) } returns
                 buildReservation(status = "CONFIRMED")
@@ -239,8 +239,8 @@ class PaymentControllerIntegrationTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(createRequestBody()))
             )
-                .andExpect(status().isGone)
-                .andExpect(jsonPath("$.code").value(ErrorCode.HOLD_EXPIRED.code))
+                .andExpect(status().isUnprocessableEntity)
+                .andExpect(jsonPath("$.code").value(ErrorCode.RESERVATION_NOT_PAYABLE.code))
         }
 
         @Test
@@ -258,6 +258,28 @@ class PaymentControllerIntegrationTest {
             )
                 .andExpect(status().isGone)
                 .andExpect(jsonPath("$.code").value(ErrorCode.HOLD_EXPIRED.code))
+        }
+
+        @Test
+        @DisplayName("동일 reservationId로 결제를 두 번 요청하면 두 번째는 409와 PAYMENT_ALREADY_EXISTS 반환")
+        fun duplicatePayment() {
+            mockMvc.perform(
+                post("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequestBody()))
+            ).andExpect(status().isOk)
+
+            mockMvc.perform(
+                post("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequestBody()))
+            )
+                .andExpect(status().isConflict)
+                .andExpect(jsonPath("$.code").value(ErrorCode.PAYMENT_ALREADY_EXISTS.code))
         }
     }
 }

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentControllerIntegrationTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentControllerIntegrationTest.kt
@@ -90,7 +90,7 @@ class PaymentControllerIntegrationTest {
     private fun buildReservation(
         ownerId: UUID = userId,
         totalAmount: BigDecimal = amount,
-        status: String = "PENDING",
+        status: ReservationServiceClient.ReservationStatus = ReservationServiceClient.ReservationStatus.PENDING,
         holdExpiresAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5)
     ) = ReservationServiceClient.ReservationDetailResponse(
         reservationId = reservationId,
@@ -243,7 +243,7 @@ class PaymentControllerIntegrationTest {
         @DisplayName("예매 상태가 PENDING이 아니면 422와 RESERVATION_NOT_PAYABLE 반환")
         fun holdExpiredByStatus() {
             every { reservationServiceClient.getReservation(reservationId) } returns
-                buildReservation(status = "CONFIRMED")
+                buildReservation(status = ReservationServiceClient.ReservationStatus.CONFIRMED)
 
             mockMvc.perform(
                 post("/payments")

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentControllerIntegrationTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentControllerIntegrationTest.kt
@@ -28,6 +28,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
+import io.kotest.matchers.shouldBe
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -141,10 +142,10 @@ class PaymentControllerIntegrationTest {
             ).andExpect(status().isOk)
 
             val payments = paymentRepository.findAll()
-            assert(payments.size == 1)
-            assert(payments[0].status == PaymentStatus.PENDING)
-            assert(payments[0].userId == userId)
-            assert(payments[0].reservationId == reservationId)
+            payments.size shouldBe 1
+            payments[0].status shouldBe PaymentStatus.PENDING
+            payments[0].userId shouldBe userId
+            payments[0].reservationId shouldBe reservationId
         }
     }
 

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentControllerIntegrationTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentControllerIntegrationTest.kt
@@ -186,6 +186,19 @@ class PaymentControllerIntegrationTest {
                     .content(objectMapper.writeValueAsString(body))
             ).andExpect(status().isBadRequest)
         }
+
+        @Test
+        @DisplayName("알 수 없는 paymentMethod 값 입력 시 400 반환")
+        fun invalidPaymentMethod() {
+            val body = mapOf("reservationId" to reservationId, "amount" to amount, "paymentMethod" to "BITCOIN")
+            mockMvc.perform(
+                post("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(body))
+            ).andExpect(status().isBadRequest)
+        }
     }
 
     @Nested

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
@@ -203,6 +203,20 @@ class PaymentServiceTest {
         }
 
         @Test
+        @DisplayName("holdExpiresAt이 현재 시각과 정확히 같으면 HOLD_EXPIRED 예외가 발생한다")
+        fun holdExpiredAtExactBoundary() {
+            val now = LocalDateTime.now(ZoneOffset.UTC)
+            every { reservationServiceClient.getReservation(reservationId) } returns
+                buildReservation(holdExpiresAt = now)
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.createPayment(userId, CreateRequest(reservationId = reservationId, amount = amount))
+            }
+
+            ex.errorCode shouldBe ErrorCode.HOLD_EXPIRED
+        }
+
+        @Test
         @DisplayName("PortOne pre-register 실패 시 Payment가 FAILED로 저장되고 PORTONE_PRE_REGISTER_FAILED 예외가 발생한다")
         fun portonePreRegisterFails() {
             every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
@@ -69,7 +69,7 @@ class PaymentServiceTest {
     private fun buildReservation(
         ownerId: UUID = userId,
         totalAmount: BigDecimal = amount,
-        status: String = "PENDING",
+        status: ReservationServiceClient.ReservationStatus = ReservationServiceClient.ReservationStatus.PENDING,
         holdExpiresAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5)
     ) = ReservationServiceClient.ReservationDetailResponse(
         reservationId = reservationId,
@@ -138,7 +138,7 @@ class PaymentServiceTest {
         @Test
         @DisplayName("예매 상태가 PENDING이 아니면 RESERVATION_NOT_PAYABLE 예외가 발생한다")
         fun holdExpiredWhenNotPending() {
-            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation(status = "CONFIRMED")
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation(status = ReservationServiceClient.ReservationStatus.CONFIRMED)
 
             val ex = assertThrows<PaymentException> {
                 paymentService.createPayment(userId, CreateRequest(reservationId = reservationId, amount = amount))

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
@@ -12,6 +12,7 @@ import com.ticketqueue.payment.exception.PaymentException
 import com.ticketqueue.payment.repository.PaymentRepository
 import feign.FeignException
 import io.kotest.matchers.shouldBe
+import org.springframework.dao.DataIntegrityViolationException
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -186,6 +187,20 @@ class PaymentServiceTest {
 
             ex.errorCode shouldBe ErrorCode.PAYMENT_ALREADY_EXISTS
             verify(exactly = 0) { reservationServiceClient.getReservation(any()) }
+        }
+
+        @Test
+        @DisplayName("existsByReservationIdAndStatusIn이 false를 반환했으나 save()에서 DB 유니크 제약 위반 시 PAYMENT_ALREADY_EXISTS 예외가 발생한다")
+        fun duplicatePaymentAtDbLevel() {
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()
+            every { paymentRepository.save(any()) } throws DataIntegrityViolationException("unique constraint")
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.createPayment(userId, CreateRequest(reservationId = reservationId, amount = amount))
+            }
+
+            ex.errorCode shouldBe ErrorCode.PAYMENT_ALREADY_EXISTS
+            verify(exactly = 1) { reservationServiceClient.getReservation(reservationId) }
         }
 
         @Test

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
@@ -7,8 +7,10 @@ import com.ticketqueue.common.external.portone.PortoneTokenService
 import com.ticketqueue.payment.client.ReservationServiceClient
 import com.ticketqueue.payment.dto.PaymentDto.CreateRequest
 import com.ticketqueue.payment.entity.Payment
+import com.ticketqueue.payment.entity.PaymentStatus
 import com.ticketqueue.payment.exception.PaymentException
 import com.ticketqueue.payment.repository.PaymentRepository
+import feign.FeignException
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.justRun
@@ -53,6 +55,7 @@ class PaymentServiceTest {
         every { portoneProperties.storeId } returns storeId
         every { portoneProperties.channelKey } returns channelKey
         every { portoneTokenService.getAccessToken() } returns bearerToken
+        every { paymentRepository.existsByReservationIdAndStatusIn(any(), any()) } returns false
 
         paymentService = PaymentService(
             paymentRepository,
@@ -133,7 +136,7 @@ class PaymentServiceTest {
         }
 
         @Test
-        @DisplayName("예매 상태가 PENDING이 아니면 HOLD_EXPIRED 예외가 발생한다")
+        @DisplayName("예매 상태가 PENDING이 아니면 RESERVATION_NOT_PAYABLE 예외가 발생한다")
         fun holdExpiredWhenNotPending() {
             every { reservationServiceClient.getReservation(reservationId) } returns buildReservation(status = "CONFIRMED")
 
@@ -141,7 +144,48 @@ class PaymentServiceTest {
                 paymentService.createPayment(userId, CreateRequest(reservationId = reservationId, amount = amount))
             }
 
-            ex.errorCode shouldBe ErrorCode.HOLD_EXPIRED
+            ex.errorCode shouldBe ErrorCode.RESERVATION_NOT_PAYABLE
+        }
+
+        @Test
+        @DisplayName("예매 서비스가 404를 반환하면 RESERVATION_NOT_FOUND 예외가 발생한다")
+        fun reservationNotFound() {
+            every { reservationServiceClient.getReservation(reservationId) } throws mockk<FeignException.NotFound>()
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.createPayment(userId, CreateRequest(reservationId = reservationId, amount = amount))
+            }
+
+            ex.errorCode shouldBe ErrorCode.RESERVATION_NOT_FOUND
+        }
+
+        @Test
+        @DisplayName("예매 서비스 네트워크 오류 시 INTERNAL_SERVER_ERROR 예외가 발생한다")
+        fun reservationServiceUnavailable() {
+            every { reservationServiceClient.getReservation(reservationId) } throws mockk<FeignException.ServiceUnavailable>()
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.createPayment(userId, CreateRequest(reservationId = reservationId, amount = amount))
+            }
+
+            ex.errorCode shouldBe ErrorCode.INTERNAL_SERVER_ERROR
+        }
+
+        @Test
+        @DisplayName("동일 reservationId에 PENDING 결제가 이미 존재하면 PAYMENT_ALREADY_EXISTS 예외가 발생한다")
+        fun duplicatePayment() {
+            every {
+                paymentRepository.existsByReservationIdAndStatusIn(
+                    reservationId, listOf(PaymentStatus.PENDING, PaymentStatus.SUCCESS)
+                )
+            } returns true
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.createPayment(userId, CreateRequest(reservationId = reservationId, amount = amount))
+            }
+
+            ex.errorCode shouldBe ErrorCode.PAYMENT_ALREADY_EXISTS
+            verify(exactly = 0) { reservationServiceClient.getReservation(any()) }
         }
 
         @Test

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
@@ -1,0 +1,179 @@
+package com.ticketqueue.payment.service
+
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.external.portone.PortoneFeignClient
+import com.ticketqueue.common.external.portone.PortoneProperties
+import com.ticketqueue.common.external.portone.PortoneTokenService
+import com.ticketqueue.payment.client.ReservationServiceClient
+import com.ticketqueue.payment.dto.PaymentDto.CreateRequest
+import com.ticketqueue.payment.entity.Payment
+import com.ticketqueue.payment.exception.PaymentException
+import com.ticketqueue.payment.repository.PaymentRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+@DisplayName("PaymentService 단위 테스트")
+class PaymentServiceTest {
+
+    private lateinit var paymentRepository: PaymentRepository
+    private lateinit var reservationServiceClient: ReservationServiceClient
+    private lateinit var portoneClient: PortoneFeignClient
+    private lateinit var portoneTokenService: PortoneTokenService
+    private lateinit var portoneProperties: PortoneProperties
+    private lateinit var paymentService: PaymentService
+
+    private val userId = UUID.randomUUID()
+    private val reservationId = UUID.randomUUID()
+    private val scheduleId = UUID.randomUUID()
+    private val amount = BigDecimal("300000")
+    private val storeId = "test-store-id"
+    private val channelKey = "test-channel-key"
+    private val bearerToken = "Bearer test-token"
+
+    @BeforeEach
+    fun setUp() {
+        paymentRepository = mockk()
+        reservationServiceClient = mockk()
+        portoneClient = mockk()
+        portoneTokenService = mockk()
+        portoneProperties = mockk()
+
+        every { portoneProperties.storeId } returns storeId
+        every { portoneProperties.channelKey } returns channelKey
+        every { portoneTokenService.getAccessToken() } returns bearerToken
+
+        paymentService = PaymentService(
+            paymentRepository,
+            reservationServiceClient,
+            portoneClient,
+            portoneTokenService,
+            portoneProperties
+        )
+    }
+
+    private fun buildReservation(
+        ownerId: UUID = userId,
+        totalAmount: BigDecimal = amount,
+        status: String = "PENDING",
+        holdExpiresAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5)
+    ) = ReservationServiceClient.ReservationDetailResponse(
+        reservationId = reservationId,
+        userId = ownerId,
+        scheduleId = scheduleId,
+        totalAmount = totalAmount,
+        status = status,
+        holdExpiresAt = holdExpiresAt,
+        seatIds = listOf(UUID.randomUUID())
+    )
+
+    @Nested
+    @DisplayName("createPayment")
+    inner class CreatePayment {
+
+        @Test
+        @DisplayName("정상 흐름: Payment가 PENDING 상태로 저장되고 CreateResponse를 반환한다")
+        fun success() {
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()
+            justRun { portoneClient.preRegisterPayment(any(), any(), any()) }
+            every { paymentRepository.save(any()) } answers {
+                val p = firstArg<Payment>()
+                Payment(
+                    id = UUID.randomUUID(),
+                    reservationId = p.reservationId,
+                    userId = p.userId,
+                    paymentKey = p.paymentKey,
+                    amount = p.amount,
+                    paymentMethod = p.paymentMethod
+                )
+            }
+
+            val response = paymentService.createPayment(userId, CreateRequest(reservationId = reservationId, amount = amount))
+
+            response.amount shouldBe amount
+            response.storeId shouldBe storeId
+            response.channelKey shouldBe channelKey
+            verify(exactly = 1) { portoneClient.preRegisterPayment(any(), any(), bearerToken) }
+            verify(exactly = 1) { paymentRepository.save(any()) }
+        }
+
+        @Test
+        @DisplayName("예매 소유자가 다르면 FORBIDDEN 예외가 발생한다")
+        fun forbiddenWhenDifferentUser() {
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation(ownerId = UUID.randomUUID())
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.createPayment(userId, CreateRequest(reservationId = reservationId, amount = amount))
+            }
+
+            ex.errorCode shouldBe ErrorCode.FORBIDDEN
+        }
+
+        @Test
+        @DisplayName("요청 금액과 예매 금액이 다르면 PAYMENT_AMOUNT_MISMATCH 예외가 발생한다")
+        fun amountMismatch() {
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation(totalAmount = BigDecimal("200000"))
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.createPayment(userId, CreateRequest(reservationId = reservationId, amount = amount))
+            }
+
+            ex.errorCode shouldBe ErrorCode.PAYMENT_AMOUNT_MISMATCH
+        }
+
+        @Test
+        @DisplayName("예매 상태가 PENDING이 아니면 HOLD_EXPIRED 예외가 발생한다")
+        fun holdExpiredWhenNotPending() {
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation(status = "CONFIRMED")
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.createPayment(userId, CreateRequest(reservationId = reservationId, amount = amount))
+            }
+
+            ex.errorCode shouldBe ErrorCode.HOLD_EXPIRED
+        }
+
+        @Test
+        @DisplayName("holdExpiresAt이 현재 시각보다 과거이면 HOLD_EXPIRED 예외가 발생한다")
+        fun holdExpiredWhenTimeOver() {
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation(
+                holdExpiresAt = LocalDateTime.now(ZoneOffset.UTC).minusSeconds(1)
+            )
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.createPayment(userId, CreateRequest(reservationId = reservationId, amount = amount))
+            }
+
+            ex.errorCode shouldBe ErrorCode.HOLD_EXPIRED
+        }
+
+        @Test
+        @DisplayName("PortOne pre-register 실패 시 Payment가 FAILED로 저장되고 PORTONE_PRE_REGISTER_FAILED 예외가 발생한다")
+        fun portonePreRegisterFails() {
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()
+            every { paymentRepository.save(any()) } answers { firstArg() }
+            every { portoneClient.preRegisterPayment(any(), any(), any()) } throws
+                RuntimeException("PortOne connection failed")
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.createPayment(userId, CreateRequest(reservationId = reservationId, amount = amount))
+            }
+
+            ex.errorCode shouldBe ErrorCode.PORTONE_PRE_REGISTER_FAILED
+            // PENDING 저장 1회 + PortOne 실패 후 FAILED 저장 1회
+            verify(exactly = 2) { paymentRepository.save(any()) }
+            verify(exactly = 1) { portoneClient.preRegisterPayment(any(), any(), any()) }
+        }
+    }
+}

--- a/backend/payment-service/src/test/resources/application-test.yml
+++ b/backend/payment-service/src/test/resources/application-test.yml
@@ -5,6 +5,11 @@ spring:
     aws:
       secretsmanager:
         enabled: false
+    openfeign:
+      client:
+        config:
+          reservation-service:
+            url: http://localhost:8084
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
@@ -14,12 +19,6 @@ spring:
     properties:
       hibernate:
         default_schema: payment_service
-  cloud:
-    openfeign:
-      client:
-        config:
-          reservation-service:
-            url: http://localhost:8084
 
 external:
   portone:

--- a/backend/payment-service/src/test/resources/application-test.yml
+++ b/backend/payment-service/src/test/resources/application-test.yml
@@ -1,0 +1,43 @@
+spring:
+  config:
+    import: ""   # aws-secretsmanager import 비활성화
+  cloud:
+    aws:
+      secretsmanager:
+        enabled: false
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        default_schema: payment_service
+  cloud:
+    openfeign:
+      client:
+        config:
+          reservation-service:
+            url: http://localhost:8084
+
+external:
+  portone:
+    enabled: true
+    api-secret: "test-api-secret-for-testing"
+    store-id: "test-store-id"
+    channel-key: "test-channel-key"
+
+internal:
+  api:
+    key: test-internal-api-key
+
+outbox:
+  poller:
+    enabled: false
+  cleanup:
+    enabled: false
+
+processed-event:
+  cleanup:
+    enabled: false

--- a/backend/payment-service/src/test/resources/db/init.sql
+++ b/backend/payment-service/src/test/resources/db/init.sql
@@ -1,0 +1,68 @@
+-- 테스트용 스키마 및 테이블 초기화 (TestContainers PostgreSQL)
+
+-- Schemas
+CREATE SCHEMA IF NOT EXISTS common;
+CREATE SCHEMA IF NOT EXISTS payment_service;
+
+-- update_timestamp 함수
+CREATE OR REPLACE FUNCTION payment_service.update_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- common.outbox_events
+CREATE TABLE IF NOT EXISTS common.outbox_events (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    aggregate_type VARCHAR(50)  NOT NULL,
+    aggregate_id   UUID         NOT NULL,
+    event_type     VARCHAR(100) NOT NULL,
+    payload        JSONB        NOT NULL,
+    created_at     TIMESTAMP    NOT NULL DEFAULT now(),
+    published      BOOLEAN               DEFAULT false,
+    published_at   TIMESTAMP,
+    retry_count    INT                   DEFAULT 0,
+    last_error     TEXT,
+    CONSTRAINT chk_outbox_retry CHECK (retry_count >= 0 AND retry_count <= 10)
+);
+
+-- common.processed_events
+CREATE TABLE IF NOT EXISTS common.processed_events (
+    event_id         UUID         NOT NULL,
+    consumer_service VARCHAR(50)  NOT NULL,
+    aggregate_id     UUID         NOT NULL,
+    event_type       VARCHAR(100) NOT NULL,
+    processed_at     TIMESTAMP    NOT NULL DEFAULT now(),
+    PRIMARY KEY (event_id, consumer_service)
+);
+
+-- payment_service.payments
+CREATE TABLE IF NOT EXISTS payment_service.payments (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    reservation_id        UUID          NOT NULL,
+    user_id               UUID          NOT NULL,
+    payment_key           VARCHAR(200)  NOT NULL UNIQUE,
+    amount                DECIMAL(10,0) NOT NULL,
+    payment_method        VARCHAR(20)   NOT NULL DEFAULT 'CARD',
+    status                VARCHAR(20)   NOT NULL DEFAULT 'PENDING',
+    portone_transaction_id VARCHAR(100),
+    portone_response      JSONB,
+    failure_reason        TEXT,
+    paid_at               TIMESTAMP,
+    created_at            TIMESTAMP     NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMP     NOT NULL DEFAULT now(),
+
+    CONSTRAINT chk_payments_status CHECK (status IN ('PENDING', 'SUCCESS', 'FAILED', 'REFUNDED')),
+    CONSTRAINT chk_payments_amount CHECK (amount >= 0),
+    CONSTRAINT chk_payments_method CHECK (payment_method IN ('CARD'))
+);
+
+CREATE UNIQUE INDEX idx_payments_payment_key ON payment_service.payments(payment_key);
+CREATE INDEX idx_payments_reservation    ON payment_service.payments(reservation_id);
+CREATE INDEX idx_payments_user_created   ON payment_service.payments(user_id, created_at DESC);
+
+CREATE TRIGGER trg_payments_updated_at
+BEFORE UPDATE ON payment_service.payments
+FOR EACH ROW EXECUTE FUNCTION payment_service.update_timestamp();

--- a/backend/payment-service/src/test/resources/db/init.sql
+++ b/backend/payment-service/src/test/resources/db/init.sql
@@ -62,6 +62,9 @@ CREATE TABLE IF NOT EXISTS payment_service.payments (
 CREATE UNIQUE INDEX idx_payments_payment_key ON payment_service.payments(payment_key);
 CREATE INDEX idx_payments_reservation    ON payment_service.payments(reservation_id);
 CREATE INDEX idx_payments_user_created   ON payment_service.payments(user_id, created_at DESC);
+CREATE UNIQUE INDEX idx_payments_reservation_pending_success
+    ON payment_service.payments(reservation_id)
+    WHERE status IN ('PENDING', 'SUCCESS');
 
 CREATE TRIGGER trg_payments_updated_at
 BEFORE UPDATE ON payment_service.payments

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClient.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClient.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 
 @FeignClient(
     name = "event-service",
-    url = "\${feign.client.config.event-service.url}",
+    url = "\${spring.cloud.openfeign.client.config.event-service.url}",
     fallbackFactory = EventServiceClientFallbackFactory::class,
     configuration = [InternalFeignConfig::class]
 )

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/controller/ReservationInternalController.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/controller/ReservationInternalController.kt
@@ -1,6 +1,6 @@
 package com.ticketqueue.reservation.controller
 
-import com.ticketqueue.reservation.entity.ReservationStatus
+import com.ticketqueue.reservation.dto.ReservationDetailResponse
 import com.ticketqueue.reservation.exception.ReservationException
 import com.ticketqueue.reservation.repository.ReservationRepository
 import com.ticketqueue.reservation.repository.ReservationSeatRepository
@@ -9,8 +9,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.math.BigDecimal
-import java.time.LocalDateTime
 import java.util.UUID
 
 // 서비스 간 내부 통신 전용 예매 API
@@ -39,13 +37,4 @@ class ReservationInternalController(
         )
     }
 
-    data class ReservationDetailResponse(
-        val reservationId: UUID,
-        val userId: UUID,
-        val scheduleId: UUID,
-        val totalAmount: BigDecimal,
-        val status: ReservationStatus,
-        val holdExpiresAt: LocalDateTime,
-        val seatIds: List<UUID>
-    )
 }

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/controller/ReservationInternalController.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/controller/ReservationInternalController.kt
@@ -1,0 +1,51 @@
+package com.ticketqueue.reservation.controller
+
+import com.ticketqueue.reservation.entity.ReservationStatus
+import com.ticketqueue.reservation.exception.ReservationException
+import com.ticketqueue.reservation.repository.ReservationRepository
+import com.ticketqueue.reservation.repository.ReservationSeatRepository
+import com.ticketqueue.common.exception.ErrorCode
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+// 서비스 간 내부 통신 전용 예매 API
+// 보안: InternalApiAuthInterceptor가 X-Service-Api-Key 헤더 검증 (API Gateway는 /internal 경로 차단)
+@RestController
+@RequestMapping("/internal/reservations")
+class ReservationInternalController(
+    private val reservationRepository: ReservationRepository,
+    private val reservationSeatRepository: ReservationSeatRepository
+) {
+
+    @GetMapping("/{reservationId}")
+    fun getReservation(@PathVariable reservationId: UUID): ReservationDetailResponse {
+        val reservation = reservationRepository.findById(reservationId).orElseThrow {
+            ReservationException(ErrorCode.RESERVATION_NOT_FOUND)
+        }
+        val seatIds = reservationSeatRepository.findByReservationId(reservationId).map { it.seatId }
+        return ReservationDetailResponse(
+            reservationId = reservation.id!!,
+            userId = reservation.userId,
+            scheduleId = reservation.scheduleId,
+            totalAmount = reservation.totalAmount,
+            status = reservation.status,
+            holdExpiresAt = reservation.holdExpiresAt,
+            seatIds = seatIds
+        )
+    }
+
+    data class ReservationDetailResponse(
+        val reservationId: UUID,
+        val userId: UUID,
+        val scheduleId: UUID,
+        val totalAmount: BigDecimal,
+        val status: ReservationStatus,
+        val holdExpiresAt: LocalDateTime,
+        val seatIds: List<UUID>
+    )
+}

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationInternalDto.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationInternalDto.kt
@@ -1,0 +1,16 @@
+package com.ticketqueue.reservation.dto
+
+import com.ticketqueue.reservation.entity.ReservationStatus
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class ReservationDetailResponse(
+    val reservationId: UUID,
+    val userId: UUID,
+    val scheduleId: UUID,
+    val totalAmount: BigDecimal,
+    val status: ReservationStatus,
+    val holdExpiresAt: LocalDateTime,
+    val seatIds: List<UUID>
+)

--- a/backend/reservation-service/src/main/resources/application-local.yml
+++ b/backend/reservation-service/src/main/resources/application-local.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: local
 
   datasource:
-    url: jdbc:postgresql://192.168.50.111:5432/ticket_queue?currentSchema=reservation_service,common
+    url: jdbc:postgresql://localhost:5432/ticket_queue?currentSchema=reservation_service,common
     username: reservation_svc_user
     password: ${db_password}
     driver-class-name: org.postgresql.Driver

--- a/backend/reservation-service/src/main/resources/application.yml
+++ b/backend/reservation-service/src/main/resources/application.yml
@@ -40,6 +40,19 @@ spring:
         spring.json.trusted.packages: com.ticketqueue.*
     listener:
       ack-mode: MANUAL_IMMEDIATE
+  cloud:
+    openfeign:
+      circuitbreaker:
+        enabled: true
+      client:
+        config:
+          default:
+            connect-timeout: 5000
+            read-timeout: 10000
+          event-service:
+            url: http://localhost:8082
+            connect-timeout: 2000
+            read-timeout: 3000
 
 # ============================================================
 # 예매 비즈니스 설정
@@ -76,22 +89,6 @@ processed-event:
   cleanup:
     enabled: true
     retention-days: 30
-
-# ============================================================
-# OpenFeign (서비스 간 내부 통신)
-# ============================================================
-feign:
-  circuitbreaker:
-    enabled: true
-  client:
-    config:
-      default:
-        connect-timeout: 5000
-        read-timeout: 10000
-      event-service:
-        url: http://localhost:8082
-        connect-timeout: 2000
-        read-timeout: 3000
 
 # ============================================================
 # Resilience4j (Event Service 연쇄 장애 방지)

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/controller/ReservationInternalControllerSecurityTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/controller/ReservationInternalControllerSecurityTest.kt
@@ -1,0 +1,113 @@
+package com.ticketqueue.reservation.controller
+
+import com.ninjasquad.springmockk.MockkBean
+import com.ticketqueue.reservation.client.EventServiceClient
+import com.ticketqueue.reservation.entity.Reservation
+import com.ticketqueue.reservation.repository.ReservationRepository
+import com.ticketqueue.reservation.repository.ReservationSeatRepository
+import io.mockk.every
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.Optional
+import java.util.UUID
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "spring.config.import=",
+        "spring.cloud.aws.region.static=us-east-1",
+        "spring.cloud.aws.credentials.access-key=test",
+        "spring.cloud.aws.credentials.secret-key=test",
+        "spring.cloud.aws.secretsmanager.enabled=false"
+    ]
+)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("ReservationInternalController 보안 통합 테스트")
+class ReservationInternalControllerSecurityTest {
+
+    companion object {
+        @Container @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("ticketing")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("db/init.sql")
+
+        @Container @JvmStatic
+        val valkey = GenericContainer("valkey/valkey:8.1.5-alpine3.23")
+            .withExposedPorts(6379)
+
+        @DynamicPropertySource @JvmStatic
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
+            registry.add("spring.datasource.username") { postgres.username }
+            registry.add("spring.datasource.password") { postgres.password }
+            registry.add("spring.data.redis.host") { valkey.host }
+            registry.add("spring.data.redis.port") { valkey.getMappedPort(6379) }
+        }
+    }
+
+    @Autowired private lateinit var mockMvc: MockMvc
+    @MockkBean private lateinit var eventServiceClient: EventServiceClient
+    @MockkBean private lateinit var reservationRepository: ReservationRepository
+    @MockkBean private lateinit var reservationSeatRepository: ReservationSeatRepository
+
+    private val reservationId = UUID.randomUUID()
+    private val userId = UUID.randomUUID()
+    private val scheduleId = UUID.randomUUID()
+
+    @Test
+    @DisplayName("X-Service-Api-Key 헤더 누락 시 401 반환")
+    fun missingApiKey() {
+        mockMvc.perform(get("/internal/reservations/$reservationId"))
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @DisplayName("잘못된 X-Service-Api-Key 시 401 반환")
+    fun wrongApiKey() {
+        mockMvc.perform(
+            get("/internal/reservations/$reservationId")
+                .header("X-Service-Api-Key", "wrong-key")
+        ).andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @DisplayName("올바른 X-Service-Api-Key 시 인증을 통과하고 200 반환")
+    fun correctApiKey() {
+        every { reservationRepository.findById(reservationId) } returns Optional.of(
+            Reservation(
+                id = reservationId,
+                userId = userId,
+                scheduleId = scheduleId,
+                eventId = UUID.randomUUID(),
+                totalAmount = BigDecimal("300000"),
+                holdExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5)
+            )
+        )
+        every { reservationSeatRepository.findByReservationId(reservationId) } returns emptyList()
+
+        mockMvc.perform(
+            get("/internal/reservations/$reservationId")
+                .header("X-Service-Api-Key", "test-internal-api-key")
+        ).andExpect(status().isOk)
+    }
+}

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/controller/ReservationInternalControllerTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/controller/ReservationInternalControllerTest.kt
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import java.math.BigDecimal
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.Optional
 import java.util.UUID
 
@@ -52,7 +53,7 @@ class ReservationInternalControllerTest {
         scheduleId = scheduleId,
         eventId = UUID.randomUUID(),
         totalAmount = BigDecimal("300000"),
-        holdExpiresAt = LocalDateTime.now().plusMinutes(5)
+        holdExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5)
     )
 
     private fun buildSeat() = ReservationSeat(

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/controller/ReservationInternalControllerTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/controller/ReservationInternalControllerTest.kt
@@ -1,0 +1,98 @@
+package com.ticketqueue.reservation.controller
+
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.reservation.entity.Reservation
+import com.ticketqueue.reservation.entity.ReservationSeat
+import com.ticketqueue.reservation.entity.ReservationStatus
+import com.ticketqueue.reservation.exception.ReservationException
+import com.ticketqueue.reservation.repository.ReservationRepository
+import com.ticketqueue.reservation.repository.ReservationSeatRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.Optional
+import java.util.UUID
+
+@DisplayName("ReservationInternalController 단위 테스트")
+class ReservationInternalControllerTest {
+
+    private lateinit var reservationRepository: ReservationRepository
+    private lateinit var reservationSeatRepository: ReservationSeatRepository
+    private lateinit var controller: ReservationInternalController
+    private lateinit var mockMvc: MockMvc
+
+    private val reservationId = UUID.randomUUID()
+    private val userId = UUID.randomUUID()
+    private val scheduleId = UUID.randomUUID()
+    private val seatId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        reservationRepository = mockk()
+        reservationSeatRepository = mockk()
+        controller = ReservationInternalController(reservationRepository, reservationSeatRepository)
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
+    }
+
+    private fun buildReservation() = Reservation(
+        id = reservationId,
+        userId = userId,
+        scheduleId = scheduleId,
+        eventId = UUID.randomUUID(),
+        totalAmount = BigDecimal("300000"),
+        holdExpiresAt = LocalDateTime.now().plusMinutes(5)
+    )
+
+    private fun buildSeat() = ReservationSeat(
+        reservationId = reservationId,
+        seatId = seatId,
+        seatNumber = "A-01",
+        grade = "VIP",
+        price = BigDecimal("300000")
+    )
+
+    @Nested
+    @DisplayName("GET /internal/reservations/{reservationId}")
+    inner class GetReservation {
+
+        @Test
+        @DisplayName("예매 ID로 예매 상세 정보와 좌석 ID 목록을 반환한다")
+        fun success() {
+            every { reservationRepository.findById(reservationId) } returns Optional.of(buildReservation())
+            every { reservationSeatRepository.findByReservationId(reservationId) } returns listOf(buildSeat())
+
+            mockMvc.perform(get("/internal/reservations/$reservationId"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.reservationId").value(reservationId.toString()))
+                .andExpect(jsonPath("$.userId").value(userId.toString()))
+                .andExpect(jsonPath("$.scheduleId").value(scheduleId.toString()))
+                .andExpect(jsonPath("$.totalAmount").value(300000))
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andExpect(jsonPath("$.seatIds[0]").value(seatId.toString()))
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 예매 ID 조회 시 ReservationException이 발생한다")
+        fun notFound() {
+            every { reservationRepository.findById(reservationId) } returns Optional.empty()
+
+            val ex = assertThrows<ReservationException> {
+                controller.getReservation(reservationId)
+            }
+
+            ex.errorCode shouldBe ErrorCode.RESERVATION_NOT_FOUND
+        }
+    }
+}

--- a/backend/reservation-service/src/test/resources/application-test.yml
+++ b/backend/reservation-service/src/test/resources/application-test.yml
@@ -15,12 +15,12 @@ spring:
     properties:
       hibernate:
         default_schema: reservation_service
-
-feign:
-  client:
-    config:
-      event-service:
-        url: http://localhost:8082
+  cloud:
+    openfeign:
+      client:
+        config:
+          event-service:
+            url: http://localhost:8082
 
 internal:
   api:

--- a/backend/user-service/src/main/resources/application-local.yml
+++ b/backend/user-service/src/main/resources/application-local.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: local
 
   datasource:
-    url: jdbc:postgresql://192.168.50.111:5432/ticket_queue?currentSchema=user_service,common
+    url: jdbc:postgresql://localhost:5432/ticket_queue?currentSchema=user_service,common
     username: user_svc_user
     password: ${db_password}
     driver-class-name: org.postgresql.Driver

--- a/docker/db_init/5_payment_service_ddl.sql
+++ b/docker/db_init/5_payment_service_ddl.sql
@@ -27,6 +27,9 @@ CREATE INDEX idx_payments_reservation ON payment_service.payments(reservation_id
 CREATE INDEX idx_payments_user_created ON payment_service.payments(user_id, created_at DESC);
 CREATE INDEX idx_payments_status_created ON payment_service.payments(status, created_at DESC);
 CREATE INDEX idx_payments_portone_response ON payment_service.payments USING GIN (portone_response);
+CREATE UNIQUE INDEX idx_payments_reservation_pending_success
+    ON payment_service.payments(reservation_id)
+    WHERE status IN ('PENDING', 'SUCCESS');
 
 -- updated_at 트리거 (payment_service.update_timestamp() 함수는 0_init_users_and_schemas.sh에서 이미 생성됨)
 CREATE TRIGGER trg_payments_updated_at

--- a/docs/code-review-payment-service.md
+++ b/docs/code-review-payment-service.md
@@ -1,0 +1,442 @@
+# Code Review: Payment Service 연동 구현 (#58)
+
+**브랜치:** `feature/58`  
+**리뷰 범위:** Payment Service 초기 구현 + Reservation Internal API + PortOne 연동  
+**리뷰 일자:** 2026-05-12
+
+---
+
+## 목차
+
+1. [P0 — 즉시 수정 필요](#p0--즉시-수정-필요)
+2. [P1 — 다음 PR 전 처리](#p1--다음-pr-전-처리)
+3. [P2 — 후속 PR 개선](#p2--후속-pr-개선)
+4. [P3 — 기술 부채 등록](#p3--기술-부채-등록)
+5. [긍정적 관찰](#긍정적-관찰)
+
+---
+
+## P0 — 즉시 수정 필요
+
+### 1. 외부 API 호출과 DB 트랜잭션 정합성 결함
+
+**파일:** `payment-service/.../service/PaymentService.kt:59-76`
+
+`portoneClient.preRegisterPayment(...)` 성공 후 `paymentRepository.save(...)` 실패 시, PortOne에는 `paymentKey`가 등록되고 로컬 DB에는 Payment 엔티티가 없는 **불일치 상태**가 발생한다.
+
+- `@Transactional` 범위 안에서 외부 HTTP 호출 → PortOne 응답 지연 시 DB 커넥션 점유 → 커넥션 풀 고갈 위험
+- SAGA 패턴 설계 의도와 충돌
+
+**권장 수정:**
+```
+1. DB save(PENDING 상태)를 먼저 수행하고 commit 후 PortOne pre-register 호출
+2. 또는 보정 잡(reconciliation)으로 orphan paymentKey 정리
+3. 외부 호출은 @Transactional 외부로 분리
+```
+
+---
+
+### 2. `ReservationDetailResponse` DTO 이중 정의 + `status` 타입 불일치
+
+**파일 1:** `reservation-service/.../controller/ReservationInternalController.kt:42` — `status: ReservationStatus` (Enum)  
+**파일 2:** `payment-service/.../client/ReservationServiceClient.kt:26` — `status: String`
+
+동일한 wire format을 나타내는 DTO가 두 서비스에 별도 정의되어 있고, `status` 타입이 불일치한다.  
+`PaymentService.kt:40`에서 `reservation.status != "PENDING"` 같은 **raw string 비교**로 이어지며, Reservation Service에서 enum 이름이 변경되거나 `@JsonValue`가 추가되면 **컴파일 타임에 감지 불가능한 silent failure** 발생.
+
+**권장 수정:**
+```
+단기: PaymentService 내부에 자체 Enum을 선언하거나 companion object 상수로 추출
+      → if (reservation.status != ReservationStatus.PENDING.name)
+장기: common 모듈에 공유 Enum/DTO 배치 (reservation-contract 모듈 추가)
+```
+
+---
+
+### 3. PortOne pre-register 실패 경로 테스트 미커버
+
+**파일:** `payment-service/.../test/.../service/PaymentServiceTest.kt`
+
+`portoneClient.preRegisterPayment(...)` 가 `FeignException`/`RetryableException`을 던지는 케이스가 전혀 없다. 결제 도메인에서 외부 API 실패는 핵심 분기점이며, P0-1번 정합성 결함과 직접 연결된다.
+
+**권장 추가:**
+```kotlin
+@Test
+fun portonePreRegisterFails() {
+    every { portoneClient.preRegisterPayment(any(), any(), any()) } throws FeignException(...)
+    // save가 호출되지 않아야 함
+    verify(exactly = 0) { paymentRepository.save(any()) }
+}
+```
+
+---
+
+### 4. 만료 시나리오 통합 테스트 미커버
+
+**파일:** `payment-service/.../test/.../controller/PaymentControllerIntegrationTest.kt:188-225`
+
+`BusinessFailure` 중첩 클래스에 `amountMismatch`, `forbidden` 케이스만 있고 Hold 만료 시나리오(`status != PENDING`, `holdExpiresAt` 경과)에 대한 통합 테스트가 없다. 컨트롤러 → 서비스 → ErrorCode → HTTP status 매핑까지 end-to-end 검증 누락.
+
+**권장 추가:**
+```
+- holdExpiredByStatus: status="CONFIRMED" → 400 + ErrorCode.HOLD_EXPIRED
+- holdExpiredByTime: holdExpiresAt = past → 400 + ErrorCode.HOLD_EXPIRED
+```
+
+---
+
+## P1 — 다음 PR 전 처리
+
+### 5. Stringly-typed 상태 비교
+
+**파일:** `payment-service/.../service/PaymentService.kt:40`
+
+```kotlin
+if (reservation.status != "PENDING") {  // ← raw string 비교
+    throw PaymentException(ErrorCode.HOLD_EXPIRED)
+}
+```
+
+오타 미탐지, IDE 리팩토링 지원 불가. P0-2번과 동일 원인.
+
+**권장 수정:**
+```kotlin
+companion object { const val STATUS_PENDING = "PENDING" }
+if (reservation.status != STATUS_PENDING) { ... }
+// 또는 Enum 공유 후 → reservation.status != ReservationStatus.PENDING
+```
+
+---
+
+### 6. Feign URL 프로퍼티 키 컨벤션 분기
+
+**파일 1:** `payment-service/.../client/ReservationServiceClient.kt:13` → `feign.client.config.reservation-service.url`  
+**파일 2:** 기존 `queue-service/.../client/EventServiceClient.kt` → `spring.cloud.openfeign.client.config.event-service.url`
+
+신규 추가된 `ReservationServiceClient`가 비표준 키를 사용하여 기존 컨벤션 분기를 더 굳혔다. Spring Cloud OpenFeign 공식 키는 `spring.cloud.openfeign.client.config.*`.
+
+**권장 수정:**
+```
+전체 Feign client URL 키를 spring.cloud.openfeign.client.config.{name}.url 로 통일
+```
+
+---
+
+### 7. 두 검증 분기가 동일 `ErrorCode(HOLD_EXPIRED)` 반환 — 의미 충돌
+
+**파일:** `payment-service/.../service/PaymentService.kt:40-46`
+
+```kotlin
+if (reservation.status != "PENDING") throw PaymentException(ErrorCode.HOLD_EXPIRED)  // 상태 문제
+if (!now.isBefore(holdExpiresAt))    throw PaymentException(ErrorCode.HOLD_EXPIRED)  // 시간 만료
+```
+
+`CANCELLED` 상태와 시간 초과는 다른 사건인데 동일 에러로 반환 → 클라이언트에게 부정확한 메시지 전달.
+
+**권장 수정:**
+```
+RESERVATION_NOT_PAYABLE (상태가 PENDING 아님) vs HOLD_EXPIRED (시간 초과) 분리
+```
+
+---
+
+### 8. `holdExpiresAt` timezone 불일치 위험
+
+**파일 1:** `payment-service/.../service/PaymentService.kt:44` — `LocalDateTime.now(ZoneOffset.UTC)` 사용  
+**파일 2:** `reservation-service/.../test/.../ReservationInternalControllerTest.kt:55` — zone 없는 `LocalDateTime.now()` 사용
+
+Reservation Service가 시스템 기본 zone(예: KST)으로 `holdExpiresAt`을 저장하고, Payment Service가 UTC 기준으로 비교하면 **9시간 일찍 만료 처리**될 수 있다.
+
+**권장 수정:**
+```
+양쪽 서비스 모두 Instant 또는 LocalDateTime.now(ZoneOffset.UTC)로 통일
+테스트 픽스처도 동일 zone 기준으로 수정
+```
+
+---
+
+### 9. Reservation 조회 실패(404/네트워크 에러) 테스트 미커버
+
+**파일:** `payment-service/.../test/.../service/PaymentServiceTest.kt`
+
+`reservationServiceClient.getReservation(...)` 이 404나 네트워크 에러를 던지는 케이스가 없다. 실서비스에서 결제 시점에 reservation이 만료/삭제되는 경합 상황은 흔하다.
+
+**권장 추가:**
+```
+- FeignException.NotFound 케이스 → 어떤 ErrorCode로 변환되는지 검증
+- RetryableException 케이스
+```
+
+---
+
+### 10. `PortoneProperties.storeId`/`channelKey` 매 요청마다 null 체크
+
+**파일:** `payment-service/.../service/PaymentService.kt:52-55`
+
+```kotlin
+val storeId = portoneProperties.storeId ?: error("external.portone.store-id is required")
+val channelKey = portoneProperties.channelKey ?: error("external.portone.channel-key is required")
+```
+
+불변 설정값임에도 매 결제 요청마다 검증 수행. `apiSecret`은 이미 `init {}`에서 부팅 시 검증하는데 이 두 값만 빠짐. `error()`는 `IllegalStateException`을 던져 운영 환경에서 5xx로 그대로 노출될 위험도 있음.
+
+**권장 수정:**
+```kotlin
+// PortoneProperties.kt
+init {
+    require(!storeId.isNullOrBlank()) { "external.portone.store-id is required" }
+    require(!channelKey.isNullOrBlank()) { "external.portone.channel-key is required" }
+}
+// → storeId, channelKey를 String(non-null)으로 선언, PaymentService에서 ?: error 제거
+```
+
+---
+
+### 11. 동일 `reservationId` 중복 결제 시도 동작 미정의/미테스트
+
+**파일:** 통합 테스트 전체
+
+같은 사용자가 재시도로 동일 `reservationId`에 대해 결제를 두 번 요청하는 경우의 동작이 정의되어 있지 않다. Payment 테이블의 unique constraint(어떤 컬럼 기준인지) 확인 필요.
+
+**권장 추가:**
+```
+concurrentDuplicatePayment 통합 테스트:
+같은 reservationId로 두 번 POST → 두 번째는 거부(또는 명시적으로 허용 문서화)
+```
+
+---
+
+### 12. `X-Service-Api-Key` 헤더 보안 검증 테스트 미커버
+
+**파일:** `reservation-service/.../test/.../controller/ReservationInternalControllerTest.kt`
+
+`standaloneSetup`으로 구성되어 보안 필터 제외. `/internal/**` 경로의 핵심 보안 메커니즘인 `InternalApiAuthInterceptor`가 어떤 테스트에서도 검증되지 않는다.
+
+**권장 추가:**
+```
+@SpringBootTest 통합 테스트로:
+- X-Service-Api-Key 헤더 누락 → 401/403
+- 잘못된 키 → 401/403
+- 올바른 키 → 200
+```
+
+---
+
+## P2 — 후속 PR 개선
+
+### 13. `PaymentStatus` 자기 전이 + early return 이중 가드
+
+**파일:** `payment-service/.../entity/PaymentStatus.kt:9-10`, `Payment.kt:67,78`
+
+```kotlin
+SUCCESS to setOf(SUCCESS, REFUNDED),  // SUCCESS→SUCCESS 자기 전이
+FAILED  to setOf(FAILED),             // FAILED→FAILED 자기 전이
+```
+
+`markSuccess`/`markFailed`에 이미 `if (status == TARGET) return` 가드가 있어 두 메커니즘이 같은 케이스를 이중 가드. `FAILED to setOf(FAILED)` 항목은 early return에 의해 `canTransitionTo` 체크에 도달하지 않아 사실상 죽은 코드.
+
+**권장 수정:**
+```kotlin
+PENDING to setOf(SUCCESS, FAILED),
+SUCCESS to setOf(REFUNDED),   // 자기 전이 제거
+FAILED  to emptySet(),        // FAILED는 종결 상태로 명시
+REFUNDED to emptySet()
+```
+
+---
+
+### 14. `SecurityConfig` 보일러플레이트 5개 서비스 중복
+
+**파일:** `payment-service`, `reservation-service`, `queue-service`, `event-service`, `user-service` 각 `SecurityConfig.kt`
+
+신규 추가된 `payment-service/SecurityConfig.kt`가 `reservation-service`와 99% 동일. `csrf disable`, STATELESS, `GatewayAuthFilter`, `SecurityErrorHandlers` 등록이 5개 서비스에서 반복.
+
+**권장 수정:**
+```kotlin
+// common-web/security에 헬퍼 추가
+fun standardChain(http: HttpSecurity, objectMapper: ObjectMapper, customize: (AuthorizeHttpRequestsConfigurer<*>.AuthorizationManagerRequestMatcherRegistry) -> Unit): SecurityFilterChain
+// 각 서비스는 endpoint 권한 규칙만 람다로 주입
+```
+
+---
+
+### 15. `ReservationInternalController` 내부에 DTO 인라인 정의
+
+**파일:** `reservation-service/.../controller/ReservationInternalController.kt:42-50`
+
+같은 서비스에 `dto/ReservationDto.kt`가 존재하는데 새 컨트롤러는 DTO를 inner class로 정의 → 서비스 내 DTO 위치 컨벤션 분기.
+
+**권장 수정:**
+```
+dto/ReservationDto.kt 내부에 ReservationDetailResponse 추가
+또는 dto/internal/ReservationInternalDto.kt 별도 파일로 분리
+```
+
+---
+
+### 16. `createPayment` 메서드 55줄 — 단일 책임 미흡
+
+**파일:** `payment-service/.../service/PaymentService.kt:33-87`
+
+예약 검증(4분기) + PortOne 설정 검증 + PortOne pre-register 호출 + DB 저장 + 응답 구성이 한 메서드에 혼재.
+
+**권장 수정:**
+```kotlin
+private fun validateReservation(reservation, userId, requestedAmount) { ... }
+// PortoneProperties.init에서 storeId/channelKey 검증 시 (b) 자동 제거
+```
+
+---
+
+### 17. `holdExpiresAt` 경계값 테스트 미커버
+
+**파일:** `payment-service/.../test/.../service/PaymentServiceTest.kt:147`
+
+`now == holdExpiresAt`인 정확한 경계값 케이스 없음. 시간 의존 코드는 `Clock`을 주입해 결정적으로 검증해야 한다.
+
+**권장 추가:**
+```kotlin
+// Clock 주입 패턴 도입 후
+@Test fun holdExpiredAtExactBoundary() {
+    val fixedNow = LocalDateTime.now(ZoneOffset.UTC)
+    every { reservationServiceClient.getReservation(any()) } returns
+        buildReservation(holdExpiresAt = fixedNow)  // now == expiry → 만료
+    assertThrows<PaymentException> { paymentService.createPayment(userId, request) }
+        .errorCode shouldBe ErrorCode.HOLD_EXPIRED
+}
+```
+
+---
+
+### 18. `PaymentMethod` enum 단일 값 — 미완성 신호
+
+**파일:** `payment-service/.../entity/PaymentMethod.kt`
+
+```kotlin
+enum class PaymentMethod { CARD }  // 단일 값
+```
+
+`CreateRequest.paymentMethod = PaymentMethod.CARD` 기본값으로 사실상 항상 CARD. 명세에 다른 결제수단이 예정되어 있지 않다면 enum을 제거하거나 TODO 주석으로 추적 필요.
+
+---
+
+### 19. `PortoneFeignConfig` vs 전역 `FeignConfig` 로깅 정책 충돌
+
+**파일:** `common-web/.../config/PortoneFeignConfig.kt`, `FeignConfig.kt`
+
+- 전역 `FeignConfig`에 `Logger.Level.FULL` 설정
+- PortOne 전용으로 `Logger.Level.BASIC`으로 다운그레이드
+
+일관성 없는 로깅 정책. `[PortOne]` prefix가 필요하다면 SLF4J MDC 또는 loggerName 매핑으로 처리하고 전역 정책에 맞추는 편이 낫다.
+
+---
+
+### 20. `ReservationInternalController`의 순차 2-쿼리
+
+**파일:** `reservation-service/.../controller/ReservationInternalController.kt:27-30`
+
+```kotlin
+val reservation = reservationRepository.findById(reservationId).orElseThrow { ... }
+val seatIds = reservationSeatRepository.findByReservationId(reservationId).map { it.seatId }
+```
+
+결제 hot-path에서 매 요청당 SELECT 2회. 트래픽 × 2 DB 부하.
+
+**권장 수정:**
+```
+@EntityGraph(attributePaths = ["seats"])로 join fetch
+또는 JPQL/Projection으로 단일 쿼리로 병합
+```
+
+---
+
+### 21. `PaymentControllerIntegrationTest` 픽스처 중복
+
+**파일:** `payment-service/.../test/.../controller/PaymentControllerIntegrationTest.kt`
+
+```kotlin
+mockMvc.perform(post("/payments").header(...).header(...).contentType(...).content(...))
+```
+위 패턴이 7번 반복.
+
+**권장 수정:**
+```kotlin
+private fun postPayment(body: Map<String, Any?>, userId: UUID? = this.userId): ResultActions
+```
+
+---
+
+### 22. `paymentMethod` 잘못된 enum 값 입력 테스트 미커버
+
+**파일:** `payment-service/.../test/.../controller/PaymentControllerIntegrationTest.kt`
+
+`"paymentMethod": "BITCOIN"` 같은 잘못된 enum 문자열 입력 시 Jackson이 어떤 응답을 반환하는지 검증 없음.
+
+**권장 추가:**
+```
+invalidPaymentMethod 테스트: "BITCOIN" 입력 → 400
+```
+
+---
+
+## P3 — 기술 부채 등록
+
+### 23. `PaymentException` 래퍼 패턴 5개 서비스 중복
+
+모든 서비스의 `XxxException`이 `BusinessException` 래퍼로 글자 단위 동일. 일관된 패턴을 따른 점은 긍정적이나 중복.
+
+**선택지:**
+```
+(a) BusinessException을 직접 throw하고 서비스 식별은 errorCode prefix로 구분
+(b) 서비스별 분리가 운영상 의미 있다면 유지 (현 방향)
+```
+
+---
+
+### 24. `Payment.refund()`에 idempotent early return 누락
+
+**파일:** `payment-service/.../entity/Payment.kt:87-92`
+
+`markSuccess`/`markFailed`는 `if (status == TARGET) return`이 있지만 `refund()`는 없어 형제 메서드와 일관성 없음.
+
+---
+
+### 25. `DateTimeUtils.now()` 데드코드
+
+**파일:** `common-core/.../util/DateTimeUtils.kt`
+
+`LocalDateTime.now(UTC)` 헬퍼가 존재하지만 코드베이스 어디에서도 사용되지 않는다. 전사 표준으로 강제하거나 제거 중 하나로 결정 필요.
+
+---
+
+### 26. `PortoneTokenService.synchronized(this)` 잠재적 lock contention
+
+**파일:** `common-web/.../external/portone/PortoneTokenService.kt:39-49`
+
+토큰 만료 임박 구간(2분)에서 동시 결제 요청이 모두 `synchronized(this)` 진입 시도. K-pop 콘서트처럼 트래픽이 한 번에 몰리는 환경에서 잠재적 stall.
+
+**권장 개선:**
+```
+백그라운드 갱신 스케줄러로 hot-path lock 진입 가능성 제거
+만료 임박 기준을 2분 → 5분으로 확대하여 여유 확보
+```
+
+---
+
+## 긍정적 관찰
+
+| 항목 | 설명 |
+|------|------|
+| PortOne 캡슐화 | `PortoneFeignClient`, `PortoneTokenService`, `PortoneProperties` 모두 `common-web`에 배치, User/Payment Service 양쪽에서 재사용 |
+| 내부 API 키 자동 주입 | `InternalFeignConfig` 재사용으로 `X-Service-Api-Key` 헤더 주입 자동화 |
+| 상태 전이 캡슐화 | `PaymentStatus.canTransitionTo()`로 전이 규칙을 enum이 책임지는 OOP 패턴 |
+| Entity invariant | `Payment.init {}`으로 `paymentKey`, `amount` 불변 조건을 entity가 직접 보장 |
+| equals/hashCode | JPA entity 표준 패턴 (`id` 기반, null-safe) 준수 |
+| 단위 테스트 | MockK 기반, 핵심 비즈니스 분기(forbidden/amountMismatch/holdExpired) 5가지 커버 |
+| Testcontainers | 통합 테스트에서 실제 PostgreSQL 사용으로 스키마 검증 |
+| 빈 Validation | `@field:NotNull`, `@field:Positive` Kotlin property 타깃 정확히 사용 |
+| DTO 분리 | `@RequestBody @Valid` + 별도 DTO 클래스로 controller/service 경계 유지 |
+
+---
+
+*Generated by code review agents (Reuse / Quality / Efficiency+Test) on 2026-05-12*

--- a/docs/specification/05_payment_service.md
+++ b/docs/specification/05_payment_service.md
@@ -11,7 +11,6 @@ Payment Service는 PortOne을 통한 결제 처리를 담당함
 - **URL:** `POST /payments`
 - **Headers:**
   - `Authorization: Bearer {accessToken}`
-  - `X-Queue-Token: {queueToken}`
 
 **Request Body**
 ```json
@@ -40,7 +39,6 @@ PortOne SDK 결제 완료 후, 서버에 최종 승인 요청
 - **URL:** `POST /payments/confirm`
 - **Headers:**
   - `Authorization: Bearer {accessToken}`
-  - `X-Queue-Token: {queueToken}`
 
 **Request Body**
 ```json


### PR DESCRIPTION
## Summary

- PortOne 연동 Payment Service 초기 구현 (결제 요청 API, pre-register, SAGA 기반 상태 관리)
- Reservation Internal API 추가 (Payment Service → Reservation Service 내부 통신)
- 코드 리뷰(P1/P2/P3) 피드백 반영: 비즈니스 로직 정확성, 설정 통일, 테스트 커버리지 확대

## Changes

**결제 요청 API (`payment-service`)**
- `POST /payments` 엔드포인트 구현 (예약 검증 → PortOne pre-register → Payment 저장)
- `PaymentService.validateReservation()` 분리로 단일 책임 개선
- `PaymentStatus` 자기 전이(SUCCESS→SUCCESS, FAILED→FAILED) 제거
- `Payment.refund()` idempotent early return 추가
- `PortoneFeignConfig` 로깅 레벨 전역 FULL 정책으로 통일

**Reservation Internal API (`reservation-service`)**
- `GET /internal/reservations/{reservationId}` 엔드포인트 추가
- `X-Service-Api-Key` 헤더 기반 내부 API 보안 적용

**설정 통일 (`common-web`, 각 서비스)**
- Feign URL 프로퍼티 키 `spring.cloud.openfeign.client.config.*` 로 전체 통일
- `application-test.yml` `spring.cloud` 중복 키 버그 수정 (통합 테스트 전체 실패 원인)

**테스트**
- `PaymentServiceTest`: 8개 단위 테스트 (정상 흐름, forbidden, 금액 불일치, 상태 검증, 404/네트워크 오류, 중복 결제, 만료 시간 경계값, PortOne 실패)
- `PaymentControllerIntegrationTest`: 12개 통합 테스트 (Testcontainers PostgreSQL, 비즈니스 검증 전 케이스 + invalidPaymentMethod)
- `ReservationInternalControllerTest` / `SecurityTest`: Internal API 정상/보안 케이스

## Test Plan

- [x] `./gradlew :payment-service:test` 전체 통과 (21개)
- [x] `./gradlew :reservation-service:test` 전체 통과
- [x] Testcontainers 통합 테스트 실제 PostgreSQL 연동 확인

## Related Issues

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payment creation flow with reservation validation and PortOne integration.
  * Internal reservation lookup endpoint for services.

* **Configuration**
  * Local service endpoints default to localhost.
  * Feign configuration reorganized and PortOne-specific request logging enabled.

* **Bug Fixes**
  * New payment/reservation error codes, tightened payment state transitions, idempotent refund guard.
  * Enforced unique pending/success payment constraint.

* **Tests**
  * Extensive unit, integration, and security tests for payment and internal APIs.

* **Documentation**
  * Added payment service code-review notes and updated API spec headers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paircoders/ticket-queue/pull/224)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->