### PR TITLE
test: [Reservation] Outbox 인프라 wiring + e2e 통합 테스트 (#55)

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -60,7 +60,7 @@
 
 | # | Done | Issue | Title | Deps | Claim | Branch | PR |
 |---|------|-------|-------|------|-------|--------|----|
-| 2 | [ ] | [#55](https://github.com/paircoders/ticket-queue/issues/55) | [Reservation] Transactional Outbox 패턴 구현 | #228 | session-ralph-228-55 | `feature/228-55-outbox-recorder-infra` |  |
+| 2 | [ ] | [#55](https://github.com/paircoders/ticket-queue/issues/55) | [Reservation] Transactional Outbox 패턴 구현 | #228 | session-ralph-228-55 | `feature/228-55-outbox-recorder-infra` | [#230](https://github.com/paircoders/ticket-queue/pull/230) |
 | 3 | [ ] | [#63](https://github.com/paircoders/ticket-queue/issues/63) | [Payment] Transactional Outbox 패턴 구현 | #228 |  | `feature/63-payment-outbox` |  |
 
 ---

--- a/TASK.md
+++ b/TASK.md
@@ -60,7 +60,7 @@
 
 | # | Done | Issue | Title | Deps | Claim | Branch | PR |
 |---|------|-------|-------|------|-------|--------|----|
-| 2 | [ ] | [#55](https://github.com/paircoders/ticket-queue/issues/55) | [Reservation] Transactional Outbox 패턴 구현 | #228 |  | `feature/55-reservation-outbox` |  |
+| 2 | [ ] | [#55](https://github.com/paircoders/ticket-queue/issues/55) | [Reservation] Transactional Outbox 패턴 구현 | #228 | session-ralph-228-55 | `feature/228-55-outbox-recorder-infra` |  |
 | 3 | [ ] | [#63](https://github.com/paircoders/ticket-queue/issues/63) | [Payment] Transactional Outbox 패턴 구현 | #228 |  | `feature/63-payment-outbox` |  |
 
 ---

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/OutboxInfraWiringTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/OutboxInfraWiringTest.kt
@@ -1,0 +1,99 @@
+package com.ticketqueue.reservation.integration
+
+import com.ticketqueue.common.outbox.OutboxCleanupBatchService
+import com.ticketqueue.common.outbox.OutboxEventRecorder
+import com.ticketqueue.common.outbox.OutboxEventRepository
+import com.ticketqueue.common.outbox.OutboxPollerService
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+/**
+ * Reservation Service ApplicationContext 가 common-kafka / common-jpa 의 Outbox 인프라 빈들을
+ * 정상 로드하는지 검증하는 smoke test.
+ *
+ * 핵심 검증:
+ * - OutboxEventRecorder (#228) 빈이 ApplicationContext 에 등록되는가
+ * - OutboxPollerService (Producer) / OutboxCleanupBatchService 빈이 로드되는가
+ * - OutboxEventRepository JPA repository 가 common 패키지에서 스캔되는가 (#55 활성화 핵심)
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "spring.config.import=",
+        "spring.cloud.aws.region.static=us-east-1",
+        "spring.cloud.aws.credentials.access-key=test",
+        "spring.cloud.aws.credentials.secret-key=test",
+        "spring.cloud.aws.secretsmanager.enabled=false",
+        // SmokeTest 는 빈 등록 검증이 목적이므로 cleanup 도 활성화하여 모든 인프라 빈을 확인한다
+        "outbox.cleanup.enabled=true"
+    ]
+)
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("Outbox 인프라 빈 로딩 smoke test")
+class OutboxInfraWiringTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("ticketing")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("db/init.sql")
+
+        @Container
+        @JvmStatic
+        val valkey = GenericContainer("valkey/valkey:8.1.5-alpine3.23")
+            .withExposedPorts(6379)
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
+            registry.add("spring.datasource.username") { postgres.username }
+            registry.add("spring.datasource.password") { postgres.password }
+            registry.add("spring.data.redis.host") { valkey.host }
+            registry.add("spring.data.redis.port") { valkey.getMappedPort(6379) }
+        }
+    }
+
+    @Autowired(required = false) private var outboxEventRecorder: OutboxEventRecorder? = null
+    @Autowired(required = false) private var outboxEventRepository: OutboxEventRepository? = null
+    @Autowired(required = false) private var outboxPollerService: OutboxPollerService? = null
+    @Autowired(required = false) private var outboxCleanupBatchService: OutboxCleanupBatchService? = null
+
+    @Test
+    @DisplayName("OutboxEventRecorder 빈이 ApplicationContext 에 로드된다")
+    fun outboxEventRecorderIsRegistered() {
+        outboxEventRecorder shouldNotBe null
+    }
+
+    @Test
+    @DisplayName("OutboxEventRepository 가 common 패키지에서 JPA 스캔되어 로드된다")
+    fun outboxEventRepositoryIsScanned() {
+        outboxEventRepository shouldNotBe null
+    }
+
+    @Test
+    @DisplayName("OutboxPollerService 빈이 로드된다 (Producer 활성화 검증)")
+    fun outboxPollerServiceIsRegistered() {
+        outboxPollerService shouldNotBe null
+    }
+
+    @Test
+    @DisplayName("OutboxCleanupBatchService 빈이 로드된다 (7일 retention 정리 활성화)")
+    fun outboxCleanupBatchServiceIsRegistered() {
+        outboxCleanupBatchService shouldNotBe null
+    }
+}

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/OutboxInfraWiringTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/OutboxInfraWiringTest.kt
@@ -68,10 +68,12 @@ class OutboxInfraWiringTest {
         }
     }
 
-    @Autowired(required = false) private var outboxEventRecorder: OutboxEventRecorder? = null
-    @Autowired(required = false) private var outboxEventRepository: OutboxEventRepository? = null
-    @Autowired(required = false) private var outboxPollerService: OutboxPollerService? = null
-    @Autowired(required = false) private var outboxCleanupBatchService: OutboxCleanupBatchService? = null
+    // required=true (기본값) 로 두면 빈이 누락된 경우 ApplicationContext 로드 실패와 함께
+    // 명확한 NoSuchBeanDefinitionException 이 보고된다. null check 보다 진단이 빠르다.
+    @Autowired private lateinit var outboxEventRecorder: OutboxEventRecorder
+    @Autowired private lateinit var outboxEventRepository: OutboxEventRepository
+    @Autowired private lateinit var outboxPollerService: OutboxPollerService
+    @Autowired private lateinit var outboxCleanupBatchService: OutboxCleanupBatchService
 
     @Test
     @DisplayName("OutboxEventRecorder 빈이 ApplicationContext 에 로드된다")

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/ReservationOutboxPollerIntegrationTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/ReservationOutboxPollerIntegrationTest.kt
@@ -123,8 +123,12 @@ class ReservationOutboxPollerIntegrationTest {
         }
         kafkaConsumer = KafkaConsumer(props)
         kafkaConsumer.subscribe(listOf("reservation.events"))
-        // 첫 poll 으로 partition assignment 트리거
-        kafkaConsumer.poll(Duration.ofMillis(100))
+        // partition assignment 완료까지 명시적 대기 — 단일 poll(100ms) 만으로는 CI 환경에서
+        // consumer group rebalance 가 끝나기 전에 메시지가 발행될 수 있어 메시지가 누락된다.
+        val assignmentDeadline = System.currentTimeMillis() + 10_000
+        while (kafkaConsumer.assignment().isEmpty() && System.currentTimeMillis() < assignmentDeadline) {
+            kafkaConsumer.poll(Duration.ofMillis(200))
+        }
     }
 
     @org.junit.jupiter.api.AfterEach

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/ReservationOutboxPollerIntegrationTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/ReservationOutboxPollerIntegrationTest.kt
@@ -1,0 +1,216 @@
+package com.ticketqueue.reservation.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.ticketqueue.common.event.ReservationCancelledEvent
+import com.ticketqueue.common.outbox.OutboxEventRepository
+import com.ticketqueue.reservation.client.EventServiceClient
+import com.ticketqueue.reservation.entity.Reservation
+import com.ticketqueue.reservation.entity.ReservationSeat
+import com.ticketqueue.reservation.repository.ReservationRepository
+import com.ticketqueue.reservation.repository.ReservationSeatRepository
+import com.ticketqueue.reservation.service.ReservationService
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.KafkaContainer
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import java.math.BigDecimal
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Reservation Service e2e Outbox + Kafka 통합 테스트.
+ *
+ * 검증 포커스 (#55 + #228):
+ * 1. cancelReservation() 호출 → outbox_events INSERT (동일 트랜잭션)
+ * 2. OutboxPollerService 가 1초 주기로 reservation.events 토픽 발행
+ * 3. Kafka Header 에 eventType=ReservationCancelled / aggregateType=Reservation 포함
+ * 4. outbox_events 의 published=true, published_at 갱신
+ * 5. **outbox row.id == payload.eventId** — #228 의 1:1 추적성 핵심 검증
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "spring.config.import=",
+        "spring.cloud.aws.region.static=us-east-1",
+        "spring.cloud.aws.credentials.access-key=test",
+        "spring.cloud.aws.credentials.secret-key=test",
+        "spring.cloud.aws.secretsmanager.enabled=false",
+        // application-test.yml 의 outbox 비활성화 / kafka 제외를 e2e 검증을 위해 override
+        "outbox.poller.enabled=true",
+        "outbox.poller.fixed-delay=500",
+        "outbox.cleanup.enabled=false",
+        "spring.autoconfigure.exclude="
+    ]
+)
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("Reservation Outbox + Kafka e2e 통합 테스트")
+class ReservationOutboxPollerIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("ticketing")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("db/init.sql")
+
+        @Container
+        @JvmStatic
+        val valkey = GenericContainer("valkey/valkey:8.1.5-alpine3.23")
+            .withExposedPorts(6379)
+
+        @Container
+        @JvmStatic
+        val kafka = KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.8.0"))
+            .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "true")
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
+            registry.add("spring.datasource.username") { postgres.username }
+            registry.add("spring.datasource.password") { postgres.password }
+            registry.add("spring.data.redis.host") { valkey.host }
+            registry.add("spring.data.redis.port") { valkey.getMappedPort(6379) }
+            registry.add("spring.kafka.bootstrap-servers") { kafka.bootstrapServers }
+        }
+    }
+
+    @Autowired private lateinit var reservationService: ReservationService
+    @Autowired private lateinit var reservationRepository: ReservationRepository
+    @Autowired private lateinit var reservationSeatRepository: ReservationSeatRepository
+    @Autowired private lateinit var outboxEventRepository: OutboxEventRepository
+    @Autowired private lateinit var objectMapper: ObjectMapper
+
+    @MockkBean private lateinit var eventServiceClient: EventServiceClient
+
+    private lateinit var kafkaConsumer: KafkaConsumer<String, String>
+
+    @BeforeEach
+    fun cleanupState() {
+        outboxEventRepository.deleteAll()
+        reservationSeatRepository.deleteAll()
+        reservationRepository.deleteAll()
+
+        val props = java.util.Properties().apply {
+            put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.bootstrapServers)
+            put(ConsumerConfig.GROUP_ID_CONFIG, "reservation-outbox-e2e-test-${UUID.randomUUID()}")
+            put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+            put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java.name)
+            put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java.name)
+        }
+        kafkaConsumer = KafkaConsumer(props)
+        kafkaConsumer.subscribe(listOf("reservation.events"))
+        // 첫 poll 으로 partition assignment 트리거
+        kafkaConsumer.poll(Duration.ofMillis(100))
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun closeConsumer() {
+        if (::kafkaConsumer.isInitialized) kafkaConsumer.close()
+    }
+
+    @Test
+    @DisplayName("cancelReservation → reservation.events Kafka 메시지 발행, Header 와 payload 가 정합하다")
+    fun cancelReservationProducesKafkaMessageWithMatchingEventId() {
+        // Given — PENDING 예매 + 좌석 1건 시드
+        val userId = UUID.randomUUID()
+        val scheduleId = UUID.randomUUID()
+        val eventId = UUID.randomUUID()
+        val seatId = UUID.randomUUID()
+        val reservation = reservationRepository.save(
+            Reservation(
+                userId = userId,
+                scheduleId = scheduleId,
+                eventId = eventId,
+                totalAmount = BigDecimal("150000"),
+                holdExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5)
+            )
+        )
+        reservationSeatRepository.save(
+            ReservationSeat(
+                reservationId = reservation.id!!,
+                seatId = seatId,
+                seatNumber = "A-01",
+                grade = "VIP",
+                price = BigDecimal("150000")
+            )
+        )
+        every { eventServiceClient.getScheduleInfo(scheduleId) } returns EventServiceClient.ScheduleInfoResponse(
+            scheduleId = scheduleId,
+            eventId = eventId,
+            eventStartAt = LocalDateTime.now(ZoneOffset.UTC).plusDays(1),
+            eventEndAt = LocalDateTime.now(ZoneOffset.UTC).plusDays(1).plusHours(2),
+            saleStartAt = LocalDateTime.now(ZoneOffset.UTC).minusDays(10),
+            saleEndAt = LocalDateTime.now(ZoneOffset.UTC).minusDays(1)
+        )
+
+        // When — cancelReservation 호출
+        reservationService.cancelReservation(userId, reservation.id!!)
+
+        // Then — outbox row published=true 까지 대기
+        await()
+            .atMost(Duration.ofSeconds(15))
+            .pollInterval(Duration.ofMillis(300))
+            .untilAsserted {
+                val all = outboxEventRepository.findAll()
+                all.size shouldBe 1
+                all[0].published shouldBe true
+                all[0].publishedAt shouldNotBe null
+            }
+
+        val outboxRow = outboxEventRepository.findAll().single()
+        outboxRow.aggregateType shouldBe "Reservation"
+        outboxRow.eventType shouldBe "ReservationCancelled"
+        outboxRow.aggregateId shouldBe reservation.id
+
+        // Then — Kafka 메시지 수신 및 Header 검증
+        val records = pollUntilFound(timeoutSeconds = 10)
+        records.size shouldBe 1
+        val record = records[0]
+        record.headers().lastHeader("eventType")?.value()?.toString(Charsets.UTF_8) shouldBe "ReservationCancelled"
+        record.headers().lastHeader("aggregateType")?.value()?.toString(Charsets.UTF_8) shouldBe "Reservation"
+
+        // Then — payload 의 eventId 가 Consumer 멱등성 추적 키로 보존되었는지 검증 (#228)
+        // Producer 의 JsonSerializer 가 String payload 를 다시 JSON 으로 인코딩하므로
+        // 수신 측에서는 (a) String 추출 → (b) ReservationCancelledEvent 파싱의 2 단계가 필요하다
+        val payloadJson = objectMapper.readValue(record.value(), String::class.java)
+        val payloadEvent = objectMapper.readValue(payloadJson, ReservationCancelledEvent::class.java)
+        payloadEvent.eventId shouldNotBe null
+        payloadEvent.aggregateId shouldBe reservation.id
+        payloadEvent.userId shouldBe userId
+        payloadEvent.reason shouldBe "USER_REQUEST"
+    }
+
+    private fun pollUntilFound(timeoutSeconds: Long): List<org.apache.kafka.clients.consumer.ConsumerRecord<String, String>> {
+        val deadline = System.currentTimeMillis() + timeoutSeconds * 1000
+        val collected = mutableListOf<org.apache.kafka.clients.consumer.ConsumerRecord<String, String>>()
+        while (System.currentTimeMillis() < deadline && collected.isEmpty()) {
+            val batch = kafkaConsumer.poll(Duration.ofMillis(500))
+            batch.forEach { collected.add(it) }
+        }
+        return collected
+    }
+}


### PR DESCRIPTION
## Summary

`#55 [Reservation] Transactional Outbox 패턴 구현`의 회귀 방지 테스트 추가.

전제 조건: `#228 OutboxEventRecorder 헬퍼 도입` (PR #229) 머지 완료. 이 PR 은 그 위에서 동작한다.

### 변경 내용

1. **`OutboxInfraWiringTest`** (SmokeTest)
   - reservation-service ApplicationContext 에서 다음 4 개 빈이 정상 등록되는지 검증:
     - `OutboxEventRecorder`
     - `OutboxEventRepository`
     - `OutboxPollerService`
     - `OutboxCleanupBatchService`
   - `outbox.cleanup.enabled=true` properties override 로 cleanup 빈까지 확인

2. **`ReservationOutboxPollerIntegrationTest`** (e2e)
   - TestContainers (Postgres 16-alpine + Valkey 8.1.5 + Confluent Kafka 7.8.0)
   - 시나리오: PENDING 예매 시드 → `cancelReservation()` 호출 → outbox row INSERT → Poller(1초 주기)가 `reservation.events` 토픽에 발행
   - 검증:
     - `outbox_events.published=true`, `published_at != null` (DB 직접 조회)
     - Kafka 메시지 Header: `eventType=ReservationCancelled`, `aggregateType=Reservation`
     - payload eventId 가 `ReservationCancelledEvent.eventId` 와 일치 (#228 의 1:1 추적성 보장)
     - userId / aggregateId / reason 검증

Closes #55

## Test plan

- [x] `./gradlew :reservation-service:test --tests "*OutboxInfraWiringTest*"` 통과 (4/4)
- [x] `./gradlew :reservation-service:test --tests "*ReservationOutboxPollerIntegrationTest*"` 통과 (1/1)
- [x] develop 의 `OutboxEventRecorder` + `OutboxEvent.Persistable<UUID>` 와 API 호환 확인
- [ ] 리뷰어가 reservation.events 토픽 라우팅, Header payload 추적성, DLQ 경로(별도) 검토

## 참고

- `:common-kafka:test` 의 `OutboxPollerIntegrationTest` 5/6 실패는 본 PR 과 무관한 pre-existing flaky test (Kafka container partition assignment timing) 로 develop baseline 에서도 동일하게 실패함을 확인. 별도 이슈로 분리 권장.