### PR TITLE
style: [Reservation] Outbox e2e 테스트 import 정리 및 KDoc 정합 (#55 follow-up)

### DIFF
--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/ReservationOutboxPollerIntegrationTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/ReservationOutboxPollerIntegrationTest.kt
@@ -14,9 +14,11 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -40,12 +42,12 @@ import java.util.UUID
 /**
  * Reservation Service e2e Outbox + Kafka 통합 테스트.
  *
- * 검증 포커스 (#55 + #228):
+ * 검증 포커스 (#55):
  * 1. cancelReservation() 호출 → outbox_events INSERT (동일 트랜잭션)
- * 2. OutboxPollerService 가 1초 주기로 reservation.events 토픽 발행
+ * 2. OutboxPollerService 가 reservation.events 토픽으로 발행
  * 3. Kafka Header 에 eventType=ReservationCancelled / aggregateType=Reservation 포함
  * 4. outbox_events 의 published=true, published_at 갱신
- * 5. **outbox row.id == payload.eventId** — #228 의 1:1 추적성 핵심 검증
+ * 5. payload JSON 의 eventId 가 Consumer 멱등성 추적 키로 보존됨 (#228 의 의도)
  */
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.MOCK,
@@ -131,7 +133,7 @@ class ReservationOutboxPollerIntegrationTest {
         }
     }
 
-    @org.junit.jupiter.api.AfterEach
+    @AfterEach
     fun closeConsumer() {
         if (::kafkaConsumer.isInitialized) kafkaConsumer.close()
     }
@@ -208,9 +210,9 @@ class ReservationOutboxPollerIntegrationTest {
         payloadEvent.reason shouldBe "USER_REQUEST"
     }
 
-    private fun pollUntilFound(timeoutSeconds: Long): List<org.apache.kafka.clients.consumer.ConsumerRecord<String, String>> {
+    private fun pollUntilFound(timeoutSeconds: Long): List<ConsumerRecord<String, String>> {
         val deadline = System.currentTimeMillis() + timeoutSeconds * 1000
-        val collected = mutableListOf<org.apache.kafka.clients.consumer.ConsumerRecord<String, String>>()
+        val collected = mutableListOf<ConsumerRecord<String, String>>()
         while (System.currentTimeMillis() < deadline && collected.isEmpty()) {
             val batch = kafkaConsumer.poll(Duration.ofMillis(500))
             batch.forEach { collected.add(it) }


### PR DESCRIPTION
## Summary

PR #230 머지 후 ai-slop-cleaner 패스에서 잡힌 minor cleanup 을 별도 PR 로 분리.

### 변경 내용

`backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/integration/ReservationOutboxPollerIntegrationTest.kt`:

- **Import 정리**:
  - `@org.junit.jupiter.api.AfterEach` → `import` 추가 후 `@AfterEach`
  - `org.apache.kafka.clients.consumer.ConsumerRecord<String, String>` → `import` 추가 후 단순 이름
- **KDoc 정합**:
  - 클래스 KDoc 의 stale 표현 `outbox row.id == payload.eventId` 를 실제 검증 내용 (`payload JSON 의 eventId 가 Consumer 멱등성 추적 키로 보존됨`) 으로 동기화

기능 변경 0. 동작 영향 0. 코드 가독성/문서 정합성만 개선.

## Follow-up to

- PR #230 (test: [Reservation] Outbox 인프라 wiring + e2e 통합 테스트)
- Closes 추가 액션 없음 (style-only 변경)

## Test plan

- [x] `./gradlew :reservation-service:test --tests "*OutboxInfraWiringTest*"` 통과 (4/4 cached)
- [x] `./gradlew :reservation-service:test --tests "*ReservationOutboxPollerIntegrationTest*"` 통과 (1/1 cached)
- [ ] 리뷰어 확인: 변경 범위가 import/주석에 한정되어 있는지

## 참고

별도 관련 이슈: #231 `OutboxPollerIntegrationTest 5/6 일관 실패` — 본 PR 과 무관한 pre-existing flaky test 로 별도 등록함.