### PR TITLE
feat: [Reservation] 선점 만료 자동 취소 배치 (#54)

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -76,7 +76,7 @@ Outbox 위에서 동작하거나 완전히 독립적인 핵심 백엔드 API. **
 | 5 | [ ] | [#61](https://github.com/paircoders/ticket-queue/issues/61) | [Payment] Timeout 및 Circuit Breaker 설정 | #59 |  | `feature/61-payment-resilience` |  |
 | 6 | [ ] | [#64](https://github.com/paircoders/ticket-queue/issues/64) | [Payment] 결제 조회 API 구현 | #59 |  | `feature/64-payment-query-api` |  |
 | 7 | [ ] | [#52](https://github.com/paircoders/ticket-queue/issues/52) | [Reservation] 예매 내역 조회 API 구현 | — |  | `feature/52-reservation-query-api` |  |
-| 8 | [ ] | [#54](https://github.com/paircoders/ticket-queue/issues/54) | [Reservation] 선점 만료 자동 취소 배치 | #55 |  | `feature/54-reservation-expire-batch` |  |
+| 8 | [ ] | [#54](https://github.com/paircoders/ticket-queue/issues/54) | [Reservation] 선점 만료 자동 취소 배치 | #55 | session-ded1f1c5 | `feature/54-reservation-expire-batch` |  |
 
 ---
 

--- a/TASK.md
+++ b/TASK.md
@@ -76,7 +76,7 @@ Outbox 위에서 동작하거나 완전히 독립적인 핵심 백엔드 API. **
 | 5 | [ ] | [#61](https://github.com/paircoders/ticket-queue/issues/61) | [Payment] Timeout 및 Circuit Breaker 설정 | #59 |  | `feature/61-payment-resilience` |  |
 | 6 | [ ] | [#64](https://github.com/paircoders/ticket-queue/issues/64) | [Payment] 결제 조회 API 구현 | #59 |  | `feature/64-payment-query-api` |  |
 | 7 | [ ] | [#52](https://github.com/paircoders/ticket-queue/issues/52) | [Reservation] 예매 내역 조회 API 구현 | — |  | `feature/52-reservation-query-api` |  |
-| 8 | [ ] | [#54](https://github.com/paircoders/ticket-queue/issues/54) | [Reservation] 선점 만료 자동 취소 배치 | #55 | session-ded1f1c5 | `feature/54-reservation-expire-batch` |  |
+| 8 | [ ] | [#54](https://github.com/paircoders/ticket-queue/issues/54) | [Reservation] 선점 만료 자동 취소 배치 | #55 | session-ded1f1c5 | `feature/54-reservation-expire-batch` | [#235](https://github.com/paircoders/ticket-queue/pull/235) |
 
 ---
 

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ExpireReservationBatchService.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ExpireReservationBatchService.kt
@@ -1,0 +1,138 @@
+package com.ticketqueue.reservation.service
+
+import com.ticketqueue.common.event.EventMetadata
+import com.ticketqueue.common.event.ReservationCancelledEvent
+import com.ticketqueue.common.outbox.OutboxEventRecorder
+import com.ticketqueue.reservation.entity.ReservationStatus
+import com.ticketqueue.reservation.repository.ReservationRepository
+import com.ticketqueue.reservation.repository.ReservationSeatRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * 선점 만료 자동 취소 배치 (REQ-RSV-007)
+ *
+ * ## 처리 흐름
+ * 1. 매분 0초(UTC)에 PENDING + holdExpiresAt 경과 예매를 후보로 조회
+ * 2. **각 예매를 개별 트랜잭션으로 분리** — 한 건의 실패가 전체 배치를 막지 않도록 격리
+ * 3. 트랜잭션 내부에서 fresh re-fetch로 dirty checking + race 재검증 (동시 취소/확정과 충돌 회피)
+ * 4. `reservation.cancel()` + `ReservationCancelledEvent`(reason=HOLD_EXPIRED) Outbox INSERT
+ * 5. `afterCommit`에서 `hold_seats:{scheduleId}` SET에서 좌석 SREM
+ *
+ * ## 잠금 처리
+ * Redisson `seat:hold:*` 락은 leaseTime=300s = HOLD_TTL과 동일하므로 만료 시점에 이미 자동 해제 상태.
+ * 별도 unlock 호출은 불필요하며 `hold_seats` SET 정리만 책임진다.
+ */
+@Service
+@ConditionalOnProperty(
+    prefix = "reservation.expire",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true
+)
+class ExpireReservationBatchService(
+    private val reservationRepository: ReservationRepository,
+    private val reservationSeatRepository: ReservationSeatRepository,
+    private val outboxEventRecorder: OutboxEventRecorder,
+    private val transactionTemplate: TransactionTemplate,
+    private val stringRedisTemplate: StringRedisTemplate
+) {
+
+    private val log = KotlinLogging.logger {}
+
+    companion object {
+        private const val EXPIRE_REASON = "HOLD_EXPIRED"
+    }
+
+    @Scheduled(cron = "0 * * * * *", zone = "UTC")
+    fun expirePendingReservations() {
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        val candidates = reservationRepository.findAllByStatusAndHoldExpiresAtBefore(
+            ReservationStatus.PENDING,
+            now
+        )
+        if (candidates.isEmpty()) return
+
+        var success = 0
+        var skipped = 0
+        var failed = 0
+        for (reservation in candidates) {
+            val reservationId = reservation.id ?: continue
+            try {
+                when (cancelExpiredReservation(reservationId)) {
+                    CancelOutcome.CANCELLED -> success++
+                    CancelOutcome.SKIPPED -> skipped++
+                }
+            } catch (e: Exception) {
+                failed++
+                log.error(e) { "Failed to expire reservation: reservationId=$reservationId" }
+            }
+        }
+        log.info {
+            "Expired reservations swept: total=${candidates.size}, cancelled=$success, skipped=$skipped, failed=$failed"
+        }
+    }
+
+    private fun cancelExpiredReservation(reservationId: UUID): CancelOutcome {
+        var outcome = CancelOutcome.SKIPPED
+        transactionTemplate.executeWithoutResult {
+            // race 재검증 — 후보 조회 이후 다른 worker가 상태/만료시각을 변경했을 수 있음
+            val fresh = reservationRepository.findById(reservationId).orElse(null)
+                ?: return@executeWithoutResult
+            if (fresh.status != ReservationStatus.PENDING) return@executeWithoutResult
+            if (!LocalDateTime.now(ZoneOffset.UTC).isAfter(fresh.holdExpiresAt)) return@executeWithoutResult
+
+            val seatIds = reservationSeatRepository.findByReservationId(reservationId).map { it.seatId }
+            fresh.cancel()
+            outboxEventRecorder.record(
+                ReservationCancelledEvent(
+                    aggregateId = reservationId,
+                    scheduleId = fresh.scheduleId,
+                    seatIds = seatIds,
+                    userId = fresh.userId,
+                    reason = EXPIRE_REASON,
+                    metadata = EventMetadata(
+                        correlationId = UUID.randomUUID(),
+                        causationId = null,
+                        userId = fresh.userId
+                    )
+                )
+            )
+            registerAfterCommit {
+                removeFromHoldSeatsSet(fresh.scheduleId, seatIds)
+            }
+            outcome = CancelOutcome.CANCELLED
+        }
+        return outcome
+    }
+
+    private fun removeFromHoldSeatsSet(scheduleId: UUID, seatIds: List<UUID>) {
+        if (seatIds.isEmpty()) return
+        try {
+            stringRedisTemplate.opsForSet()
+                .remove(RedisKeys.holdSeatsSet(scheduleId), *seatIds.map { it.toString() }.toTypedArray())
+        } catch (e: Exception) {
+            // hold_seats SET은 600s TTL이 보정한다 — 배치 자체는 실패 전파 금지
+            log.warn(e) { "hold_seats SREM 실패 (scheduleId=$scheduleId). TTL이 보정합니다." }
+        }
+    }
+
+    private fun registerAfterCommit(action: () -> Unit) {
+        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+            override fun afterCommit() {
+                action()
+            }
+        })
+    }
+
+    private enum class CancelOutcome { CANCELLED, SKIPPED }
+}

--- a/backend/reservation-service/src/main/resources/application.yml
+++ b/backend/reservation-service/src/main/resources/application.yml
@@ -67,6 +67,8 @@ reservation:
     key-prefix: "reservation:"
     hold-key-prefix: "seat:hold:"    # {hold-key-prefix}{scheduleId}:{seatId}
     hold-seats-prefix: "hold_seats:" # {hold-seats-prefix}{scheduleId}
+  expire:
+    enabled: true  # 선점 만료 자동 취소 배치 (cron="0 * * * * *" UTC, REQ-RSV-007)
 
 # ============================================================
 # Transactional Outbox Pattern

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ExpireReservationBatchServiceTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ExpireReservationBatchServiceTest.kt
@@ -1,0 +1,294 @@
+package com.ticketqueue.reservation.service
+
+import com.ticketqueue.common.event.ReservationCancelledEvent
+import com.ticketqueue.common.outbox.OutboxEventRecorder
+import com.ticketqueue.reservation.entity.Reservation
+import com.ticketqueue.reservation.entity.ReservationSeat
+import com.ticketqueue.reservation.entity.ReservationStatus
+import com.ticketqueue.reservation.repository.ReservationRepository
+import com.ticketqueue.reservation.repository.ReservationSeatRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.core.SetOperations
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.transaction.TransactionStatus
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import org.springframework.transaction.support.TransactionTemplate
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.Optional
+import java.util.UUID
+import java.util.function.Consumer
+
+@DisplayName("ExpireReservationBatchService 단위 테스트")
+class ExpireReservationBatchServiceTest {
+
+    private lateinit var reservationRepository: ReservationRepository
+    private lateinit var reservationSeatRepository: ReservationSeatRepository
+    private lateinit var outboxEventRecorder: OutboxEventRecorder
+    private lateinit var transactionTemplate: TransactionTemplate
+    private lateinit var stringRedisTemplate: StringRedisTemplate
+    private lateinit var setOps: SetOperations<String, String>
+    private lateinit var batch: ExpireReservationBatchService
+
+    @BeforeEach
+    fun setUp() {
+        reservationRepository = mockk()
+        reservationSeatRepository = mockk()
+        outboxEventRecorder = mockk()
+        transactionTemplate = mockk()
+        stringRedisTemplate = mockk()
+        setOps = mockk()
+
+        every { stringRedisTemplate.opsForSet() } returns setOps
+
+        // transactionTemplate.executeWithoutResult를 즉시 실행하면서,
+        // 콜백이 등록한 TransactionSynchronization.afterCommit도 invoke한다 (실제 commit 후 동작 시뮬레이션).
+        every { transactionTemplate.executeWithoutResult(any()) } answers {
+            val action = firstArg<Consumer<TransactionStatus>>()
+            TransactionSynchronizationManager.initSynchronization()
+            try {
+                action.accept(mockk(relaxed = true))
+                TransactionSynchronizationManager.getSynchronizations().forEach { it.afterCommit() }
+            } finally {
+                TransactionSynchronizationManager.clear()
+            }
+        }
+
+        batch = ExpireReservationBatchService(
+            reservationRepository,
+            reservationSeatRepository,
+            outboxEventRecorder,
+            transactionTemplate,
+            stringRedisTemplate
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clear()
+        }
+    }
+
+    @Test
+    @DisplayName("만료된 PENDING 예매가 없으면 추가 조회/저장 없이 종료한다")
+    fun noopWhenNoCandidates() {
+        every {
+            reservationRepository.findAllByStatusAndHoldExpiresAtBefore(ReservationStatus.PENDING, any())
+        } returns emptyList()
+
+        batch.expirePendingReservations()
+
+        verify(exactly = 1) {
+            reservationRepository.findAllByStatusAndHoldExpiresAtBefore(ReservationStatus.PENDING, any())
+        }
+        verify(exactly = 0) { transactionTemplate.executeWithoutResult(any()) }
+        verify(exactly = 0) { setOps.remove(any<String>(), *anyVararg()) }
+        confirmVerified(reservationRepository, reservationSeatRepository, outboxEventRecorder, setOps)
+    }
+
+    @Test
+    @DisplayName("PENDING + 만료된 예매를 CANCELLED로 전이하고 Outbox 발행 + hold_seats SREM을 수행한다")
+    fun cancelsExpiredReservation() {
+        val reservationId = UUID.randomUUID()
+        val scheduleId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
+        val seatIds = listOf(UUID.randomUUID(), UUID.randomUUID())
+        val reservation = pendingReservation(reservationId, scheduleId, userId, holdExpiresAt = pastMinutes(10))
+
+        every {
+            reservationRepository.findAllByStatusAndHoldExpiresAtBefore(ReservationStatus.PENDING, any())
+        } returns listOf(reservation)
+        every { reservationRepository.findById(reservationId) } returns Optional.of(reservation)
+        every { reservationSeatRepository.findByReservationId(reservationId) } returns
+            seatIds.map { reservationSeat(reservationId, it) }
+
+        val eventSlot = slot<ReservationCancelledEvent>()
+        every { outboxEventRecorder.record(capture(eventSlot)) } answers { mockk(relaxed = true) }
+        every { setOps.remove(any<String>(), *anyVararg()) } returns seatIds.size.toLong()
+
+        batch.expirePendingReservations()
+
+        reservation.status shouldBe ReservationStatus.CANCELLED
+        eventSlot.captured.aggregateId shouldBe reservationId
+        eventSlot.captured.scheduleId shouldBe scheduleId
+        eventSlot.captured.userId shouldBe userId
+        eventSlot.captured.seatIds shouldBe seatIds
+        eventSlot.captured.reason shouldBe "HOLD_EXPIRED"
+        eventSlot.captured.eventType shouldBe "ReservationCancelled"
+
+        verify(exactly = 1) {
+            setOps.remove(
+                "hold_seats:$scheduleId",
+                *seatIds.map { it.toString() }.toTypedArray()
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("좌석이 비어 있는 예매는 SREM은 호출하지 않지만 Outbox 이벤트는 발행한다")
+    fun publishesEventEvenWithoutSeats() {
+        val reservationId = UUID.randomUUID()
+        val reservation = pendingReservation(reservationId, holdExpiresAt = pastMinutes(2))
+
+        every {
+            reservationRepository.findAllByStatusAndHoldExpiresAtBefore(ReservationStatus.PENDING, any())
+        } returns listOf(reservation)
+        every { reservationRepository.findById(reservationId) } returns Optional.of(reservation)
+        every { reservationSeatRepository.findByReservationId(reservationId) } returns emptyList()
+
+        val eventSlot = slot<ReservationCancelledEvent>()
+        every { outboxEventRecorder.record(capture(eventSlot)) } answers { mockk(relaxed = true) }
+
+        batch.expirePendingReservations()
+
+        reservation.status shouldBe ReservationStatus.CANCELLED
+        eventSlot.captured.seatIds shouldBe emptyList()
+        verify(exactly = 0) { setOps.remove(any<String>(), *anyVararg()) }
+    }
+
+    @Test
+    @DisplayName("fresh re-fetch에서 상태가 이미 PENDING이 아니면 cancel/Outbox를 호출하지 않는다")
+    fun skipsWhenStatusChangedConcurrently() {
+        val reservationId = UUID.randomUUID()
+        val candidate = pendingReservation(reservationId, holdExpiresAt = pastMinutes(5))
+        val freshConfirmed = pendingReservation(reservationId, holdExpiresAt = pastMinutes(5))
+            .apply { status = ReservationStatus.CONFIRMED }
+
+        every {
+            reservationRepository.findAllByStatusAndHoldExpiresAtBefore(ReservationStatus.PENDING, any())
+        } returns listOf(candidate)
+        every { reservationRepository.findById(reservationId) } returns Optional.of(freshConfirmed)
+
+        batch.expirePendingReservations()
+
+        verify(exactly = 0) { reservationSeatRepository.findByReservationId(any()) }
+        verify(exactly = 0) { outboxEventRecorder.record(any()) }
+        verify(exactly = 0) { setOps.remove(any<String>(), *anyVararg()) }
+    }
+
+    @Test
+    @DisplayName("fresh re-fetch에서 holdExpiresAt이 갱신되어 아직 미래라면 cancel하지 않는다")
+    fun skipsWhenHoldExpiresAtExtended() {
+        val reservationId = UUID.randomUUID()
+        val candidate = pendingReservation(reservationId, holdExpiresAt = pastMinutes(5))
+        val freshExtended = pendingReservation(
+            reservationId,
+            holdExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5)
+        )
+
+        every {
+            reservationRepository.findAllByStatusAndHoldExpiresAtBefore(ReservationStatus.PENDING, any())
+        } returns listOf(candidate)
+        every { reservationRepository.findById(reservationId) } returns Optional.of(freshExtended)
+
+        batch.expirePendingReservations()
+
+        verify(exactly = 0) { outboxEventRecorder.record(any()) }
+        verify(exactly = 0) { setOps.remove(any<String>(), *anyVararg()) }
+    }
+
+    @Test
+    @DisplayName("fresh re-fetch에서 예매가 삭제된 경우 조용히 skip한다")
+    fun skipsWhenReservationDeleted() {
+        val reservationId = UUID.randomUUID()
+        val candidate = pendingReservation(reservationId, holdExpiresAt = pastMinutes(1))
+
+        every {
+            reservationRepository.findAllByStatusAndHoldExpiresAtBefore(ReservationStatus.PENDING, any())
+        } returns listOf(candidate)
+        every { reservationRepository.findById(reservationId) } returns Optional.empty()
+
+        batch.expirePendingReservations()
+
+        verify(exactly = 0) { outboxEventRecorder.record(any()) }
+        verify(exactly = 0) { reservationSeatRepository.findByReservationId(any()) }
+    }
+
+    @Test
+    @DisplayName("한 건의 트랜잭션이 예외를 던져도 나머지 후보는 계속 처리한다")
+    fun isolatesFailuresPerReservation() {
+        val failingId = UUID.randomUUID()
+        val succeedingId = UUID.randomUUID()
+        val failingReservation = pendingReservation(failingId, holdExpiresAt = pastMinutes(3))
+        val succeedingReservation = pendingReservation(succeedingId, holdExpiresAt = pastMinutes(3))
+
+        every {
+            reservationRepository.findAllByStatusAndHoldExpiresAtBefore(ReservationStatus.PENDING, any())
+        } returns listOf(failingReservation, succeedingReservation)
+        every { reservationRepository.findById(failingId) } throws RuntimeException("DB blip")
+        every { reservationRepository.findById(succeedingId) } returns Optional.of(succeedingReservation)
+        every { reservationSeatRepository.findByReservationId(succeedingId) } returns emptyList()
+
+        val eventSlot = slot<ReservationCancelledEvent>()
+        every { outboxEventRecorder.record(capture(eventSlot)) } answers { mockk(relaxed = true) }
+
+        batch.expirePendingReservations()
+
+        succeedingReservation.status shouldBe ReservationStatus.CANCELLED
+        failingReservation.status shouldBe ReservationStatus.PENDING
+        eventSlot.captured.aggregateId shouldBe succeedingId
+    }
+
+    @Test
+    @DisplayName("Redis SREM 실패는 배치 전체를 실패시키지 않는다 (TTL 보정 위임)")
+    fun swallowsRedisFailures() {
+        val reservationId = UUID.randomUUID()
+        val reservation = pendingReservation(reservationId, holdExpiresAt = pastMinutes(2))
+        val seatId = UUID.randomUUID()
+
+        every {
+            reservationRepository.findAllByStatusAndHoldExpiresAtBefore(ReservationStatus.PENDING, any())
+        } returns listOf(reservation)
+        every { reservationRepository.findById(reservationId) } returns Optional.of(reservation)
+        every { reservationSeatRepository.findByReservationId(reservationId) } returns
+            listOf(reservationSeat(reservationId, seatId))
+        every { outboxEventRecorder.record(any()) } answers { mockk(relaxed = true) }
+        every { setOps.remove(any<String>(), *anyVararg()) } throws RuntimeException("redis down")
+
+        // 예외가 전파되지 않아야 한다
+        batch.expirePendingReservations()
+
+        reservation.status shouldBe ReservationStatus.CANCELLED
+        verify(exactly = 1) { outboxEventRecorder.record(any()) }
+    }
+
+    // ---- Fixtures ----
+
+    private fun pendingReservation(
+        id: UUID,
+        scheduleId: UUID = UUID.randomUUID(),
+        userId: UUID = UUID.randomUUID(),
+        holdExpiresAt: LocalDateTime
+    ): Reservation = Reservation(
+        id = id,
+        userId = userId,
+        scheduleId = scheduleId,
+        eventId = UUID.randomUUID(),
+        status = ReservationStatus.PENDING,
+        totalAmount = BigDecimal("10000"),
+        holdExpiresAt = holdExpiresAt
+    )
+
+    private fun reservationSeat(reservationId: UUID, seatId: UUID): ReservationSeat = ReservationSeat(
+        id = UUID.randomUUID(),
+        reservationId = reservationId,
+        seatId = seatId,
+        seatNumber = "A1",
+        grade = "VIP",
+        price = BigDecimal("10000")
+    )
+
+    private fun pastMinutes(minutes: Long): LocalDateTime =
+        LocalDateTime.now(ZoneOffset.UTC).minusMinutes(minutes)
+}


### PR DESCRIPTION
Closes #54 (REQ-RSV-007)

## Summary
- `ExpireReservationBatchService` 신규: `@Scheduled(cron = "0 * * * * *", zone = "UTC")` — 매분 PENDING + `hold_expires_at` 경과 예매를 일괄 취소
- 각 예매를 **개별 트랜잭션**으로 분리해 한 건 실패가 전체 배치를 막지 않도록 격리
- 트랜잭션 내부에서 **fresh re-fetch** 후 상태/만료시각 재검증 (동시 취소·확정 API 와의 race 회피)
- `ReservationCancelledEvent(reason = "HOLD_EXPIRED")` Outbox INSERT
- `afterCommit` 콜백에서 `hold_seats:{scheduleId}` SET 좌석 SREM — DB 롤백 시 Redis 오염 없음, SREM 실패는 600 s TTL 이 보정
- Redisson `seat:hold:*` 락은 leaseTime = 300 s = HOLD_TTL 과 동일하여 만료 시점 자동 해제 (별도 `unlock()` 불필요)
- `reservation.expire.enabled` (`matchIfMissing = true`) 로 운영/테스트 격리 가능

## Test plan
- [x] `ExpireReservationBatchServiceTest` (MockK 단위 테스트 8 케이스):
  - 후보 없음 → 추가 호출 없이 종료
  - PENDING + 만료 → CANCELLED + Outbox(reason=HOLD_EXPIRED) + SREM
  - 좌석 비어있음 → Outbox 만 발행, SREM 호출 없음
  - 동시 취소로 상태 변경됨 → cancel/Outbox 호출 없음
  - 다른 worker 가 `holdExpiresAt` 연장 → skip
  - 예매 삭제됨 (`findById` empty) → skip
  - 한 건 예외 → 나머지 후보 정상 처리
  - Redis SREM 실패 → 배치 전체는 성공 (TTL 보정 위임)
- [x] `./gradlew :reservation-service:test` — 전체 통과, 회귀 없음