### PR TITLE
feat: [Payment] 결제 승인 API 구현 (#59)

### DIFF
--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/controller/PaymentController.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/controller/PaymentController.kt
@@ -1,5 +1,7 @@
 package com.ticketqueue.payment.controller
 
+import com.ticketqueue.payment.dto.PaymentDto.ConfirmRequest
+import com.ticketqueue.payment.dto.PaymentDto.ConfirmResponse
 import com.ticketqueue.payment.dto.PaymentDto.CreateRequest
 import com.ticketqueue.payment.dto.PaymentDto.CreateResponse
 import com.ticketqueue.payment.service.PaymentService
@@ -23,5 +25,13 @@ class PaymentController(
         @RequestBody @Valid request: CreateRequest
     ): CreateResponse {
         return paymentService.createPayment(userId, request)
+    }
+
+    @PostMapping("/confirm")
+    fun confirmPayment(
+        @RequestHeader("X-User-Id") userId: UUID,
+        @RequestBody @Valid request: ConfirmRequest
+    ): ConfirmResponse {
+        return paymentService.confirmPayment(userId, request)
     }
 }

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/dto/PaymentDto.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/dto/PaymentDto.kt
@@ -1,9 +1,12 @@
 package com.ticketqueue.payment.dto
 
 import com.ticketqueue.payment.entity.PaymentMethod
+import com.ticketqueue.payment.entity.PaymentStatus
+import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Positive
 import java.math.BigDecimal
+import java.time.LocalDateTime
 import java.util.UUID
 
 class PaymentDto {
@@ -20,5 +23,19 @@ class PaymentDto {
         val storeId: String,
         val channelKey: String,
         val paymentKey: String
+    )
+
+    data class ConfirmRequest(
+        @field:NotNull val reservationId: UUID,
+        @field:NotNull val paymentId: UUID,
+        @field:NotBlank val paymentKey: String,
+        @field:NotBlank val transactionId: String,
+        @field:NotNull @field:Positive val amount: BigDecimal
+    )
+
+    data class ConfirmResponse(
+        val paymentId: UUID,
+        val status: PaymentStatus,
+        val paidAt: LocalDateTime?
     )
 }

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/repository/PaymentRepository.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/repository/PaymentRepository.kt
@@ -2,11 +2,19 @@ package com.ticketqueue.payment.repository
 
 import com.ticketqueue.payment.entity.Payment
 import com.ticketqueue.payment.entity.PaymentStatus
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.Optional
 import java.util.UUID
 
 interface PaymentRepository : JpaRepository<Payment, UUID> {
     fun findByPaymentKey(paymentKey: String): Optional<Payment>
     fun existsByReservationIdAndStatusIn(reservationId: UUID, statuses: List<PaymentStatus>): Boolean
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Payment p where p.id = :id")
+    fun findByIdForUpdate(@Param("id") id: UUID): Optional<Payment>
 }

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
@@ -1,10 +1,12 @@
 package com.ticketqueue.payment.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.event.EventMetadata
 import com.ticketqueue.common.event.PaymentFailedEvent
 import com.ticketqueue.common.event.PaymentSuccessEvent
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.common.external.portone.PortoneFeignClient
+import com.ticketqueue.common.external.portone.PortonePaymentResponse
 import com.ticketqueue.common.external.portone.PortonePreRegisterRequest
 import com.ticketqueue.common.external.portone.PortoneProperties
 import com.ticketqueue.common.external.portone.PortoneTokenService
@@ -12,6 +14,8 @@ import com.ticketqueue.common.outbox.OutboxEventRecorder
 import com.ticketqueue.payment.client.ReservationServiceClient
 import com.ticketqueue.payment.client.ReservationServiceClient.ReservationDetailResponse
 import com.ticketqueue.payment.client.ReservationServiceClient.ReservationStatus
+import com.ticketqueue.payment.dto.PaymentDto.ConfirmRequest
+import com.ticketqueue.payment.dto.PaymentDto.ConfirmResponse
 import com.ticketqueue.payment.dto.PaymentDto.CreateRequest
 import com.ticketqueue.payment.dto.PaymentDto.CreateResponse
 import com.ticketqueue.payment.entity.Payment
@@ -37,6 +41,7 @@ class PaymentService(
     private val portoneProperties: PortoneProperties,
     private val outboxEventRecorder: OutboxEventRecorder,
     private val transactionTemplate: TransactionTemplate,
+    private val objectMapper: ObjectMapper,
 ) {
 
     private val log = KotlinLogging.logger {}
@@ -109,6 +114,99 @@ class PaymentService(
             storeId = storeId,
             channelKey = channelKey,
             paymentKey = paymentKey
+        )
+    }
+
+    /**
+     * 결제 승인 서비스 (REQ-PAY-010)
+     *
+     * ## 승인 프로세스
+     * 1. Payment 조회 — 소유권/요청 본문 정합성/상태 머신으로 조기 거절
+     * 2. Reservation 재조회 — hold_expires_at 만료 검증, scheduleId/seatIds 확보
+     * 3. PortOne `getPayment(paymentKey)` 호출 — status/amount/transactionId 위변조 검증
+     * 4. DB 트랜잭션: PESSIMISTIC_WRITE 락 + 상태 재검증 + markSuccess|markFailed + Outbox 발행
+     *
+     * PortOne 응답이 PAID 가 아니거나 amount/transactionId 가 어긋나면 markFailed + PaymentFailedEvent 를 같은
+     * 트랜잭션으로 기록한 뒤 200 OK + status=FAILED 로 응답한다 (스펙 1.2). PortOne 호출 자체가 실패하면
+     * 502 PORTONE_API_ERROR 로 즉시 전파한다. 동시 confirm race 는 락 재검증으로 차단되어 중복 outbox 발행이
+     * 발생하지 않는다.
+     */
+    fun confirmPayment(userId: UUID, request: ConfirmRequest): ConfirmResponse {
+        val payment = paymentRepository.findById(request.paymentId)
+            .orElseThrow { PaymentException(ErrorCode.RESOURCE_NOT_FOUND) }
+
+        if (payment.userId != userId) throw PaymentException(ErrorCode.FORBIDDEN)
+        if (payment.paymentKey != request.paymentKey
+            || payment.reservationId != request.reservationId
+            || payment.amount.compareTo(request.amount) != 0
+        ) {
+            throw PaymentException(ErrorCode.INVALID_INPUT)
+        }
+
+        when (payment.status) {
+            PaymentStatus.SUCCESS -> throw PaymentException(ErrorCode.PAYMENT_ALREADY_EXISTS)
+            PaymentStatus.FAILED, PaymentStatus.REFUNDED -> throw PaymentException(ErrorCode.PAYMENT_FAILED)
+            PaymentStatus.PENDING -> Unit
+        }
+
+        val reservation = try {
+            reservationServiceClient.getReservation(payment.reservationId)
+        } catch (e: FeignException.NotFound) {
+            throw PaymentException(ErrorCode.RESERVATION_NOT_FOUND)
+        } catch (e: FeignException) {
+            throw PaymentException(ErrorCode.INTERNAL_SERVER_ERROR)
+        }
+
+        if (!LocalDateTime.now(ZoneOffset.UTC).isBefore(reservation.holdExpiresAt)) {
+            throw PaymentException(ErrorCode.HOLD_EXPIRED)
+        }
+
+        val portoneResponse: PortonePaymentResponse = try {
+            portoneClient.getPayment(
+                paymentId = payment.paymentKey,
+                storeId = storeId,
+                token = portoneTokenService.getAccessToken()
+            )
+        } catch (e: FeignException) {
+            throw PaymentException(ErrorCode.PORTONE_API_ERROR)
+        }
+
+        val responseJson = objectMapper.writeValueAsString(portoneResponse)
+        val expectedAmount = payment.amount.longValueExact()
+        val failureReason: String? = when {
+            portoneResponse.status != "PAID" -> "PORTONE_STATUS_${portoneResponse.status}"
+            portoneResponse.amount.total != expectedAmount -> "AMOUNT_MISMATCH"
+            portoneResponse.transactionId != request.transactionId -> "TX_ID_MISMATCH"
+            else -> null
+        }
+
+        // 락 재검증은 PortOne HTTP 호출 이후 짧은 트랜잭션 안에서만 보유한다.
+        val finalPayment = transactionTemplate.execute<Payment> {
+            val locked = paymentRepository.findByIdForUpdate(payment.id!!).orElseThrow {
+                PaymentException(ErrorCode.RESOURCE_NOT_FOUND)
+            }
+            when (locked.status) {
+                PaymentStatus.SUCCESS -> throw PaymentException(ErrorCode.PAYMENT_ALREADY_EXISTS)
+                PaymentStatus.FAILED, PaymentStatus.REFUNDED -> throw PaymentException(ErrorCode.PAYMENT_FAILED)
+                PaymentStatus.PENDING -> Unit
+            }
+            if (failureReason == null) {
+                val paidAt = portoneResponse.paidAt?.toLocalDateTime() ?: LocalDateTime.now(ZoneOffset.UTC)
+                locked.markSuccess(portoneResponse.transactionId, responseJson, paidAt)
+                recordPaymentSuccess(locked, reservation)
+            } else {
+                locked.markFailed(failureReason, responseJson)
+                recordPaymentFailed(locked, failureReason)
+            }
+            paymentRepository.save(locked)
+        } ?: throw PaymentException(ErrorCode.INTERNAL_SERVER_ERROR)
+
+        log.info { "Payment confirmed: paymentId=${finalPayment.id}, status=${finalPayment.status}, failureReason=$failureReason" }
+
+        return ConfirmResponse(
+            paymentId = finalPayment.id!!,
+            status = finalPayment.status,
+            paidAt = finalPayment.paidAt
         )
     }
 

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentControllerIntegrationTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentControllerIntegrationTest.kt
@@ -3,9 +3,15 @@ package com.ticketqueue.payment.controller
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.external.portone.PortoneCustomer
 import com.ticketqueue.common.external.portone.PortoneFeignClient
+import com.ticketqueue.common.external.portone.PortonePaymentAmount
+import com.ticketqueue.common.external.portone.PortonePaymentResponse
+import com.ticketqueue.common.external.portone.PortoneSelectedChannel
 import com.ticketqueue.common.external.portone.PortoneTokenService
+import com.ticketqueue.common.outbox.OutboxEventRepository
 import com.ticketqueue.payment.client.ReservationServiceClient
+import com.ticketqueue.payment.entity.Payment
 import com.ticketqueue.payment.entity.PaymentStatus
 import com.ticketqueue.payment.repository.PaymentRepository
 import io.mockk.every
@@ -31,6 +37,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 import io.kotest.matchers.shouldBe
 import java.math.BigDecimal
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
 
@@ -71,6 +78,7 @@ class PaymentControllerIntegrationTest {
     @Autowired private lateinit var mockMvc: MockMvc
     @Autowired private lateinit var objectMapper: ObjectMapper
     @Autowired private lateinit var paymentRepository: PaymentRepository
+    @Autowired private lateinit var outboxEventRepository: OutboxEventRepository
 
     @MockkBean private lateinit var reservationServiceClient: ReservationServiceClient
     @MockkBean private lateinit var portoneClient: PortoneFeignClient
@@ -82,6 +90,7 @@ class PaymentControllerIntegrationTest {
 
     @BeforeEach
     fun setUp() {
+        outboxEventRepository.deleteAll()
         paymentRepository.deleteAll()
         every { portoneTokenService.getAccessToken() } returns "Bearer test-token"
         justRun { portoneClient.preRegisterPayment(any(), any(), any()) }
@@ -296,4 +305,201 @@ class PaymentControllerIntegrationTest {
                 .andExpect(jsonPath("$.code").value(ErrorCode.PAYMENT_ALREADY_EXISTS.code))
         }
     }
+
+    @Nested
+    @DisplayName("결제 승인 API (POST /payments/confirm)")
+    inner class ConfirmEndpoint {
+
+        private val paymentKey = UUID.randomUUID().toString()
+        private val transactionId = "tx-int-1"
+
+        private fun savePendingPayment(): Payment = paymentRepository.saveAndFlush(
+            Payment(
+                reservationId = reservationId,
+                userId = userId,
+                paymentKey = paymentKey,
+                amount = amount,
+            )
+        )
+
+        private fun buildPortoneResponse(
+            status: String = "PAID",
+            totalAmount: Long = amount.longValueExact(),
+            txId: String = transactionId,
+        ) = PortonePaymentResponse(
+            id = paymentKey,
+            transactionId = txId,
+            merchantId = "m",
+            storeId = "test-store-id",
+            status = status,
+            amount = PortonePaymentAmount(total = totalAmount, taxFree = 0, discount = 0, paid = totalAmount, cancelled = 0, cancelledTaxFree = 0),
+            currency = "KRW",
+            channel = PortoneSelectedChannel(type = "TEST", pgProvider = "stub", pgMerchantId = "m"),
+            version = "v2",
+            requestedAt = OffsetDateTime.now(ZoneOffset.UTC),
+            updatedAt = OffsetDateTime.now(ZoneOffset.UTC),
+            statusChangedAt = OffsetDateTime.now(ZoneOffset.UTC),
+            orderName = "order",
+            customer = PortoneCustomer(),
+            paidAt = OffsetDateTime.now(ZoneOffset.UTC),
+        )
+
+        private fun confirmBody(
+            payment: Payment,
+            paymentKey: String = this.paymentKey,
+            transactionId: String = this.transactionId,
+            amount: BigDecimal = this@PaymentControllerIntegrationTest.amount,
+            reservationId: UUID = this@PaymentControllerIntegrationTest.reservationId,
+        ) = mapOf(
+            "reservationId" to reservationId,
+            "paymentId" to payment.id,
+            "paymentKey" to paymentKey,
+            "transactionId" to transactionId,
+            "amount" to amount,
+        )
+
+        @Test
+        @DisplayName("정상 승인: 200 + status=SUCCESS, DB SUCCESS 영속, Outbox PaymentSuccess row 생성")
+        fun confirmSuccess() {
+            val payment = savePendingPayment()
+            every { portoneClient.getPayment(paymentKey, "test-store-id", "Bearer test-token") } returns buildPortoneResponse()
+
+            mockMvc.perform(
+                post("/payments/confirm")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(confirmBody(payment)))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.paymentId").value(payment.id.toString()))
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.paidAt").isNotEmpty)
+
+            val persisted = paymentRepository.findById(payment.id!!).get()
+            persisted.status shouldBe PaymentStatus.SUCCESS
+            persisted.portoneTransactionId shouldBe transactionId
+            assert(persisted.paidAt != null)
+
+            val outboxEvents = outboxEventRepository.findByAggregateTypeAndAggregateId("Payment", payment.id!!)
+            outboxEvents.size shouldBe 1
+            outboxEvents[0].eventType shouldBe "PaymentSuccess"
+            outboxEvents[0].published shouldBe false
+        }
+
+        @Test
+        @DisplayName("멱등성: 이미 SUCCESS 상태에서 재호출 시 409 PAYMENT_ALREADY_EXISTS")
+        fun confirmIdempotent() {
+            val payment = savePendingPayment()
+            every { portoneClient.getPayment(paymentKey, "test-store-id", "Bearer test-token") } returns buildPortoneResponse()
+
+            mockMvc.perform(
+                post("/payments/confirm")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(confirmBody(payment)))
+            ).andExpect(status().isOk)
+
+            mockMvc.perform(
+                post("/payments/confirm")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(confirmBody(payment)))
+            )
+                .andExpect(status().isConflict)
+                .andExpect(jsonPath("$.code").value(ErrorCode.PAYMENT_ALREADY_EXISTS.code))
+        }
+
+        @Test
+        @DisplayName("PortOne FAILED 응답: 200 + status=FAILED + Outbox PaymentFailed row")
+        fun confirmFailedFromPortone() {
+            val payment = savePendingPayment()
+            every { portoneClient.getPayment(paymentKey, "test-store-id", "Bearer test-token") } returns
+                buildPortoneResponse(status = "FAILED")
+
+            mockMvc.perform(
+                post("/payments/confirm")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(confirmBody(payment)))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.status").value("FAILED"))
+
+            val persisted = paymentRepository.findById(payment.id!!).get()
+            persisted.status shouldBe PaymentStatus.FAILED
+            persisted.failureReason shouldBe "PORTONE_STATUS_FAILED"
+
+            val outboxEvents = outboxEventRepository.findByAggregateTypeAndAggregateId("Payment", payment.id!!)
+            outboxEvents.size shouldBe 1
+            outboxEvents[0].eventType shouldBe "PaymentFailed"
+        }
+
+        @Test
+        @DisplayName("PortOne 금액 위조: 200 + status=FAILED + reason=AMOUNT_MISMATCH")
+        fun confirmAmountTampered() {
+            val payment = savePendingPayment()
+            every { portoneClient.getPayment(paymentKey, "test-store-id", "Bearer test-token") } returns
+                buildPortoneResponse(totalAmount = 100L)
+
+            mockMvc.perform(
+                post("/payments/confirm")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(confirmBody(payment)))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.status").value("FAILED"))
+
+            val persisted = paymentRepository.findById(payment.id!!).get()
+            persisted.failureReason shouldBe "AMOUNT_MISMATCH"
+        }
+
+        @Test
+        @DisplayName("요청 본문 paymentKey 위조 → 400 INVALID_INPUT")
+        fun confirmRequestTampered() {
+            val payment = savePendingPayment()
+
+            mockMvc.perform(
+                post("/payments/confirm")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(confirmBody(payment, paymentKey = "tampered")))
+            )
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INPUT.code))
+        }
+
+        @Test
+        @DisplayName("X-User-Id 헤더 누락 → 401")
+        fun confirmMissingUserId() {
+            val payment = savePendingPayment()
+
+            mockMvc.perform(
+                post("/payments/confirm")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(confirmBody(payment)))
+            ).andExpect(status().isUnauthorized)
+        }
+
+        @Test
+        @DisplayName("amount 음수 → 400 (Bean Validation)")
+        fun confirmNegativeAmount() {
+            val payment = savePendingPayment()
+
+            mockMvc.perform(
+                post("/payments/confirm")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(confirmBody(payment, amount = BigDecimal("-1"))))
+            ).andExpect(status().isBadRequest)
+        }
+    }
 }
+

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
@@ -1,13 +1,20 @@
 package com.ticketqueue.payment.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.event.PaymentFailedEvent
+import com.ticketqueue.common.event.PaymentSuccessEvent
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.external.portone.PortoneCustomer
 import com.ticketqueue.common.external.portone.PortoneFeignClient
+import com.ticketqueue.common.external.portone.PortonePaymentAmount
+import com.ticketqueue.common.external.portone.PortonePaymentResponse
 import com.ticketqueue.common.external.portone.PortoneProperties
+import com.ticketqueue.common.external.portone.PortoneSelectedChannel
 import com.ticketqueue.common.external.portone.PortoneTokenService
 import com.ticketqueue.common.outbox.OutboxEvent
 import com.ticketqueue.common.outbox.OutboxEventRecorder
 import com.ticketqueue.payment.client.ReservationServiceClient
+import com.ticketqueue.payment.dto.PaymentDto.ConfirmRequest
 import com.ticketqueue.payment.dto.PaymentDto.CreateRequest
 import com.ticketqueue.payment.entity.Payment
 import com.ticketqueue.payment.entity.PaymentStatus
@@ -27,10 +34,13 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.transaction.TransactionStatus
+import org.springframework.transaction.support.TransactionCallback
 import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.util.Optional
 import java.util.UUID
 import java.util.function.Consumer
 
@@ -44,6 +54,7 @@ class PaymentServiceTest {
     private lateinit var portoneProperties: PortoneProperties
     private lateinit var outboxEventRecorder: OutboxEventRecorder
     private lateinit var transactionTemplate: TransactionTemplate
+    private val objectMapper: ObjectMapper = ObjectMapper().findAndRegisterModules()
     private lateinit var paymentService: PaymentService
 
     private val userId = UUID.randomUUID()
@@ -53,6 +64,7 @@ class PaymentServiceTest {
     private val storeId = "test-store-id"
     private val channelKey = "test-channel-key"
     private val bearerToken = "Bearer test-token"
+    private val seatIds = listOf(UUID.randomUUID(), UUID.randomUUID())
 
     @BeforeEach
     fun setUp() {
@@ -68,9 +80,22 @@ class PaymentServiceTest {
         every { portoneProperties.channelKey } returns channelKey
         every { portoneTokenService.getAccessToken() } returns bearerToken
         every { paymentRepository.existsByReservationIdAndStatusIn(any(), any()) } returns false
-        // TransactionTemplate stub: 람다를 즉시 실행하여 트랜잭션 통과를 시뮬레이션
+        every { outboxEventRecorder.record(any()) } answers {
+            OutboxEvent(
+                id = UUID.randomUUID(),
+                aggregateType = "Payment",
+                aggregateId = UUID.randomUUID(),
+                eventType = "stub",
+                payload = "{}"
+            )
+        }
+        // TransactionTemplate#executeWithoutResult(Consumer<TransactionStatus>): 람다 즉시 실행
         every { transactionTemplate.executeWithoutResult(any()) } answers {
             firstArg<Consumer<TransactionStatus>>().accept(mockk(relaxed = true))
+        }
+        every { transactionTemplate.execute<Any?>(any()) } answers {
+            val callback = firstArg<TransactionCallback<Any?>>()
+            callback.doInTransaction(mockk(relaxed = true))
         }
 
         paymentService = PaymentService(
@@ -81,6 +106,7 @@ class PaymentServiceTest {
             portoneProperties,
             outboxEventRecorder,
             transactionTemplate,
+            objectMapper,
         )
     }
 
@@ -96,7 +122,63 @@ class PaymentServiceTest {
         totalAmount = totalAmount,
         status = status,
         holdExpiresAt = holdExpiresAt,
-        seatIds = listOf(UUID.randomUUID())
+        seatIds = seatIds
+    )
+
+    private fun buildPayment(
+        id: UUID = UUID.randomUUID(),
+        ownerId: UUID = userId,
+        paymentKey: String = "pk-abc",
+        paymentAmount: BigDecimal = amount,
+        status: PaymentStatus = PaymentStatus.PENDING,
+    ): Payment {
+        val payment = Payment(
+            id = id,
+            reservationId = reservationId,
+            userId = ownerId,
+            paymentKey = paymentKey,
+            amount = paymentAmount,
+        )
+        when (status) {
+            PaymentStatus.PENDING -> Unit
+            PaymentStatus.SUCCESS -> payment.markSuccess("tx-x", "{}", LocalDateTime.now(ZoneOffset.UTC))
+            PaymentStatus.FAILED -> payment.markFailed("preset")
+            PaymentStatus.REFUNDED -> {
+                payment.markSuccess("tx-x", "{}", LocalDateTime.now(ZoneOffset.UTC))
+                payment.refund()
+            }
+        }
+        return payment
+    }
+
+    private fun buildPortoneResponse(
+        status: String = "PAID",
+        totalAmount: Long = amount.longValueExact(),
+        transactionId: String = "tx-1",
+        paidAt: OffsetDateTime? = OffsetDateTime.now(ZoneOffset.UTC),
+    ): PortonePaymentResponse = PortonePaymentResponse(
+        id = "pk-abc",
+        transactionId = transactionId,
+        merchantId = "m",
+        storeId = storeId,
+        status = status,
+        amount = PortonePaymentAmount(
+            total = totalAmount,
+            taxFree = 0,
+            discount = 0,
+            paid = totalAmount,
+            cancelled = 0,
+            cancelledTaxFree = 0,
+        ),
+        currency = "KRW",
+        channel = PortoneSelectedChannel(type = "TEST", pgProvider = "stub", pgMerchantId = "m"),
+        version = "v2",
+        requestedAt = OffsetDateTime.now(ZoneOffset.UTC),
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC),
+        statusChangedAt = OffsetDateTime.now(ZoneOffset.UTC),
+        orderName = "order",
+        customer = PortoneCustomer(),
+        paidAt = paidAt,
     )
 
     @Nested
@@ -266,7 +348,6 @@ class PaymentServiceTest {
                     paymentMethod = p.paymentMethod
                 )
             }
-            every { outboxEventRecorder.record(any()) } returns mockk<OutboxEvent>(relaxed = true)
             every { portoneClient.preRegisterPayment(any(), any(), any()) } throws
                 RuntimeException("PortOne connection failed")
 
@@ -314,6 +395,268 @@ class PaymentServiceTest {
             event.reservationId shouldBe reservationId
             event.reason shouldBe "PortOne pre-register failed: connection refused"
             event.metadata.userId shouldBe userId
+        }
+    }
+
+    @Nested
+    @DisplayName("confirmPayment")
+    inner class ConfirmPayment {
+
+        private val paymentId = UUID.randomUUID()
+        private val paymentKey = "pk-abc"
+        private val transactionId = "tx-1"
+
+        private fun confirmRequest(
+            reservationId: UUID = this@PaymentServiceTest.reservationId,
+            paymentId: UUID = this.paymentId,
+            paymentKey: String = this.paymentKey,
+            transactionId: String = this.transactionId,
+            amount: BigDecimal = this@PaymentServiceTest.amount,
+        ) = ConfirmRequest(
+            reservationId = reservationId,
+            paymentId = paymentId,
+            paymentKey = paymentKey,
+            transactionId = transactionId,
+            amount = amount,
+        )
+
+        @Test
+        @DisplayName("정상 흐름: PortOne PAID 응답 → markSuccess + PaymentSuccessEvent 발행, ConfirmResponse 반환")
+        fun success() {
+            val payment = buildPayment(id = paymentId, paymentKey = paymentKey)
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment)
+            every { paymentRepository.findByIdForUpdate(paymentId) } returns Optional.of(payment)
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()
+            every { portoneClient.getPayment(paymentKey, storeId, bearerToken) } returns buildPortoneResponse(transactionId = transactionId)
+            every { paymentRepository.save(any()) } answers { firstArg() }
+            val captured = slot<PaymentSuccessEvent>()
+            every { outboxEventRecorder.record(capture(captured)) } answers {
+                OutboxEvent(id = UUID.randomUUID(), aggregateType = "Payment", aggregateId = paymentId, eventType = "PaymentSuccess", payload = "{}")
+            }
+
+            val response = paymentService.confirmPayment(userId, confirmRequest())
+
+            response.paymentId shouldBe paymentId
+            response.status shouldBe PaymentStatus.SUCCESS
+            response.paidAt shouldBe payment.paidAt
+            payment.status shouldBe PaymentStatus.SUCCESS
+            payment.portoneTransactionId shouldBe transactionId
+            captured.captured.reservationId shouldBe reservationId
+            captured.captured.scheduleId shouldBe scheduleId
+            captured.captured.seatIds shouldBe seatIds
+            captured.captured.portoneTransactionId shouldBe transactionId
+            verify(exactly = 1) { outboxEventRecorder.record(any<PaymentSuccessEvent>()) }
+        }
+
+        @Test
+        @DisplayName("이미 SUCCESS인 결제 재호출 시 PAYMENT_ALREADY_EXISTS 예외 (멱등성)")
+        fun idempotentSuccess() {
+            val payment = buildPayment(id = paymentId, paymentKey = paymentKey, status = PaymentStatus.SUCCESS)
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment)
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.confirmPayment(userId, confirmRequest())
+            }
+
+            ex.errorCode shouldBe ErrorCode.PAYMENT_ALREADY_EXISTS
+            verify(exactly = 0) { portoneClient.getPayment(any(), any(), any()) }
+        }
+
+        @Test
+        @DisplayName("이미 FAILED인 결제 재호출 시 PAYMENT_FAILED 예외")
+        fun alreadyFailed() {
+            val payment = buildPayment(id = paymentId, paymentKey = paymentKey, status = PaymentStatus.FAILED)
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment)
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.confirmPayment(userId, confirmRequest())
+            }
+
+            ex.errorCode shouldBe ErrorCode.PAYMENT_FAILED
+        }
+
+        @Test
+        @DisplayName("이미 REFUNDED인 결제 재호출 시 PAYMENT_FAILED 예외")
+        fun alreadyRefunded() {
+            val payment = buildPayment(id = paymentId, paymentKey = paymentKey, status = PaymentStatus.REFUNDED)
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment)
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.confirmPayment(userId, confirmRequest())
+            }
+
+            ex.errorCode shouldBe ErrorCode.PAYMENT_FAILED
+            verify(exactly = 0) { portoneClient.getPayment(any(), any(), any()) }
+        }
+
+        @Test
+        @DisplayName("락 재조회 시 다른 트랜잭션이 SUCCESS로 선점한 경우 PAYMENT_ALREADY_EXISTS (race 차단)")
+        fun raceWinnerCommittedSuccess() {
+            val payment = buildPayment(id = paymentId, paymentKey = paymentKey, status = PaymentStatus.PENDING)
+            val racedSuccess = buildPayment(id = paymentId, paymentKey = paymentKey, status = PaymentStatus.SUCCESS)
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment)
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()
+            every { portoneClient.getPayment(paymentKey, storeId, bearerToken) } returns buildPortoneResponse()
+            every { paymentRepository.findByIdForUpdate(paymentId) } returns Optional.of(racedSuccess)
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.confirmPayment(userId, confirmRequest())
+            }
+
+            ex.errorCode shouldBe ErrorCode.PAYMENT_ALREADY_EXISTS
+            verify(exactly = 0) { outboxEventRecorder.record(any()) }
+        }
+
+        @Test
+        @DisplayName("PortOne status가 PAID가 아니면 markFailed + PaymentFailedEvent 발행, status=FAILED 응답")
+        fun portoneNotPaid() {
+            val payment = buildPayment(id = paymentId, paymentKey = paymentKey)
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment)
+            every { paymentRepository.findByIdForUpdate(paymentId) } returns Optional.of(payment)
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()
+            every { portoneClient.getPayment(paymentKey, storeId, bearerToken) } returns buildPortoneResponse(status = "FAILED")
+            every { paymentRepository.save(any()) } answers { firstArg() }
+            val captured = slot<PaymentFailedEvent>()
+            every { outboxEventRecorder.record(capture(captured)) } answers {
+                OutboxEvent(id = UUID.randomUUID(), aggregateType = "Payment", aggregateId = paymentId, eventType = "PaymentFailed", payload = "{}")
+            }
+
+            val response = paymentService.confirmPayment(userId, confirmRequest())
+
+            response.status shouldBe PaymentStatus.FAILED
+            response.paidAt shouldBe null
+            payment.status shouldBe PaymentStatus.FAILED
+            payment.failureReason shouldBe "PORTONE_STATUS_FAILED"
+            captured.captured.reason shouldBe "PORTONE_STATUS_FAILED"
+            verify(exactly = 1) { outboxEventRecorder.record(any<PaymentFailedEvent>()) }
+        }
+
+        @Test
+        @DisplayName("PortOne 금액이 DB 금액과 다르면 markFailed + reason=AMOUNT_MISMATCH")
+        fun amountMismatch() {
+            val payment = buildPayment(id = paymentId, paymentKey = paymentKey)
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment)
+            every { paymentRepository.findByIdForUpdate(paymentId) } returns Optional.of(payment)
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()
+            every { portoneClient.getPayment(paymentKey, storeId, bearerToken) } returns buildPortoneResponse(totalAmount = 100L)
+            every { paymentRepository.save(any()) } answers { firstArg() }
+
+            val response = paymentService.confirmPayment(userId, confirmRequest())
+
+            response.status shouldBe PaymentStatus.FAILED
+            payment.failureReason shouldBe "AMOUNT_MISMATCH"
+        }
+
+        @Test
+        @DisplayName("PortOne transactionId가 요청과 다르면 markFailed + reason=TX_ID_MISMATCH")
+        fun txIdMismatch() {
+            val payment = buildPayment(id = paymentId, paymentKey = paymentKey)
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment)
+            every { paymentRepository.findByIdForUpdate(paymentId) } returns Optional.of(payment)
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()
+            every { portoneClient.getPayment(paymentKey, storeId, bearerToken) } returns buildPortoneResponse(transactionId = "tx-other")
+            every { paymentRepository.save(any()) } answers { firstArg() }
+
+            val response = paymentService.confirmPayment(userId, confirmRequest())
+
+            response.status shouldBe PaymentStatus.FAILED
+            payment.failureReason shouldBe "TX_ID_MISMATCH"
+        }
+
+        @Test
+        @DisplayName("요청 본문 paymentKey가 DB와 다르면 INVALID_INPUT 예외 (위변조 차단)")
+        fun paymentKeyMismatch() {
+            val payment = buildPayment(id = paymentId, paymentKey = paymentKey)
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment)
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.confirmPayment(userId, confirmRequest(paymentKey = "tampered"))
+            }
+
+            ex.errorCode shouldBe ErrorCode.INVALID_INPUT
+        }
+
+        @Test
+        @DisplayName("요청 본문 reservationId가 DB와 다르면 INVALID_INPUT 예외")
+        fun reservationIdMismatch() {
+            val payment = buildPayment(id = paymentId, paymentKey = paymentKey)
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment)
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.confirmPayment(userId, confirmRequest(reservationId = UUID.randomUUID()))
+            }
+
+            ex.errorCode shouldBe ErrorCode.INVALID_INPUT
+        }
+
+        @Test
+        @DisplayName("요청 본문 amount가 DB와 다르면 INVALID_INPUT 예외")
+        fun requestAmountMismatch() {
+            val payment = buildPayment(id = paymentId, paymentKey = paymentKey)
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment)
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.confirmPayment(userId, confirmRequest(amount = BigDecimal("999")))
+            }
+
+            ex.errorCode shouldBe ErrorCode.INVALID_INPUT
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 결제 → FORBIDDEN")
+        fun forbidden() {
+            val payment = buildPayment(id = paymentId, paymentKey = paymentKey, ownerId = UUID.randomUUID())
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment)
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.confirmPayment(userId, confirmRequest())
+            }
+
+            ex.errorCode shouldBe ErrorCode.FORBIDDEN
+        }
+
+        @Test
+        @DisplayName("Payment 부재 → RESOURCE_NOT_FOUND")
+        fun paymentNotFound() {
+            every { paymentRepository.findById(paymentId) } returns Optional.empty()
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.confirmPayment(userId, confirmRequest())
+            }
+
+            ex.errorCode shouldBe ErrorCode.RESOURCE_NOT_FOUND
+        }
+
+        @Test
+        @DisplayName("Reservation holdExpiresAt이 만료되면 HOLD_EXPIRED 예외")
+        fun holdExpired() {
+            val payment = buildPayment(id = paymentId, paymentKey = paymentKey)
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment)
+            every { reservationServiceClient.getReservation(reservationId) } returns
+                buildReservation(holdExpiresAt = LocalDateTime.now(ZoneOffset.UTC).minusSeconds(1))
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.confirmPayment(userId, confirmRequest())
+            }
+
+            ex.errorCode shouldBe ErrorCode.HOLD_EXPIRED
+            verify(exactly = 0) { portoneClient.getPayment(any(), any(), any()) }
+        }
+
+        @Test
+        @DisplayName("PortOne 호출이 FeignException으로 실패하면 PORTONE_API_ERROR 예외")
+        fun portoneApiError() {
+            val payment = buildPayment(id = paymentId, paymentKey = paymentKey)
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment)
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()
+            every { portoneClient.getPayment(any(), any(), any()) } throws mockk<FeignException.ServiceUnavailable>()
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.confirmPayment(userId, confirmRequest())
+            }
+
+            ex.errorCode shouldBe ErrorCode.PORTONE_API_ERROR
+            verify(exactly = 0) { outboxEventRecorder.record(any()) }
         }
     }
 }


### PR DESCRIPTION
## Summary
- POST /payments/confirm 엔드포인트 추가. PortOne V2 getPayment 단건 조회로 status/amount/transactionId 위변조를 서버 측에서 재검증.
- 결과에 따라 PaymentSuccessEvent / PaymentFailedEvent 를 OutboxEventRecorder(#228 helper) 로 같은 트랜잭션에 기록. 후속 Consumer(#53/#62)에서 Reservation/Event 갱신을 담당.
- 동시 confirm race: PESSIMISTIC_WRITE 락 + 트랜잭션 안 상태 재검증 (PortOne HTTP 호출 중에는 락 미보유).

## 응답 매트릭스
| 케이스 | HTTP | 비고 |
|---|---|---|
| 정상 승인 | 200 | status=SUCCESS, paidAt 포함, Outbox PaymentSuccess INSERT |
| PortOne FAILED / amount mismatch / txId mismatch | 200 | status=FAILED, paidAt=null, Outbox PaymentFailed INSERT (스펙 1.2) |
| 멱등 재호출 (이미 SUCCESS) | 409 | PAYMENT_ALREADY_EXISTS |
| 이미 FAILED / REFUNDED | 400 | PAYMENT_FAILED |
| 요청 본문 paymentKey/reservationId/amount 위조 | 400 | INVALID_INPUT |
| 타인의 결제 | 403 | FORBIDDEN |
| Payment 부재 | 404 | RESOURCE_NOT_FOUND |
| Reservation hold 만료 | 410 | HOLD_EXPIRED (Queue Token 만료 후에도 hold_expires_at 기반 결제 가능) |
| PortOne 인프라 실패 (Feign 예외) | 502 | PORTONE_API_ERROR |

## REQ
REQ-PAY-010

## Tier 의존성 메모
TASK.md 표기상 Hard dep는 #63(Payment Outbox)이지만, OutboxEventRecorder + Outbox Poller 인프라는 #228 머지로 이미 사용 가능 상태이며 payment-service application.yml 의 outbox.poller.enabled=true 가 활성화되어 있어 정합. Tier 1 #63 PR은 본 PR 머지 후 application 수준의 wiring 점검만 남게 됨.

## Test plan
- [x] ./gradlew :payment-service:test BUILD SUCCESSFUL — 44 tests, 0 failures, 0 ignored
- [x] ./gradlew :payment-service:check BUILD SUCCESSFUL
- [x] PaymentServiceTest.ConfirmPayment: 정상/멱등/REFUNDED/PortOne FAILED·amount·txId 불일치/위변조 차단/소유권/HOLD_EXPIRED/PortOne API 오류/race winner — 13 case
- [x] PaymentControllerIntegrationTest.ConfirmEndpoint (TestContainers): 정상 200 + Outbox PaymentSuccess row / 멱등 409 / PortOne FAILED + Outbox PaymentFailed / amount 위조 / paymentKey 위조 400 / X-User-Id 누락 401 / amount 음수 400 — 7 case
- [x] Architect 리뷰어 APPROVED (PESSIMISTIC_WRITE race 가드 + REFUNDED 테스트 보강 반영)
- [ ] develop 머지 후 #53 Reservation Kafka Consumer 작업에서 payment.events PaymentSuccess/PaymentFailed payload 검증