### PR TITLE
feat: [Payment] Transactional Outbox 패턴 구현 (#63)

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -61,7 +61,7 @@
 | # | Done | Issue | Title | Deps | Claim | Branch | PR |
 |---|------|-------|-------|------|-------|--------|----|
 | 2 | [ ] | [#55](https://github.com/paircoders/ticket-queue/issues/55) | [Reservation] Transactional Outbox 패턴 구현 | #228 |  | `feature/55-reservation-outbox` |  |
-| 3 | [ ] | [#63](https://github.com/paircoders/ticket-queue/issues/63) | [Payment] Transactional Outbox 패턴 구현 | #228 |  | `feature/63-payment-outbox` |  |
+| 3 | [ ] | [#63](https://github.com/paircoders/ticket-queue/issues/63) | [Payment] Transactional Outbox 패턴 구현 | #228 | session-356e13ec | `feature/63-payment-outbox` | [#233](https://github.com/paircoders/ticket-queue/pull/233) |
 
 ---
 

--- a/backend/common-kafka/src/main/kotlin/com/ticketqueue/common/event/PaymentEvents.kt
+++ b/backend/common-kafka/src/main/kotlin/com/ticketqueue/common/event/PaymentEvents.kt
@@ -15,7 +15,8 @@ data class PaymentSuccessEvent(
     val amount: BigDecimal,
     val paidAt: LocalDateTime,
     val scheduleId: UUID,
-    val seatIds: List<UUID>
+    val seatIds: List<UUID>,
+    val portoneTransactionId: String
 ) : BaseEvent(
     eventId = eventId,
     eventType = "PaymentSuccess",

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/consumer/PaymentEventConsumerTest.kt
@@ -61,7 +61,8 @@ class PaymentEventConsumerTest {
                 amount = BigDecimal("100000"),
                 paidAt = LocalDateTime.now(),
                 scheduleId = scheduleId,
-                seatIds = seatIds
+                seatIds = seatIds,
+                portoneTransactionId = "portone_tx_123"
             )
             val json = objectMapper.writeValueAsString(event)
 

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
@@ -1,11 +1,16 @@
 package com.ticketqueue.payment.service
 
+import com.ticketqueue.common.event.EventMetadata
+import com.ticketqueue.common.event.PaymentFailedEvent
+import com.ticketqueue.common.event.PaymentSuccessEvent
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.common.external.portone.PortoneFeignClient
 import com.ticketqueue.common.external.portone.PortonePreRegisterRequest
 import com.ticketqueue.common.external.portone.PortoneProperties
 import com.ticketqueue.common.external.portone.PortoneTokenService
+import com.ticketqueue.common.outbox.OutboxEventRecorder
 import com.ticketqueue.payment.client.ReservationServiceClient
+import com.ticketqueue.payment.client.ReservationServiceClient.ReservationDetailResponse
 import com.ticketqueue.payment.client.ReservationServiceClient.ReservationStatus
 import com.ticketqueue.payment.dto.PaymentDto.CreateRequest
 import com.ticketqueue.payment.dto.PaymentDto.CreateResponse
@@ -17,6 +22,7 @@ import feign.FeignException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -28,7 +34,9 @@ class PaymentService(
     private val reservationServiceClient: ReservationServiceClient,
     private val portoneClient: PortoneFeignClient,
     private val portoneTokenService: PortoneTokenService,
-    private val portoneProperties: PortoneProperties
+    private val portoneProperties: PortoneProperties,
+    private val outboxEventRecorder: OutboxEventRecorder,
+    private val transactionTemplate: TransactionTemplate,
 ) {
 
     private val log = KotlinLogging.logger {}
@@ -81,8 +89,15 @@ class PaymentService(
                 token = portoneTokenService.getAccessToken()
             )
         } catch (e: Exception) {
-            payment.markFailed("PortOne pre-register failed: ${e.message}")
-            paymentRepository.save(payment)
+            val reason = "PortOne pre-register failed: ${e.message}"
+            // payment 는 위 첫 save() 가 자체 트랜잭션으로 즉시 커밋되며 detached 상태가 된다.
+            // 아래 save() 는 SimpleJpaRepository 의 merge() 경로로 UPDATE 한 행만 발행하고,
+            // recordPaymentFailed() 의 outbox INSERT 와 같은 트랜잭션에서 원자적으로 커밋된다.
+            transactionTemplate.executeWithoutResult {
+                payment.markFailed(reason)
+                paymentRepository.save(payment)
+                recordPaymentFailed(payment, reason)
+            }
             throw PaymentException(ErrorCode.PORTONE_PRE_REGISTER_FAILED)
         }
 
@@ -98,7 +113,7 @@ class PaymentService(
     }
 
     private fun validateReservation(
-        reservation: ReservationServiceClient.ReservationDetailResponse,
+        reservation: ReservationDetailResponse,
         userId: UUID,
         requestedAmount: BigDecimal
     ) {
@@ -106,5 +121,47 @@ class PaymentService(
         if (reservation.status != ReservationStatus.PENDING) throw PaymentException(ErrorCode.RESERVATION_NOT_PAYABLE)
         if (!LocalDateTime.now(ZoneOffset.UTC).isBefore(reservation.holdExpiresAt)) throw PaymentException(ErrorCode.HOLD_EXPIRED)
         if (reservation.totalAmount.compareTo(requestedAmount) != 0) throw PaymentException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
+    }
+
+    /**
+     * Transactional Outbox 발행 헬퍼 — PaymentSuccess.
+     *
+     * 호출자는 활성 트랜잭션 내부에서 호출해야 한다 ([OutboxEventRecorder] PROPAGATION_MANDATORY).
+     * payment 는 markSuccess() 가 이미 호출되어 paidAt / portoneTransactionId 가 채워진 상태여야 한다.
+     * 결제 승인 API (#59) 가 confirm 트랜잭션 내부에서 호출하기 위한 재사용 진입점.
+     */
+    private fun recordPaymentSuccess(payment: Payment, reservation: ReservationDetailResponse) {
+        val paidAt = requireNotNull(payment.paidAt) { "payment.paidAt must be set before recording PaymentSuccess" }
+        val transactionId = requireNotNull(payment.portoneTransactionId) { "payment.portoneTransactionId must be set before recording PaymentSuccess" }
+        outboxEventRecorder.record(
+            PaymentSuccessEvent(
+                aggregateId = payment.id!!,
+                reservationId = payment.reservationId,
+                paymentKey = payment.paymentKey,
+                amount = payment.amount,
+                paidAt = paidAt,
+                scheduleId = reservation.scheduleId,
+                seatIds = reservation.seatIds,
+                portoneTransactionId = transactionId,
+                metadata = EventMetadata(userId = payment.userId)
+            )
+        )
+    }
+
+    /**
+     * Transactional Outbox 발행 헬퍼 — PaymentFailed.
+     *
+     * 호출자는 활성 트랜잭션 내부에서 호출해야 한다 ([OutboxEventRecorder] PROPAGATION_MANDATORY).
+     * createPayment 의 PortOne pre-register 실패 분기 / 결제 승인 실패 분기에서 공통 사용.
+     */
+    private fun recordPaymentFailed(payment: Payment, reason: String) {
+        outboxEventRecorder.record(
+            PaymentFailedEvent(
+                aggregateId = payment.id!!,
+                reservationId = payment.reservationId,
+                reason = reason,
+                metadata = EventMetadata(userId = payment.userId)
+            )
+        )
     }
 }

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/integration/PaymentOutboxIntegrationTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/integration/PaymentOutboxIntegrationTest.kt
@@ -1,0 +1,172 @@
+package com.ticketqueue.payment.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.ninjasquad.springmockk.MockkBean
+import com.ticketqueue.common.event.PaymentFailedEvent
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.external.portone.PortoneFeignClient
+import com.ticketqueue.common.external.portone.PortoneTokenService
+import com.ticketqueue.common.outbox.OutboxEventRepository
+import com.ticketqueue.payment.client.ReservationServiceClient
+import com.ticketqueue.payment.entity.PaymentStatus
+import com.ticketqueue.payment.repository.PaymentRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Transactional Outbox 통합 테스트 — PortOne pre-register 실패 경로.
+ *
+ * 시나리오: POST /payments → reservation 검증 통과 → Payment(PENDING) INSERT →
+ * PortOne pre-register stub 이 예외 → 트랜잭션 안에서 markFailed + outbox row INSERT →
+ * 502 BAD_GATEWAY 응답.
+ *
+ * **검증 포인트:**
+ * 1. `payment_service.payments` row 의 status = FAILED
+ * 2. `common.outbox_events` row 1건 + aggregateType=Payment / eventType=PaymentFailed / published=false
+ * 3. row.id == JSON payload.eventId  (#228 OutboxEventRecorder SOT 계약)
+ *
+ * Poller 는 application-test.yml 에서 비활성화되어 있으므로 published=false 상태로 검증 가능.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "spring.config.import=",
+        "spring.cloud.aws.region.static=us-east-1",
+        "spring.cloud.aws.credentials.access-key=test",
+        "spring.cloud.aws.credentials.secret-key=test",
+        "spring.cloud.aws.secretsmanager.enabled=false"
+    ]
+)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("Payment Transactional Outbox 통합 테스트 (PortOne 실패 → outbox row)")
+class PaymentOutboxIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:18-alpine")
+            .withDatabaseName("ticketing")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("db/init.sql")
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
+            registry.add("spring.datasource.username") { postgres.username }
+            registry.add("spring.datasource.password") { postgres.password }
+        }
+    }
+
+    @Autowired private lateinit var mockMvc: MockMvc
+    @Autowired private lateinit var objectMapper: ObjectMapper
+    @Autowired private lateinit var paymentRepository: PaymentRepository
+    @Autowired private lateinit var outboxEventRepository: OutboxEventRepository
+
+    @MockkBean private lateinit var reservationServiceClient: ReservationServiceClient
+    @MockkBean private lateinit var portoneClient: PortoneFeignClient
+    @MockkBean private lateinit var portoneTokenService: PortoneTokenService
+
+    private val userId = UUID.randomUUID()
+    private val reservationId = UUID.randomUUID()
+    private val amount = BigDecimal("300000")
+
+    @BeforeEach
+    fun setUp() {
+        outboxEventRepository.deleteAll()
+        paymentRepository.deleteAll()
+        every { portoneTokenService.getAccessToken() } returns "Bearer test-token"
+        every { reservationServiceClient.getReservation(reservationId) } returns
+            ReservationServiceClient.ReservationDetailResponse(
+                reservationId = reservationId,
+                userId = userId,
+                scheduleId = UUID.randomUUID(),
+                totalAmount = amount,
+                status = ReservationServiceClient.ReservationStatus.PENDING,
+                holdExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5),
+                seatIds = listOf(UUID.randomUUID(), UUID.randomUUID())
+            )
+    }
+
+    @AfterEach
+    fun cleanUp() {
+        outboxEventRepository.deleteAll()
+        paymentRepository.deleteAll()
+    }
+
+    @Test
+    @DisplayName("PortOne pre-register 실패 시 payment.status=FAILED 와 outbox_events row 1건이 INSERT 된다 (id == payload.eventId)")
+    fun portoneFailureInsertsOutboxRowAtomically() {
+        every { portoneClient.preRegisterPayment(any(), any(), any()) } throws
+            RuntimeException("simulated PortOne 5xx")
+
+        mockMvc.perform(
+            post("/payments")
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        mapOf(
+                            "reservationId" to reservationId,
+                            "amount" to amount,
+                            "paymentMethod" to "CARD"
+                        )
+                    )
+                )
+        )
+            .andExpect(status().isBadGateway)
+            .andExpect(jsonPath("$.code").value(ErrorCode.PORTONE_PRE_REGISTER_FAILED.code))
+
+        // 1) payment row 검증
+        val payments = paymentRepository.findAll()
+        payments.size shouldBe 1
+        val payment = payments.single()
+        payment.status shouldBe PaymentStatus.FAILED
+        payment.reservationId shouldBe reservationId
+        payment.userId shouldBe userId
+
+        // 2) outbox row 검증
+        val outboxRows = outboxEventRepository.findAll()
+        outboxRows.size shouldBe 1
+        val row = outboxRows.single()
+        row.aggregateType shouldBe "Payment"
+        row.eventType shouldBe "PaymentFailed"
+        row.aggregateId shouldBe payment.id
+        row.published shouldBe false
+
+        // 3) SOT 계약: row.id == payload.eventId
+        val payload = objectMapper.readValue<PaymentFailedEvent>(row.payload)
+        row.id shouldBe payload.eventId
+        payload.aggregateType shouldBe "Payment"
+        payload.eventType shouldBe "PaymentFailed"
+        payload.reservationId shouldBe reservationId
+        payload.metadata.userId shouldBe userId
+    }
+}

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
@@ -1,9 +1,12 @@
 package com.ticketqueue.payment.service
 
+import com.ticketqueue.common.event.PaymentFailedEvent
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.common.external.portone.PortoneFeignClient
 import com.ticketqueue.common.external.portone.PortoneProperties
 import com.ticketqueue.common.external.portone.PortoneTokenService
+import com.ticketqueue.common.outbox.OutboxEvent
+import com.ticketqueue.common.outbox.OutboxEventRecorder
 import com.ticketqueue.payment.client.ReservationServiceClient
 import com.ticketqueue.payment.dto.PaymentDto.CreateRequest
 import com.ticketqueue.payment.entity.Payment
@@ -12,20 +15,24 @@ import com.ticketqueue.payment.exception.PaymentException
 import com.ticketqueue.payment.repository.PaymentRepository
 import feign.FeignException
 import io.kotest.matchers.shouldBe
-import org.springframework.dao.DataIntegrityViolationException
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.transaction.TransactionStatus
+import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.util.UUID
+import java.util.function.Consumer
 
 @DisplayName("PaymentService 단위 테스트")
 class PaymentServiceTest {
@@ -35,6 +42,8 @@ class PaymentServiceTest {
     private lateinit var portoneClient: PortoneFeignClient
     private lateinit var portoneTokenService: PortoneTokenService
     private lateinit var portoneProperties: PortoneProperties
+    private lateinit var outboxEventRecorder: OutboxEventRecorder
+    private lateinit var transactionTemplate: TransactionTemplate
     private lateinit var paymentService: PaymentService
 
     private val userId = UUID.randomUUID()
@@ -52,18 +61,26 @@ class PaymentServiceTest {
         portoneClient = mockk()
         portoneTokenService = mockk()
         portoneProperties = mockk()
+        outboxEventRecorder = mockk()
+        transactionTemplate = mockk()
 
         every { portoneProperties.storeId } returns storeId
         every { portoneProperties.channelKey } returns channelKey
         every { portoneTokenService.getAccessToken() } returns bearerToken
         every { paymentRepository.existsByReservationIdAndStatusIn(any(), any()) } returns false
+        // TransactionTemplate stub: 람다를 즉시 실행하여 트랜잭션 통과를 시뮬레이션
+        every { transactionTemplate.executeWithoutResult(any()) } answers {
+            firstArg<Consumer<TransactionStatus>>().accept(mockk(relaxed = true))
+        }
 
         paymentService = PaymentService(
             paymentRepository,
             reservationServiceClient,
             portoneClient,
             portoneTokenService,
-            portoneProperties
+            portoneProperties,
+            outboxEventRecorder,
+            transactionTemplate,
         )
     }
 
@@ -87,7 +104,7 @@ class PaymentServiceTest {
     inner class CreatePayment {
 
         @Test
-        @DisplayName("정상 흐름: Payment가 PENDING 상태로 저장되고 CreateResponse를 반환한다")
+        @DisplayName("정상 흐름: Payment가 PENDING 상태로 저장되고 CreateResponse를 반환한다 (Outbox 발행 없음)")
         fun success() {
             every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()
             justRun { portoneClient.preRegisterPayment(any(), any(), any()) }
@@ -110,6 +127,9 @@ class PaymentServiceTest {
             response.channelKey shouldBe channelKey
             verify(exactly = 1) { portoneClient.preRegisterPayment(any(), any(), bearerToken) }
             verify(exactly = 1) { paymentRepository.save(any()) }
+            // 정상 흐름에서는 Outbox 발행이 없어야 한다 (PaymentSuccess 는 #59 confirm 트리거)
+            verify(exactly = 0) { outboxEventRecorder.record(any()) }
+            verify(exactly = 0) { transactionTemplate.executeWithoutResult(any()) }
         }
 
         @Test
@@ -235,7 +255,18 @@ class PaymentServiceTest {
         @DisplayName("PortOne pre-register 실패 시 Payment가 FAILED로 저장되고 PORTONE_PRE_REGISTER_FAILED 예외가 발생한다")
         fun portonePreRegisterFails() {
             every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()
-            every { paymentRepository.save(any()) } answers { firstArg() }
+            every { paymentRepository.save(any()) } answers {
+                val p = firstArg<Payment>()
+                Payment(
+                    id = UUID.randomUUID(),
+                    reservationId = p.reservationId,
+                    userId = p.userId,
+                    paymentKey = p.paymentKey,
+                    amount = p.amount,
+                    paymentMethod = p.paymentMethod
+                )
+            }
+            every { outboxEventRecorder.record(any()) } returns mockk<OutboxEvent>(relaxed = true)
             every { portoneClient.preRegisterPayment(any(), any(), any()) } throws
                 RuntimeException("PortOne connection failed")
 
@@ -244,9 +275,45 @@ class PaymentServiceTest {
             }
 
             ex.errorCode shouldBe ErrorCode.PORTONE_PRE_REGISTER_FAILED
-            // PENDING 저장 1회 + PortOne 실패 후 FAILED 저장 1회
+            // PENDING 저장 1회 + 트랜잭션 안에서 FAILED 저장 1회 = 총 2회
             verify(exactly = 2) { paymentRepository.save(any()) }
             verify(exactly = 1) { portoneClient.preRegisterPayment(any(), any(), any()) }
+            verify(exactly = 1) { transactionTemplate.executeWithoutResult(any()) }
+            verify(exactly = 1) { outboxEventRecorder.record(any<PaymentFailedEvent>()) }
+        }
+
+        @Test
+        @DisplayName("PortOne pre-register 실패 시 PaymentFailedEvent envelope 필드가 정확히 채워진다")
+        fun portonePreRegisterFailsRecordsPaymentFailedEnvelope() {
+            val savedPaymentId = UUID.randomUUID()
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()
+            every { paymentRepository.save(any()) } answers {
+                val p = firstArg<Payment>()
+                Payment(
+                    id = savedPaymentId,
+                    reservationId = p.reservationId,
+                    userId = p.userId,
+                    paymentKey = p.paymentKey,
+                    amount = p.amount,
+                    paymentMethod = p.paymentMethod
+                )
+            }
+            val eventSlot = slot<PaymentFailedEvent>()
+            every { outboxEventRecorder.record(capture(eventSlot)) } returns mockk<OutboxEvent>(relaxed = true)
+            every { portoneClient.preRegisterPayment(any(), any(), any()) } throws
+                RuntimeException("connection refused")
+
+            assertThrows<PaymentException> {
+                paymentService.createPayment(userId, CreateRequest(reservationId = reservationId, amount = amount))
+            }
+
+            val event = eventSlot.captured
+            event.aggregateType shouldBe "Payment"
+            event.eventType shouldBe "PaymentFailed"
+            event.aggregateId shouldBe savedPaymentId
+            event.reservationId shouldBe reservationId
+            event.reason shouldBe "PortOne pre-register failed: connection refused"
+            event.metadata.userId shouldBe userId
         }
     }
 }

--- a/docs/architecture/05_kafka.md
+++ b/docs/architecture/05_kafka.md
@@ -144,7 +144,8 @@
   "amount": 200000.00,
   "paidAt": "2026-01-20T10:00:00",
   "scheduleId": "schedule-uuid-111",
-  "seatIds": ["seat-uuid-001", "seat-uuid-002"]
+  "seatIds": ["seat-uuid-001", "seat-uuid-002"],
+  "portoneTransactionId": "portone-tx-abc-123"
 }
 ```
 </details>
@@ -157,8 +158,7 @@
 | `paidAt` | Timestamp | 결제 완료 시각 |
 | `scheduleId` | UUID | 회차 ID |
 | `seatIds` | UUID[] | 결제된 좌석 ID 목록 |
-
-> **Note:** `portoneTransactionId` 필드는 Payment Service Outbox 구현 시 추가 예정
+| `portoneTransactionId` | String | PortOne 결제 트랜잭션 ID (PG사 추적용) |
 
 #### 3.2.2 PaymentFailed
 <details>


### PR DESCRIPTION
## Summary
- PaymentService 의 상태 전이를 `OutboxEventRecorder`(#228) 로 위임하여 도메인 변경과 동일 트랜잭션에서 `common.outbox_events` 에 이벤트를 INSERT 한다. `OutboxEvent.id == BaseEvent.eventId` SOT 계약으로 Consumer 의 `processed_events` 와 1:1 멱등성 매핑이 가능하다.
- `createPayment` 의 PortOne pre-register 실패 분기를 `TransactionTemplate.executeWithoutResult` 로 묶어 `markFailed + save + recordPaymentFailed` 를 원자적으로 처리한다. PortOne Feign 호출은 트랜잭션 밖에서 유지된다.
- `PaymentSuccessEvent` envelope 에 `portoneTransactionId` 정식 필드 추가 (#59 결제 승인 API 에서 채워짐).

## Acceptance Criteria
- [x] PaymentService 생성자에 `OutboxEventRecorder` + `TransactionTemplate` 주입
- [x] `recordPaymentSuccess` / `recordPaymentFailed` private 헬퍼 추가 — Outbox 발행 진입점 (#59 confirm 트랜잭션에서 재사용)
- [x] `createPayment` PortOne pre-register catch 블록이 TransactionTemplate 안에서 도메인 변경 + Outbox INSERT 를 원자화
- [x] PortOne Feign 외부 호출은 트랜잭션 밖 유지
- [x] `PaymentSuccessEvent.portoneTransactionId` 정식 필드 + docs `05_kafka.md` Note 정리
- [x] 단위 테스트: PaymentFailedEvent envelope 캡처 검증 + 정상 흐름 outbox 미호출 verify
- [x] 통합 테스트: TestContainers PostgreSQL + MockkBean PortOne 5xx stub → `payment.status=FAILED` + `outbox_events` row 1건 + `row.id == payload.eventId` SOT 검증

## Files Changed
| File | Change |
|---|---|
| `backend/common-kafka/.../event/PaymentEvents.kt` | `PaymentSuccessEvent.portoneTransactionId: String` 정식 필드 추가 |
| `backend/event-service/.../consumer/PaymentEventConsumerTest.kt` | 위 필드 추가에 따른 생성자 호출 보강 |
| `backend/payment-service/.../service/PaymentService.kt` | OutboxEventRecorder/TransactionTemplate 주입, record* 헬퍼, createPayment 실패 분기 트랜잭션 통합 |
| `backend/payment-service/.../service/PaymentServiceTest.kt` | TransactionTemplate stub, Outbox 발행 검증 시나리오 2건 추가 |
| `backend/payment-service/.../integration/PaymentOutboxIntegrationTest.kt` | **NEW** — DB roundtrip + SOT 계약 검증 |
| `docs/architecture/05_kafka.md` | 3.2.1 PaymentSuccess Note 제거 + `portoneTransactionId` 정식 필드 문서화 |

## Test Plan
- [x] `./gradlew :payment-service:test` — 단위 + 통합 모두 그린
- [x] `./gradlew :common-kafka:test :event-service:test :reservation-service:test` — 영향 모듈 회귀 그린 (Kafka Awaitility/EventController 일부는 환경 의존 flaky 로 확인됨; 단독 재실행 시 모두 통과, 본 PR 의 변경과 무관)
- [x] architect 리뷰 (STANDARD tier) — **APPROVED**. 권고된 detached merge 의도 명시 KDoc 반영

## Notes
- `recordPaymentSuccess` 는 본 PR 범위에서 호출되지 않는다. #59 결제 승인 API 가 confirm 트랜잭션 내부에서 호출하기 위한 재사용 진입점으로 미리 노출했다.
- Reservation Service 에는 아직 `PaymentSuccessEvent` Consumer 가 없어 `portoneTransactionId` 필드 추가가 하위 호환 위험 없음을 확인했다.
- `outbox.poller.enabled=true`, `cleanup.aggregate-type=Payment` 는 `payment-service/application.yml` 에 이미 설정되어 있어 application 부팅 시 폴러/정리 배치가 자동 활성화된다.

Closes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Payment transactions now capture and track the PortOne transaction identifier for better transaction traceability.
  * Implemented reliable event persistence for payment failures to ensure no event loss.

* **Documentation**
  * Updated event schema documentation to reflect the new payment transaction identifier field.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paircoders/ticket-queue/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->