### PR TITLE
refactor: [Common/Reservation] OutboxEventRecorder 헬퍼 도입 및 ReservationService 적용 (#228)

### DIFF
--- a/backend/common-jpa/src/main/kotlin/com/ticketqueue/common/outbox/OutboxEvent.kt
+++ b/backend/common-jpa/src/main/kotlin/com/ticketqueue/common/outbox/OutboxEvent.kt
@@ -3,17 +3,28 @@ package com.ticketqueue.common.outbox
 import jakarta.persistence.*
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
+import org.springframework.data.domain.Persistable
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.util.UUID
 
+/**
+ * Transactional Outbox row.
+ *
+ * **ID 정책 (SOT):** `id` 는 `BaseEvent.eventId` 와 동일한 UUID로 호출자가 명시 주입한다.
+ * outbox row PK ↔ Kafka 발행 payload eventId ↔ Consumer `processed_events.event_id` 가 1:1 매핑된다.
+ *
+ * **`Persistable<UUID>` 사용 이유:** 명시 id non-null entity는 기본적으로 `SimpleJpaRepository.save()` 가
+ * `merge()` (SELECT-then-INSERT) 경로를 탄다. `@Transient _isNew` + `@PostLoad/@PostPersist` 토글로
+ * 신규 entity 는 `persist()` (pure INSERT) 경로를 유지하여 N+1 SELECT 를 회피한다.
+ */
 @Entity
+@Access(AccessType.FIELD)
 @Table(name = "outbox_events", schema = "common")
 class OutboxEvent(
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "id")
-    val id: UUID? = null,
+    private val id: UUID,
 
     @Column(name = "aggregate_type", nullable = false, length = 50)
     val aggregateType: String,
@@ -42,12 +53,26 @@ class OutboxEvent(
 
     @Column(name = "created_at", nullable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC)
-) {
+) : Persistable<UUID> {
+
+    @Transient
+    private var _isNew: Boolean = true
+
+    override fun getId(): UUID = id
+
+    override fun isNew(): Boolean = _isNew
+
+    @PostLoad
+    @PostPersist
+    fun markNotNew() {
+        _isNew = false
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is OutboxEvent) return false
-        return id != null && id == other.id
+        return id == other.id
     }
 
-    override fun hashCode(): Int = id?.hashCode() ?: 0
+    override fun hashCode(): Int = id.hashCode()
 }

--- a/backend/common-jpa/src/test/kotlin/com/ticketqueue/common/outbox/OutboxEventRepositoryCustomImplTest.kt
+++ b/backend/common-jpa/src/test/kotlin/com/ticketqueue/common/outbox/OutboxEventRepositoryCustomImplTest.kt
@@ -67,6 +67,7 @@ class OutboxEventRepositoryCustomImplTest {
         publishedAt: LocalDateTime? = null,
         aggregateType: String = "TestAggregate"
     ): OutboxEvent = OutboxEvent(
+        id = UUID.randomUUID(),
         aggregateType = aggregateType,
         aggregateId = UUID.randomUUID(),
         eventType = "TestEvent",
@@ -106,10 +107,10 @@ class OutboxEventRepositoryCustomImplTest {
         ).sortedBy { it.toString() }.let {
             outboxEventRepository.findAll().map { e -> e.id }
         }
-        outboxEventRepository.existsById(toDelete.id!!) shouldBe false
-        outboxEventRepository.existsById(notPublished.id!!) shouldBe true
-        outboxEventRepository.existsById(notYet.id!!) shouldBe true
-        outboxEventRepository.existsById(otherType.id!!) shouldBe true
+        outboxEventRepository.existsById(toDelete.id) shouldBe false
+        outboxEventRepository.existsById(notPublished.id) shouldBe true
+        outboxEventRepository.existsById(notYet.id) shouldBe true
+        outboxEventRepository.existsById(otherType.id) shouldBe true
     }
 
     @Test
@@ -131,9 +132,9 @@ class OutboxEventRepositoryCustomImplTest {
         val deleted = outboxEventRepository.deleteAllPublishedEventsBefore(cutoff)
 
         deleted shouldBe 2L
-        outboxEventRepository.existsById(payment.id!!) shouldBe false
-        outboxEventRepository.existsById(reservation.id!!) shouldBe false
-        outboxEventRepository.existsById(notPublished.id!!) shouldBe true
+        outboxEventRepository.existsById(payment.id) shouldBe false
+        outboxEventRepository.existsById(reservation.id) shouldBe false
+        outboxEventRepository.existsById(notPublished.id) shouldBe true
     }
 
     @Test
@@ -149,6 +150,6 @@ class OutboxEventRepositoryCustomImplTest {
         val deleted = outboxEventRepository.deleteAllPublishedEventsBefore(cutoff)
 
         deleted shouldBe 0L
-        outboxEventRepository.existsById(unpublished.id!!) shouldBe true
+        outboxEventRepository.existsById(unpublished.id) shouldBe true
     }
 }

--- a/backend/common-kafka/src/main/kotlin/com/ticketqueue/common/outbox/OutboxEventRecorder.kt
+++ b/backend/common-kafka/src/main/kotlin/com/ticketqueue/common/outbox/OutboxEventRecorder.kt
@@ -1,0 +1,41 @@
+package com.ticketqueue.common.outbox
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.event.BaseEvent
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * `BaseEvent` 를 `OutboxEvent` 로 변환하여 Transactional Outbox 테이블에 저장하는 공용 헬퍼.
+ *
+ * **ID 바인딩 (SOT):** `OutboxEvent.id == event.eventId`
+ *   → Consumer 의 `processed_events.event_id` 와 1:1 매핑 가능 (멱등성 추적 기반).
+ *
+ * **트랜잭션:** `PROPAGATION_MANDATORY` — 활성 트랜잭션 부재 시 즉시 예외.
+ *   Transactional Outbox Pattern 은 비즈니스 변경과 outbox INSERT 의 원자성에 의존하므로,
+ *   호출자(`@Transactional` 메서드 또는 `TransactionTemplate` 람다 내부)가 트랜잭션을 책임진다.
+ *
+ * **멱등성:** 동일 `eventId` 로 두 번 `record()` 호출 시 PK 충돌
+ *   → `DataIntegrityViolationException`. 호출자가 재시도 멱등성 보장에 활용 가능.
+ *
+ * 재사용 예정: `ReservationService.cancelReservation()`, `PaymentService` (Outbox 도입 시).
+ */
+@Component
+class OutboxEventRecorder(
+    private val outboxEventRepository: OutboxEventRepository,
+    private val objectMapper: ObjectMapper
+) {
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    fun record(event: BaseEvent): OutboxEvent =
+        outboxEventRepository.save(
+            OutboxEvent(
+                id = event.eventId,
+                aggregateType = event.aggregateType,
+                aggregateId = event.aggregateId,
+                eventType = event.eventType,
+                payload = objectMapper.writeValueAsString(event)
+            )
+        )
+}

--- a/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxEventRecorderIntegrationTest.kt
+++ b/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxEventRecorderIntegrationTest.kt
@@ -1,0 +1,148 @@
+package com.ticketqueue.common.outbox
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.event.EventMetadata
+import com.ticketqueue.common.event.ReservationCancelledEvent
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.test.annotation.Rollback
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@ActiveProfiles("test")
+@Import(OutboxEventRecorderIntegrationTest.RecorderTestConfig::class)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Rollback(false)
+@DisplayName("OutboxEventRecorder DB round-trip 통합 테스트")
+class OutboxEventRecorderIntegrationTest {
+
+    @TestConfiguration
+    class RecorderTestConfig {
+        @Bean
+        fun outboxEventRecorder(
+            outboxEventRepository: OutboxEventRepository,
+            objectMapper: ObjectMapper
+        ): OutboxEventRecorder = OutboxEventRecorder(outboxEventRepository, objectMapper)
+
+        @Bean
+        fun txTemplate(txManager: PlatformTransactionManager): TransactionTemplate =
+            TransactionTemplate(txManager)
+    }
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer<Nothing>("postgres:15-alpine").apply {
+            withDatabaseName("testdb")
+            withUsername("test")
+            withPassword("test")
+        }
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun props(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+            registry.add("spring.jpa.hibernate.ddl-auto") { "create-drop" }
+            registry.add("spring.jpa.properties.hibernate.default_schema") { "common" }
+            registry.add("spring.jpa.properties.hibernate.hbm2ddl.create_namespaces") { "true" }
+        }
+    }
+
+    @Autowired
+    lateinit var recorder: OutboxEventRecorder
+
+    @Autowired
+    lateinit var outboxEventRepository: OutboxEventRepository
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    lateinit var txTemplate: TransactionTemplate
+
+    @AfterEach
+    fun cleanUp() {
+        outboxEventRepository.deleteAll()
+    }
+
+    @Test
+    @DisplayName("record() 후 DB에서 event.eventId로 조회 가능 (SOT 라운드트립)")
+    fun roundtrip() {
+        val event = sampleEvent()
+
+        txTemplate.executeWithoutResult { recorder.record(event) }
+
+        val saved = outboxEventRepository.findById(event.eventId).orElseThrow()
+        saved.id shouldBe event.eventId
+        saved.aggregateType shouldBe "Reservation"
+        saved.aggregateId shouldBe event.aggregateId
+        saved.eventType shouldBe "ReservationCancelled"
+        saved.published shouldBe false
+
+        val deserialized = objectMapper.readValue(saved.payload, ReservationCancelledEvent::class.java)
+        deserialized.eventId shouldBe event.eventId
+        deserialized.userId shouldBe event.userId
+        deserialized.seatIds shouldBe event.seatIds
+    }
+
+    @Test
+    @DisplayName("동일 eventId로 두 번 record() 시 PK 충돌 (DataIntegrityViolationException) — producer-side 멱등성")
+    fun pkConflictOnDuplicateEventId() {
+        val event = sampleEvent()
+
+        txTemplate.executeWithoutResult { recorder.record(event) }
+
+        assertThrows<DataIntegrityViolationException> {
+            txTemplate.executeWithoutResult { recorder.record(event) }
+        }
+
+        outboxEventRepository.count() shouldBe 1L
+    }
+
+    @Test
+    @DisplayName("서로 다른 eventId 이벤트 두 건은 충돌 없이 저장된다")
+    fun twoDistinctEventsCoexist() {
+        val e1 = sampleEvent()
+        val e2 = sampleEvent()
+
+        txTemplate.executeWithoutResult { recorder.record(e1) }
+        txTemplate.executeWithoutResult { recorder.record(e2) }
+
+        outboxEventRepository.count() shouldBe 2L
+        outboxEventRepository.findById(e1.eventId).isPresent shouldBe true
+        outboxEventRepository.findById(e2.eventId).isPresent shouldBe true
+    }
+
+    private fun sampleEvent() = ReservationCancelledEvent(
+        aggregateId = UUID.randomUUID(),
+        scheduleId = UUID.randomUUID(),
+        seatIds = listOf(UUID.randomUUID()),
+        userId = UUID.randomUUID(),
+        reason = "USER_REQUEST",
+        metadata = EventMetadata(userId = UUID.randomUUID())
+    )
+}

--- a/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxEventRecorderTest.kt
+++ b/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxEventRecorderTest.kt
@@ -1,0 +1,121 @@
+package com.ticketqueue.common.outbox
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.event.EventMetadata
+import com.ticketqueue.common.event.ReservationCancelledEvent
+import com.ticketqueue.common.event.ReservationConfirmedEvent
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.dao.DataIntegrityViolationException
+import java.util.UUID
+
+@DisplayName("OutboxEventRecorder 단위 테스트")
+class OutboxEventRecorderTest {
+
+    private lateinit var outboxEventRepository: OutboxEventRepository
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var recorder: OutboxEventRecorder
+
+    @BeforeEach
+    fun setUp() {
+        outboxEventRepository = mockk()
+        objectMapper = jacksonObjectMapper().apply { registerModule(JavaTimeModule()) }
+        recorder = OutboxEventRecorder(outboxEventRepository, objectMapper)
+    }
+
+    @Test
+    @DisplayName("record() 호출 시 OutboxEvent.id == event.eventId (SOT 바인딩)")
+    fun recordBindsEventIdToOutboxId() {
+        val event = sampleCancelledEvent()
+        val slot = slot<OutboxEvent>()
+        every { outboxEventRepository.save(capture(slot)) } answers { firstArg() }
+
+        recorder.record(event)
+
+        slot.captured.id shouldBe event.eventId
+    }
+
+    @Test
+    @DisplayName("aggregateType, aggregateId, eventType이 BaseEvent에서 정확히 전달된다")
+    fun recordMapsBaseEventFields() {
+        val event = sampleCancelledEvent()
+        val slot = slot<OutboxEvent>()
+        every { outboxEventRepository.save(capture(slot)) } answers { firstArg() }
+
+        recorder.record(event)
+
+        slot.captured.aggregateType shouldBe "Reservation"
+        slot.captured.eventType shouldBe "ReservationCancelled"
+        slot.captured.aggregateId shouldBe event.aggregateId
+    }
+
+    @Test
+    @DisplayName("payload는 ObjectMapper로 직렬화된 JSON 문자열이며 원본 이벤트와 동등하게 역직렬화된다")
+    fun recordSerializesPayloadAsRoundtrippableJson() {
+        val event = sampleCancelledEvent()
+        val slot = slot<OutboxEvent>()
+        every { outboxEventRepository.save(capture(slot)) } answers { firstArg() }
+
+        recorder.record(event)
+
+        val deserialized = objectMapper.readValue(slot.captured.payload, ReservationCancelledEvent::class.java)
+        deserialized.eventId shouldBe event.eventId
+        deserialized.aggregateId shouldBe event.aggregateId
+        deserialized.scheduleId shouldBe event.scheduleId
+        deserialized.seatIds shouldBe event.seatIds
+        deserialized.userId shouldBe event.userId
+        deserialized.reason shouldBe event.reason
+    }
+
+    @Test
+    @DisplayName("다른 BaseEvent 서브타입(ReservationConfirmedEvent)에서도 동일하게 동작한다")
+    fun recordWorksForOtherBaseEventSubtypes() {
+        val event = ReservationConfirmedEvent(
+            aggregateId = UUID.randomUUID(),
+            scheduleId = UUID.randomUUID(),
+            seatIds = listOf(UUID.randomUUID()),
+            userId = UUID.randomUUID()
+        )
+        val slot = slot<OutboxEvent>()
+        every { outboxEventRepository.save(capture(slot)) } answers { firstArg() }
+
+        recorder.record(event)
+
+        slot.captured.id shouldBe event.eventId
+        slot.captured.aggregateType shouldBe "Reservation"
+        slot.captured.eventType shouldBe "ReservationConfirmed"
+    }
+
+    @Test
+    @DisplayName("repository.save()가 DataIntegrityViolationException을 던지면 record()가 동일 예외를 전파한다")
+    fun recordPropagatesPkConflict() {
+        val event = sampleCancelledEvent()
+        every { outboxEventRepository.save(any()) } throws
+            DataIntegrityViolationException("duplicate key value violates unique constraint")
+
+        assertThrows<DataIntegrityViolationException> {
+            recorder.record(event)
+        }
+    }
+
+    private fun sampleCancelledEvent() = ReservationCancelledEvent(
+        aggregateId = UUID.randomUUID(),
+        scheduleId = UUID.randomUUID(),
+        seatIds = listOf(UUID.randomUUID(), UUID.randomUUID()),
+        userId = UUID.randomUUID(),
+        reason = "USER_REQUEST",
+        metadata = EventMetadata(
+            correlationId = UUID.randomUUID(),
+            causationId = null,
+            userId = UUID.randomUUID()
+        )
+    )
+}

--- a/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxPollerDlqIntegrationTest.kt
+++ b/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxPollerDlqIntegrationTest.kt
@@ -121,7 +121,7 @@ class OutboxPollerDlqIntegrationTest {
         dlqPayload["eventType"] shouldBe "PaymentSuccess"
 
         // Verify event is marked as published
-        val updatedEvent = outboxEventRepository.findById(event.id!!).get()
+        val updatedEvent = outboxEventRepository.findById(event.id).get()
         updatedEvent.published shouldBe true
         updatedEvent.retryCount shouldBe 3
     }
@@ -168,7 +168,7 @@ class OutboxPollerDlqIntegrationTest {
         dlqPayload["eventType"] shouldBe "ReservationCancelled"
 
         // Verify event is marked as published
-        val updatedEvent = outboxEventRepository.findById(event.id!!).get()
+        val updatedEvent = outboxEventRepository.findById(event.id).get()
         updatedEvent.published shouldBe true
         updatedEvent.retryCount shouldBe 3
     }
@@ -198,7 +198,7 @@ class OutboxPollerDlqIntegrationTest {
         kafkaContainer.stop()
 
         // Manually set retryCount to 2 to trigger DLQ on next poll
-        val updatedEvent = outboxEventRepository.findById(event.id!!).get()
+        val updatedEvent = outboxEventRepository.findById(event.id).get()
         updatedEvent.retryCount = 2
         outboxEventRepository.save(updatedEvent)
 
@@ -232,7 +232,7 @@ class OutboxPollerDlqIntegrationTest {
         payloadData["amount"] shouldBe originalAmount
 
         // Verify event is marked as published
-        val finalEvent = outboxEventRepository.findById(event.id!!).get()
+        val finalEvent = outboxEventRepository.findById(event.id).get()
         finalEvent.published shouldBe true
         finalEvent.publishedAt shouldNotBe null
         finalEvent.retryCount shouldBe 3

--- a/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxPollerEdgeCaseIntegrationTest.kt
+++ b/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxPollerEdgeCaseIntegrationTest.kt
@@ -88,6 +88,7 @@ class OutboxPollerEdgeCaseIntegrationTest {
 
         for (i in 1..eventCount) {
             val event = OutboxEvent(
+                id = UUID.randomUUID(),
                 aggregateType = "Payment",
                 aggregateId = UUID.randomUUID(),
                 eventType = "PaymentSuccess",
@@ -124,6 +125,7 @@ class OutboxPollerEdgeCaseIntegrationTest {
         repeat(eventCount) { i ->
             outboxEventRepository.save(
                 OutboxEvent(
+                    id = UUID.randomUUID(),
                     aggregateType = "Payment",
                     aggregateId = UUID.randomUUID(),
                     eventType = "PaymentSuccess",
@@ -175,6 +177,7 @@ class OutboxPollerEdgeCaseIntegrationTest {
     private fun insertEventAndRollback() {
         outboxEventRepository.save(
             OutboxEvent(
+                id = UUID.randomUUID(),
                 aggregateType = "Payment",
                 aggregateId = UUID.randomUUID(),
                 eventType = "PaymentSuccess",

--- a/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxPollerIntegrationTest.kt
+++ b/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxPollerIntegrationTest.kt
@@ -81,6 +81,7 @@ class OutboxPollerIntegrationTest {
         val aggregateId = UUID.randomUUID()
         val event = outboxEventRepository.save(
             OutboxEvent(
+                id = UUID.randomUUID(),
                 aggregateType = "Payment",
                 aggregateId = aggregateId,
                 eventType = "PaymentSuccess",
@@ -95,7 +96,7 @@ class OutboxPollerIntegrationTest {
             .atMost(Duration.ofSeconds(5))
             .pollInterval(Duration.ofMillis(500))
             .untilAsserted {
-                val savedEvent = outboxEventRepository.findById(event.id!!).get()
+                val savedEvent = outboxEventRepository.findById(event.id).get()
                 savedEvent.published shouldBe true
                 savedEvent.publishedAt shouldNotBe null
             }
@@ -118,6 +119,7 @@ class OutboxPollerIntegrationTest {
         val payload = createPaymentPayload(aggregateId)
         outboxEventRepository.save(
             OutboxEvent(
+                id = UUID.randomUUID(),
                 aggregateType = "Payment",
                 aggregateId = aggregateId,
                 eventType = "PaymentSuccess",
@@ -147,6 +149,7 @@ class OutboxPollerIntegrationTest {
         val payload = createReservationPayload(aggregateId)
         outboxEventRepository.save(
             OutboxEvent(
+                id = UUID.randomUUID(),
                 aggregateType = "Reservation",
                 aggregateId = aggregateId,
                 eventType = "ReservationCancelled",
@@ -176,6 +179,7 @@ class OutboxPollerIntegrationTest {
             Thread.sleep(1) // Ensure different createdAt timestamps
             outboxEventRepository.save(
                 OutboxEvent(
+                    id = UUID.randomUUID(),
                     aggregateType = "Payment",
                     aggregateId = UUID.randomUUID(),
                     eventType = "PaymentSuccess",
@@ -214,7 +218,7 @@ class OutboxPollerIntegrationTest {
 
         // Verify message order (createdAt order should be preserved)
         val messages = kafkaTestConsumer.getMessages("payment.events")
-        val eventIds = events.map { it.id!! }
+        val eventIds = events.map { it.id }
         val receivedEventIndices = messages.mapNotNull { message ->
             // Extract event index from correlation ID
             val correlationId = message.substringAfter("\"correlationId\":\"")
@@ -236,6 +240,7 @@ class OutboxPollerIntegrationTest {
         val aggregateId = UUID.randomUUID()
         val publishedEvent = outboxEventRepository.save(
             OutboxEvent(
+                id = UUID.randomUUID(),
                 aggregateType = "Payment",
                 aggregateId = aggregateId,
                 eventType = "PaymentSuccess",
@@ -256,7 +261,7 @@ class OutboxPollerIntegrationTest {
         messages shouldHaveSize 0
 
         // Event should still be marked as published
-        val event = outboxEventRepository.findById(publishedEvent.id!!).get()
+        val event = outboxEventRepository.findById(publishedEvent.id).get()
         event.published shouldBe true
     }
 

--- a/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxPollerRetryIntegrationTest.kt
+++ b/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxPollerRetryIntegrationTest.kt
@@ -99,7 +99,7 @@ class OutboxPollerRetryIntegrationTest {
 
         // Then: 성공하면 published=true, retryCount는 변경 안 됨
         await().atMost(3, TimeUnit.SECONDS).untilAsserted {
-            val updated = outboxEventRepository.findById(event.id!!).orElseThrow()
+            val updated = outboxEventRepository.findById(event.id).orElseThrow()
             updated.published shouldBe true
             updated.publishedAt shouldNotBe null
             updated.retryCount shouldBe 2 // 성공 시 retryCount는 증가하지 않음
@@ -125,7 +125,7 @@ class OutboxPollerRetryIntegrationTest {
 
         // Then: retryCount=3, published=true (DLQ 이동 후 마킹)
         await().atMost(5, TimeUnit.SECONDS).untilAsserted {
-            val updated = outboxEventRepository.findById(savedEvent.id!!).orElseThrow()
+            val updated = outboxEventRepository.findById(savedEvent.id).orElseThrow()
             updated.retryCount shouldBe 3
             updated.published shouldBe true
             updated.publishedAt shouldNotBe null
@@ -158,7 +158,7 @@ class OutboxPollerRetryIntegrationTest {
 
         // Then: DLQ 전송 실패해도 published=true로 마킹됨 (현재 구현)
         await().atMost(5, TimeUnit.SECONDS).untilAsserted {
-            val updated = outboxEventRepository.findById(savedEvent.id!!).orElseThrow()
+            val updated = outboxEventRepository.findById(savedEvent.id).orElseThrow()
             updated.published shouldBe true
             updated.retryCount shouldBe 3
         }
@@ -183,7 +183,7 @@ class OutboxPollerRetryIntegrationTest {
         Thread.sleep(2500)
 
         // Then: retryCount=3 유지, published=false 유지 (변화 없음)
-        val unchanged = outboxEventRepository.findById(savedEvent.id!!).orElseThrow()
+        val unchanged = outboxEventRepository.findById(savedEvent.id).orElseThrow()
         unchanged.retryCount shouldBe 3
         unchanged.published shouldBe false
         unchanged.publishedAt shouldBe null
@@ -194,6 +194,7 @@ class OutboxPollerRetryIntegrationTest {
 
     private fun createOutboxEvent(aggregateType: String, eventType: String): OutboxEvent {
         return OutboxEvent(
+            id = UUID.randomUUID(),
             aggregateType = aggregateType,
             aggregateId = UUID.randomUUID(),
             eventType = eventType,

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
@@ -5,8 +5,7 @@ import com.ticketqueue.common.event.EventMetadata
 import java.math.BigDecimal
 import com.ticketqueue.common.event.ReservationCancelledEvent
 import com.ticketqueue.common.exception.ErrorCode
-import com.ticketqueue.common.outbox.OutboxEvent
-import com.ticketqueue.common.outbox.OutboxEventRepository
+import com.ticketqueue.common.outbox.OutboxEventRecorder
 import com.ticketqueue.reservation.client.EventServiceClient
 import com.ticketqueue.reservation.dto.ReservationDto.CancelResponse
 import com.ticketqueue.reservation.dto.ReservationDto.ChangeSeatsRequest
@@ -45,7 +44,7 @@ class ReservationService(
     private val reservationSeatRepository: ReservationSeatRepository,
     private val objectMapper: ObjectMapper,
     private val transactionTemplate: TransactionTemplate,
-    private val outboxEventRepository: OutboxEventRepository
+    private val outboxEventRecorder: OutboxEventRecorder
 ) {
 
     private val log = KotlinLogging.logger {}
@@ -316,24 +315,17 @@ class ReservationService(
 
         transactionTemplate.executeWithoutResult {
             reservation.cancel()
-            outboxEventRepository.save(
-                OutboxEvent(
-                    aggregateType = "Reservation",
+            outboxEventRecorder.record(
+                ReservationCancelledEvent(
                     aggregateId = reservationId,
-                    eventType = "ReservationCancelled",
-                    payload = objectMapper.writeValueAsString(
-                        ReservationCancelledEvent(
-                            aggregateId = reservationId,
-                            scheduleId = reservation.scheduleId,
-                            seatIds = seatIds,
-                            userId = reservation.userId,
-                            reason = "USER_REQUEST",
-                            metadata = EventMetadata(
-                                correlationId = UUID.randomUUID(),
-                                causationId = null,
-                                userId = reservation.userId
-                            )
-                        )
+                    scheduleId = reservation.scheduleId,
+                    seatIds = seatIds,
+                    userId = reservation.userId,
+                    reason = "USER_REQUEST",
+                    metadata = EventMetadata(
+                        correlationId = UUID.randomUUID(),
+                        causationId = null,
+                        userId = reservation.userId
                     )
                 )
             )

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/CancelReservationOutboxIntegrationTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/CancelReservationOutboxIntegrationTest.kt
@@ -1,0 +1,169 @@
+package com.ticketqueue.reservation.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.ninjasquad.springmockk.MockkBean
+import com.ticketqueue.common.event.ReservationCancelledEvent
+import com.ticketqueue.common.outbox.OutboxEventRepository
+import com.ticketqueue.reservation.client.EventServiceClient
+import com.ticketqueue.reservation.entity.Reservation
+import com.ticketqueue.reservation.entity.ReservationSeat
+import com.ticketqueue.reservation.entity.ReservationStatus
+import com.ticketqueue.reservation.repository.ReservationRepository
+import com.ticketqueue.reservation.repository.ReservationSeatRepository
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "spring.config.import=",
+        "spring.cloud.aws.region.static=us-east-1",
+        "spring.cloud.aws.credentials.access-key=test",
+        "spring.cloud.aws.credentials.secret-key=test",
+        "spring.cloud.aws.secretsmanager.enabled=false"
+    ]
+)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("예매 취소 Outbox 통합 테스트 (DELETE /reservations/{id} → outbox row)")
+class CancelReservationOutboxIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("ticketing")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("db/init.sql")
+
+        @Container
+        @JvmStatic
+        val valkey = GenericContainer("valkey/valkey:8.1.5-alpine3.23")
+            .withExposedPorts(6379)
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
+            registry.add("spring.datasource.username") { postgres.username }
+            registry.add("spring.datasource.password") { postgres.password }
+            registry.add("spring.data.redis.host") { valkey.host }
+            registry.add("spring.data.redis.port") { valkey.getMappedPort(6379) }
+        }
+    }
+
+    @Autowired private lateinit var mockMvc: MockMvc
+    @Autowired private lateinit var objectMapper: ObjectMapper
+    @Autowired private lateinit var reservationRepository: ReservationRepository
+    @Autowired private lateinit var reservationSeatRepository: ReservationSeatRepository
+    @Autowired private lateinit var outboxEventRepository: OutboxEventRepository
+
+    @MockkBean private lateinit var eventServiceClient: EventServiceClient
+
+    private val userId = UUID.randomUUID()
+    private val scheduleId = UUID.randomUUID()
+    private val eventId = UUID.randomUUID()
+    private val seatIdA = UUID.randomUUID()
+    private val seatIdB = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        every { eventServiceClient.getScheduleInfo(scheduleId) } returns
+            EventServiceClient.ScheduleInfoResponse(
+                scheduleId = scheduleId,
+                eventId = eventId,
+                eventStartAt = LocalDateTime.now(ZoneOffset.UTC).plusDays(3),
+                eventEndAt = LocalDateTime.now(ZoneOffset.UTC).plusDays(3).plusHours(3),
+                saleStartAt = LocalDateTime.now(ZoneOffset.UTC).minusDays(7),
+                saleEndAt = LocalDateTime.now(ZoneOffset.UTC).plusDays(2)
+            )
+    }
+
+    @AfterEach
+    fun cleanUp() {
+        outboxEventRepository.deleteAll()
+        reservationSeatRepository.deleteAll()
+        reservationRepository.deleteAll()
+    }
+
+    @Test
+    @DisplayName("PENDING 예매 취소 시 outbox_events row 1건이 INSERT 되고 id == payload eventId 이다 (SOT)")
+    fun cancelInsertsOutboxRowWithIdEqualToEventId() {
+        val reservation = persistPendingReservation()
+        persistSeats(reservation.id!!, listOf(seatIdA, seatIdB))
+
+        mockMvc.perform(
+            delete("/reservations/{reservationId}", reservation.id)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+        ).andExpect(status().isOk)
+
+        val outboxRows = outboxEventRepository.findAll().toList()
+        outboxRows shouldHaveSize 1
+
+        val row = outboxRows.single()
+        row.aggregateType shouldBe "Reservation"
+        row.aggregateId shouldBe reservation.id
+        row.eventType shouldBe "ReservationCancelled"
+        row.published shouldBe false
+
+        val payload = objectMapper.readValue<ReservationCancelledEvent>(row.payload)
+        row.id shouldBe payload.eventId
+        payload.scheduleId shouldBe scheduleId
+        payload.userId shouldBe userId
+        payload.seatIds.sortedBy { it.toString() } shouldBe
+            listOf(seatIdA, seatIdB).sortedBy { it.toString() }
+        payload.reason shouldBe "USER_REQUEST"
+    }
+
+    private fun persistPendingReservation(): Reservation {
+        val reservation = Reservation(
+            userId = userId,
+            scheduleId = scheduleId,
+            eventId = eventId,
+            status = ReservationStatus.PENDING,
+            totalAmount = BigDecimal("200000"),
+            holdExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5)
+        )
+        return reservationRepository.save(reservation)
+    }
+
+    private fun persistSeats(reservationId: UUID, seatIds: List<UUID>) {
+        seatIds.forEachIndexed { idx, seatId ->
+            reservationSeatRepository.save(
+                ReservationSeat(
+                    reservationId = reservationId,
+                    seatId = seatId,
+                    seatNumber = "A-${idx + 1}",
+                    grade = "VIP",
+                    price = BigDecimal("100000")
+                )
+            )
+        }
+    }
+}

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ReservationServiceTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ReservationServiceTest.kt
@@ -5,8 +5,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.ticketqueue.common.event.ReservationCancelledEvent
 import com.ticketqueue.common.exception.ErrorCode
-import com.ticketqueue.common.outbox.OutboxEvent
-import com.ticketqueue.common.outbox.OutboxEventRepository
+import com.ticketqueue.common.outbox.OutboxEventRecorder
 import com.ticketqueue.reservation.client.EventServiceClient
 import com.ticketqueue.reservation.dto.ReservationDto.HoldRequest
 import com.ticketqueue.reservation.dto.ReservationDto.SeatStatusResponse
@@ -61,7 +60,7 @@ class ReservationServiceTest {
     private lateinit var reservationSeatRepository: ReservationSeatRepository
     private lateinit var objectMapper: ObjectMapper
     private lateinit var transactionTemplate: TransactionTemplate
-    private lateinit var outboxEventRepository: OutboxEventRepository
+    private lateinit var outboxEventRecorder: OutboxEventRecorder
     private lateinit var reservationService: ReservationService
 
     private val userId = UUID.randomUUID()
@@ -85,7 +84,7 @@ class ReservationServiceTest {
         reservationSeatRepository = mockk()
         objectMapper = jacksonObjectMapper().apply { registerModule(JavaTimeModule()) }
         transactionTemplate = mockk()
-        outboxEventRepository = mockk()
+        outboxEventRecorder = mockk()
 
         every { stringRedisTemplate.opsForValue() } returns valueOps
         every { stringRedisTemplate.opsForSet() } returns setOps
@@ -98,7 +97,7 @@ class ReservationServiceTest {
             reservationSeatRepository,
             objectMapper,
             transactionTemplate,
-            outboxEventRepository
+            outboxEventRecorder
         )
     }
 
@@ -300,14 +299,14 @@ class ReservationServiceTest {
         private val reservationId = UUID.randomUUID()
 
         @Test
-        @DisplayName("payload를 ReservationCancelledEvent로 역직렬화할 수 있고 표준 envelope 필드를 포함한다")
-        fun cancelledPayloadIsDeserializableWithCorrectFields() {
-            val outboxSlot = slot<OutboxEvent>()
-            setUpCancelSuccess(outboxSlot)
+        @DisplayName("OutboxEventRecorder.record() 호출 시 표준 envelope 필드를 포함한다")
+        fun cancelledEventHasCorrectFields() {
+            val eventSlot = slot<ReservationCancelledEvent>()
+            setUpCancelSuccess(eventSlot)
 
             val response = reservationService.cancelReservation(userId, reservationId)
 
-            val event = objectMapper.readValue(outboxSlot.captured.payload, ReservationCancelledEvent::class.java)
+            val event = eventSlot.captured
             event.eventType shouldBe "ReservationCancelled"
             event.aggregateType shouldBe "Reservation"
             event.aggregateId shouldBe reservationId
@@ -318,21 +317,19 @@ class ReservationServiceTest {
             event.metadata.userId shouldBe userId
             event.metadata.correlationId shouldNotBe null
             event.metadata.causationId shouldBe null
-            outboxSlot.captured.aggregateType shouldBe "Reservation"
-            outboxSlot.captured.eventType shouldBe "ReservationCancelled"
             response.id shouldBe reservationId
             response.refundAmount shouldBe BigDecimal.ZERO
         }
 
         @Test
-        @DisplayName("payload JSON에 reservationId, paymentId, cancelledAt 필드가 없다")
-        fun cancelledPayloadDoesNotContainRemovedFields() {
-            val outboxSlot = slot<OutboxEvent>()
-            setUpCancelSuccess(outboxSlot)
+        @DisplayName("이벤트 JSON에 reservationId, paymentId, cancelledAt 필드가 없다")
+        fun cancelledEventDoesNotContainRemovedFields() {
+            val eventSlot = slot<ReservationCancelledEvent>()
+            setUpCancelSuccess(eventSlot)
 
             reservationService.cancelReservation(userId, reservationId)
 
-            val tree = objectMapper.readTree(outboxSlot.captured.payload)
+            val tree = objectMapper.readTree(objectMapper.writeValueAsString(eventSlot.captured))
             tree.has("reservationId") shouldBe false
             tree.has("paymentId") shouldBe false
             tree.has("cancelledAt") shouldBe false
@@ -342,8 +339,8 @@ class ReservationServiceTest {
         @DisplayName("CONFIRMED 예매 취소 시 refundAmount는 totalAmount와 같다")
         fun confirmedCancellationHasRefundAmount() {
             val totalAmount = BigDecimal("150000")
-            val outboxSlot = slot<OutboxEvent>()
-            setUpCancelSuccess(outboxSlot, status = ReservationStatus.CONFIRMED, totalAmount = totalAmount)
+            val eventSlot = slot<ReservationCancelledEvent>()
+            setUpCancelSuccess(eventSlot, status = ReservationStatus.CONFIRMED, totalAmount = totalAmount)
 
             val response = reservationService.cancelReservation(userId, reservationId)
 
@@ -392,7 +389,7 @@ class ReservationServiceTest {
         }
 
         private fun setUpCancelSuccess(
-            outboxSlot: io.mockk.CapturingSlot<OutboxEvent>,
+            eventSlot: io.mockk.CapturingSlot<ReservationCancelledEvent>,
             status: ReservationStatus = ReservationStatus.PENDING,
             totalAmount: BigDecimal = BigDecimal.ZERO
         ) {
@@ -408,7 +405,7 @@ class ReservationServiceTest {
             every { eventServiceClient.getScheduleInfo(scheduleId) } returns eventScheduleTomorrow()
             every { reservationSeatRepository.findByReservationId(reservationId) } returns
                 listOf(mockk { every { seatId } returns seatId1 })
-            every { outboxEventRepository.save(capture(outboxSlot)) } answers { firstArg() }
+            every { outboxEventRecorder.record(capture(eventSlot)) } returns mockk(relaxed = true)
             every { transactionTemplate.executeWithoutResult(any()) } answers {
                 TransactionSynchronizationManager.initSynchronization()
                 try {


### PR DESCRIPTION
## Summary

- `OutboxEventRecorder` 공용 헬퍼(`common-kafka`) 신규 — Reservation/Payment 양쪽 재사용 (Payment Outbox #63에서 동일 헬퍼 사용 예정)
- `OutboxEvent.id == BaseEvent.eventId` 강제 + `Persistable<UUID>` 구현으로 `persist()` 경로 유지 (N+1 SELECT 회피)
- `ReservationService.cancelReservation()` 의존성 교체: `outboxEventRepository` → `outboxEventRecorder`
- 단위 + TestContainers DB round-trip + Producer-side 멱등성(PK 충돌) + 발행 통합 테스트 4종 추가

## Changes

### Common JPA
- `OutboxEvent.id`: `@GeneratedValue` 제거, non-null `private val id: UUID` 명시 주입
- `Persistable<UUID>` 구현 — `@Transient _isNew` + `@PostLoad/@PostPersist` 토글로 `JpaRepository.save()`가 명시 ID에서도 `persist()` 경로 유지
- `@Access(AccessType.FIELD)` 안전망 추가
- `equals/hashCode` 를 id non-null 가정으로 단순화

### Common Kafka
- `OutboxEventRecorder` 신규 — `BaseEvent` → `OutboxEvent` 변환·저장 + payload 직렬화 일원화
- `@Transactional(propagation = MANDATORY)` — 활성 트랜잭션 부재 시 즉시 실패 (silent 누락 방지)
- KDoc: SOT 바인딩 · 트랜잭션 요구사항 · 멱등성 규약 명시

### Reservation Service
- `cancelReservation()` (line 317-343) `transactionTemplate.executeWithoutResult { }` 람다 내부에서 `outboxEventRecorder.record(ReservationCancelledEvent(...))` 단일 호출로 단순화
- `OutboxEvent` / `OutboxEventRepository` import 제거
- ReservationService 클래스 레벨 `@Transactional` 부재 이유: Redisson 락 보유 시간 최소화 위해 `transactionTemplate` 으로 짧은 트랜잭션 격리 (holdSeats/changeSeats 패턴과 일치). Recorder MANDATORY가 람다 내부에서 안전.

### Test
- `OutboxEventRecorderTest` (unit, mockk) — ID 바인딩 / payload 직렬화 / 예외 전파 / 다중 BaseEvent 서브타입
- `OutboxEventRecorderIntegrationTest` (TestContainers PostgreSQL) — DB round-trip + **동일 eventId PK 충돌 검증** (producer-side 멱등성)
- `ReservationServiceTest` 갱신 — `outboxSlot<OutboxEvent>` → `eventSlot<ReservationCancelledEvent>`, recorder mock 으로 전환
- `CancelReservationOutboxIntegrationTest` 신규 (TestContainers PostgreSQL+Valkey) — DELETE → outbox row 검증 (id == payload.eventId SOT)
- OutboxPoller 5종 통합 테스트 + OutboxEventRepositoryCustomImpl 회귀 없음 (기존 OutboxEvent 호출처 16곳에 `id` 명시 추가)

## 본 PR 범위

- ✅ Producer-side (Outbox INSERT, Kafka 발행, PK 멱등성) — 본 PR에서 완료
- ✅ `OutboxEvent.id == payload.eventId` SOT 바인딩 검증
- 🔜 Consumer-side 멱등성 e2e (좌석 AVAILABLE 복원 1회 + replay 0회) — #53 Event Service Consumer 작업에서 검증 (이슈 본문 코멘트 참조)
- 🔜 `OutboxPollerService.processEvent()` 의 redundant `save(event)` 정리 (dirty checking 이 처리) — 별도 cleanup PR

## Test Plan
- [x] `./gradlew :common-jpa:test` 통과
- [x] `./gradlew :common-kafka:test` 통과 (Recorder unit + integration + 기존 Poller 5종 회귀 없음)
- [x] `./gradlew :reservation-service:test` 통과 (Service unit + cancel outbox integration)

Issue: #228


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced event recording reliability for reservation cancellations with improved transactional handling and explicit event ID management.
  * Strengthened internal event persistence mechanism with better state tracking to prevent duplicate event processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paircoders/ticket-queue/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->