### PR TITLE
feat: [Payment] PortOne Timeout/Circuit Breaker Fallback (#61)

### DIFF
--- a/backend/common-core/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
+++ b/backend/common-core/src/main/kotlin/com/ticketqueue/common/exception/ErrorCode.kt
@@ -53,7 +53,8 @@ enum class ErrorCode(
     PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "PAYMENT_AMOUNT_MISMATCH", "결제 금액이 일치하지 않습니다."),
     REFUND_FAILED(HttpStatus.BAD_REQUEST, "REFUND_FAILED", "환불에 실패했습니다."),
     PORTONE_PRE_REGISTER_FAILED(HttpStatus.BAD_GATEWAY, "PORTONE_PRE_REGISTER_FAILED", "PortOne 사전 결제 등록에 실패했습니다."),
-    
+    PORTONE_CIRCUIT_OPEN(HttpStatus.SERVICE_UNAVAILABLE, "PORTONE_CIRCUIT_OPEN", "결제 게이트웨이가 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도해주세요."),
+
     // PortOne (Identity Verification)
     PORTONE_VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "PORTONE_VERIFICATION_NOT_FOUND", "본인인증 기록을 찾을 수 없습니다."),
     PORTONE_VERIFICATION_TIMEOUT(HttpStatus.BAD_REQUEST, "PORTONE_VERIFICATION_TIMEOUT", "본인인증 시간이 초과되었거나 완료되지 않았습니다."),

--- a/backend/common-web/build.gradle.kts
+++ b/backend/common-web/build.gradle.kts
@@ -16,9 +16,10 @@ dependencies {
     // OpenFeign (FeignConfig, PortoneFeignClient에 필요)
     api(libs.spring.cloud.starter.openfeign)
 
-    // Resilience4j CircuitBreaker — PortoneFallbackFactory가 CallNotPermittedException을 도메인 예외로 변환.
-    // PortoneFeignClient 사용 서비스(payment-service, user-service)는 이미 implementation 의존성을 갖고 있어 런타임 충돌 없음.
-    compileOnly(libs.resilience4j.circuitbreaker)
+    // Resilience4j CircuitBreaker — PortoneFallbackFactory(@Component)가 CallNotPermittedException 을 도메인 예외로 변환.
+    // common-web 을 의존하는 모든 서비스는 com.ticketqueue.common 을 component-scan 하므로 런타임 클래스패스에서도 필요.
+    // implementation 으로 선언: consumers 컴파일 노출 없이 runtime 만 보장 (도메인 예외는 BusinessException 으로 추상화됨).
+    implementation(libs.resilience4j.circuitbreaker)
 
     // Spring Security (InternalApiKeyValidator 등에서 사용)
     compileOnly(libs.spring.boot.starter.security)

--- a/backend/common-web/build.gradle.kts
+++ b/backend/common-web/build.gradle.kts
@@ -16,6 +16,10 @@ dependencies {
     // OpenFeign (FeignConfig, PortoneFeignClient에 필요)
     api(libs.spring.cloud.starter.openfeign)
 
+    // Resilience4j CircuitBreaker — PortoneFallbackFactory가 CallNotPermittedException을 도메인 예외로 변환.
+    // PortoneFeignClient 사용 서비스(payment-service, user-service)는 이미 implementation 의존성을 갖고 있어 런타임 충돌 없음.
+    compileOnly(libs.resilience4j.circuitbreaker)
+
     // Spring Security (InternalApiKeyValidator 등에서 사용)
     compileOnly(libs.spring.boot.starter.security)
 
@@ -23,6 +27,7 @@ dependencies {
     testImplementation(libs.bundles.test.base)
     testImplementation(libs.spring.cloud.starter.openfeign)
     testImplementation(libs.spring.boot.starter.security)
+    testImplementation(libs.resilience4j.circuitbreaker)
 }
 
 tasks.withType<Test> {

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneCircuitOpenException.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneCircuitOpenException.kt
@@ -1,0 +1,8 @@
+package com.ticketqueue.common.external.portone
+
+import com.ticketqueue.common.exception.BusinessException
+import com.ticketqueue.common.exception.ErrorCode
+
+class PortoneCircuitOpenException(
+    cause: Throwable? = null
+) : BusinessException(ErrorCode.PORTONE_CIRCUIT_OPEN, ErrorCode.PORTONE_CIRCUIT_OPEN.message, cause)

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneFallbackFactory.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneFallbackFactory.kt
@@ -1,0 +1,50 @@
+package com.ticketqueue.common.external.portone
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException
+import org.springframework.cloud.openfeign.FallbackFactory
+import org.springframework.stereotype.Component
+
+/**
+ * PortOne FeignClient 호출이 Resilience4j Circuit Breaker 또는 일반 예외로 실패했을 때
+ * 도메인 예외로 변환하는 FallbackFactory.
+ *
+ * - CallNotPermittedException → PortoneCircuitOpenException (503) 로 변환하여 호출자에게 CB Open 의미 전달
+ * - 그 외 cause → 원본을 그대로 재전파하여 기존 catch 흐름(FeignException 등) 유지
+ */
+@Component
+class PortoneFallbackFactory : FallbackFactory<PortoneFeignClient> {
+
+    override fun create(cause: Throwable): PortoneFeignClient = PortoneFallback(cause)
+
+    private class PortoneFallback(private val cause: Throwable) : PortoneFeignClient {
+
+        override fun login(request: PortoneTokenRequest): PortoneTokenResponse = throwMapped()
+
+        override fun refreshToken(request: PortoneRefreshRequest): PortoneTokenResponse = throwMapped()
+
+        override fun getIdentityVerification(
+            identityVerificationId: String,
+            storeId: String?,
+            token: String
+        ): PortoneIdentityV2Response = throwMapped()
+
+        override fun preRegisterPayment(
+            paymentId: String,
+            request: PortonePreRegisterRequest,
+            token: String
+        ): Unit = throwMapped()
+
+        override fun getPayment(
+            paymentId: String,
+            storeId: String?,
+            token: String
+        ): PortonePaymentResponse = throwMapped()
+
+        private fun throwMapped(): Nothing {
+            if (cause is CallNotPermittedException) {
+                throw PortoneCircuitOpenException(cause)
+            }
+            throw cause
+        }
+    }
+}

--- a/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneFeignClient.kt
+++ b/backend/common-web/src/main/kotlin/com/ticketqueue/common/external/portone/PortoneFeignClient.kt
@@ -10,7 +10,8 @@ import org.springframework.web.bind.annotation.*
 @FeignClient(
     name = "portone-v2-client",
     url = "\${external.portone.api-url:https://api.portone.io}",
-    configuration = [PortoneFeignConfig::class]
+    configuration = [PortoneFeignConfig::class],
+    fallbackFactory = PortoneFallbackFactory::class
 )
 interface PortoneFeignClient {
 

--- a/backend/common-web/src/test/kotlin/com/ticketqueue/common/external/portone/PortoneFallbackFactoryTest.kt
+++ b/backend/common-web/src/test/kotlin/com/ticketqueue/common/external/portone/PortoneFallbackFactoryTest.kt
@@ -1,0 +1,77 @@
+package com.ticketqueue.common.external.portone
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Issue #61 — PortoneFallbackFactory 매핑 계약을 잠그는 단위 테스트.
+ *
+ * Resilience4j CircuitBreaker 가 호출을 차단해 던지는 [CallNotPermittedException] 만
+ * 도메인 예외 [PortoneCircuitOpenException] 으로 변환되어야 한다. 그 외 cause 는 원본 그대로
+ * 재전파되어 호출자의 기존 FeignException catch 흐름이 깨지지 않는다.
+ */
+@DisplayName("PortoneFallbackFactory 매핑 단위 테스트")
+class PortoneFallbackFactoryTest {
+
+    private val factory = PortoneFallbackFactory()
+
+    private fun openCircuitException(): CallNotPermittedException {
+        val cb = CircuitBreaker.ofDefaults("portone-test")
+        cb.transitionToOpenState()
+        return CallNotPermittedException.createCallNotPermittedException(cb)
+    }
+
+    @Test
+    @DisplayName("CallNotPermittedException 원인 시 preRegisterPayment 는 PortoneCircuitOpenException(cause=원본) 으로 변환된다")
+    fun preRegisterMapsCircuitOpen() {
+        val cause = openCircuitException()
+        val fallback = factory.create(cause)
+
+        val ex = shouldThrow<PortoneCircuitOpenException> {
+            fallback.preRegisterPayment(
+                paymentId = "pk-test",
+                request = PortonePreRegisterRequest(storeId = "store", totalAmount = 1000L),
+                token = "Bearer t",
+            )
+        }
+        ex.cause shouldBe cause
+    }
+
+    @Test
+    @DisplayName("CallNotPermittedException 원인 시 getPayment 도 동일 매핑")
+    fun getPaymentMapsCircuitOpen() {
+        val cause = openCircuitException()
+        val fallback = factory.create(cause)
+
+        shouldThrow<PortoneCircuitOpenException> {
+            fallback.getPayment(paymentId = "pk-test", storeId = "store", token = "Bearer t")
+        }
+    }
+
+    @Test
+    @DisplayName("CallNotPermittedException 원인 시 토큰 발급 메서드(login) 도 동일 매핑")
+    fun loginMapsCircuitOpen() {
+        val cause = openCircuitException()
+        val fallback = factory.create(cause)
+
+        shouldThrow<PortoneCircuitOpenException> {
+            fallback.login(PortoneTokenRequest(apiSecret = "secret"))
+        }
+    }
+
+    @Test
+    @DisplayName("일반 RuntimeException 원인은 원본 그대로 재전파된다 (FeignException catch 흐름 보존)")
+    fun rethrowsRuntimeCauseAsIs() {
+        val cause = RuntimeException("connection refused")
+        val fallback = factory.create(cause)
+
+        val ex = shouldThrow<RuntimeException> {
+            fallback.getPayment(paymentId = "pk-test", storeId = "store", token = "Bearer t")
+        }
+        ex shouldBe cause
+    }
+}

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
@@ -5,6 +5,7 @@ import com.ticketqueue.common.event.EventMetadata
 import com.ticketqueue.common.event.PaymentFailedEvent
 import com.ticketqueue.common.event.PaymentSuccessEvent
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.external.portone.PortoneCircuitOpenException
 import com.ticketqueue.common.external.portone.PortoneFeignClient
 import com.ticketqueue.common.external.portone.PortonePaymentResponse
 import com.ticketqueue.common.external.portone.PortonePreRegisterRequest
@@ -94,7 +95,11 @@ class PaymentService(
                 token = portoneTokenService.getAccessToken()
             )
         } catch (e: Exception) {
-            val reason = "PortOne pre-register failed: ${e.message}"
+            val reason = if (e is PortoneCircuitOpenException) {
+                "PortOne circuit breaker open"
+            } else {
+                "PortOne pre-register failed: ${e.message}"
+            }
             // payment 는 위 첫 save() 가 자체 트랜잭션으로 즉시 커밋되며 detached 상태가 된다.
             // 아래 save() 는 SimpleJpaRepository 의 merge() 경로로 UPDATE 한 행만 발행하고,
             // recordPaymentFailed() 의 outbox INSERT 와 같은 트랜잭션에서 원자적으로 커밋된다.
@@ -103,6 +108,8 @@ class PaymentService(
                 paymentRepository.save(payment)
                 recordPaymentFailed(payment, reason)
             }
+            // CB Open 은 도메인 예외(503) 그대로 전파하여 클라이언트가 재시도 의미를 구분할 수 있게 한다.
+            if (e is PortoneCircuitOpenException) throw e
             throw PaymentException(ErrorCode.PORTONE_PRE_REGISTER_FAILED)
         }
 
@@ -127,9 +134,10 @@ class PaymentService(
      * 4. DB 트랜잭션: PESSIMISTIC_WRITE 락 + 상태 재검증 + markSuccess|markFailed + Outbox 발행
      *
      * PortOne 응답이 PAID 가 아니거나 amount/transactionId 가 어긋나면 markFailed + PaymentFailedEvent 를 같은
-     * 트랜잭션으로 기록한 뒤 200 OK + status=FAILED 로 응답한다 (스펙 1.2). PortOne 호출 자체가 실패하면
-     * 502 PORTONE_API_ERROR 로 즉시 전파한다. 동시 confirm race 는 락 재검증으로 차단되어 중복 outbox 발행이
-     * 발생하지 않는다.
+     * 트랜잭션으로 기록한 뒤 200 OK + status=FAILED 로 응답한다 (스펙 1.2). PortOne 호출이 FeignException 으로
+     * 실패하면 502 PORTONE_API_ERROR 로, Resilience4j CircuitBreaker 가 차단한 경우(CallNotPermittedException →
+     * FallbackFactory) 503 PORTONE_CIRCUIT_OPEN 으로 즉시 전파한다 — Payment 는 PENDING 으로 남아 클라이언트가
+     * 안전하게 재시도할 수 있다. 동시 confirm race 는 락 재검증으로 차단되어 중복 outbox 발행이 발생하지 않는다.
      */
     fun confirmPayment(userId: UUID, request: ConfirmRequest): ConfirmResponse {
         val payment = paymentRepository.findById(request.paymentId)
@@ -167,6 +175,9 @@ class PaymentService(
                 storeId = storeId,
                 token = portoneTokenService.getAccessToken()
             )
+        } catch (e: PortoneCircuitOpenException) {
+            // CircuitBreaker Open → 503 그대로 전파. Payment 는 PENDING 유지 → 클라이언트 재시도 가능.
+            throw e
         } catch (e: FeignException) {
             throw PaymentException(ErrorCode.PORTONE_API_ERROR)
         }

--- a/backend/payment-service/src/main/resources/application.yml
+++ b/backend/payment-service/src/main/resources/application.yml
@@ -38,6 +38,8 @@ spring:
     openfeign:
       circuitbreaker:
         enabled: true
+        group:
+          enabled: true
       client:
         config:
           default:

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/config/CircuitBreakerConfigTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/config/CircuitBreakerConfigTest.kt
@@ -1,0 +1,93 @@
+package com.ticketqueue.payment.config
+
+import com.ninjasquad.springmockk.MockkBean
+import com.ticketqueue.common.external.portone.PortoneFeignClient
+import com.ticketqueue.common.external.portone.PortoneTokenService
+import com.ticketqueue.payment.client.ReservationServiceClient
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.time.Duration
+
+/**
+ * Issue #61 — PortOne CircuitBreaker 설정 검증 (REQ-PAY-009)
+ *
+ * application.yml 의 `resilience4j.circuitbreaker.instances.portone-v2-client` 설정이
+ * Spring Boot autoconfiguration 을 거쳐 [CircuitBreakerRegistry] 에 정확히 반영되는지 확인한다.
+ * api-gateway 의 `CircuitBreakerConfigTest` 패턴을 차용한다.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    properties = [
+        "spring.config.import=",
+        "spring.cloud.aws.region.static=us-east-1",
+        "spring.cloud.aws.credentials.access-key=test",
+        "spring.cloud.aws.credentials.secret-key=test",
+        "spring.cloud.aws.secretsmanager.enabled=false"
+    ]
+)
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("PortOne CircuitBreaker 설정 검증 (REQ-PAY-009)")
+class CircuitBreakerConfigTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:18-alpine")
+            .withDatabaseName("ticketing")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("db/init.sql")
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
+            registry.add("spring.datasource.username") { postgres.username }
+            registry.add("spring.datasource.password") { postgres.password }
+        }
+    }
+
+    @Autowired
+    private lateinit var circuitBreakerRegistry: CircuitBreakerRegistry
+
+    @MockkBean private lateinit var reservationServiceClient: ReservationServiceClient
+    @MockkBean private lateinit var portoneClient: PortoneFeignClient
+    @MockkBean private lateinit var portoneTokenService: PortoneTokenService
+
+    @Test
+    @DisplayName("portone-v2-client CircuitBreaker 인스턴스가 레지스트리에서 조회 가능해야 한다")
+    fun instanceExists() {
+        val cb = circuitBreakerRegistry.circuitBreaker("portone-v2-client")
+        cb shouldNotBe null
+        cb.name shouldBe "portone-v2-client"
+    }
+
+    @Test
+    @DisplayName("portone-v2-client CB 설정값이 application.yml(default 상속) 과 일치해야 한다")
+    fun configMatchesYml() {
+        val config = circuitBreakerRegistry.circuitBreaker("portone-v2-client").circuitBreakerConfig
+
+        // application.yml default: slidingWindowSize: 100
+        config.slidingWindowSize shouldBe 100
+        // application.yml default: minimumNumberOfCalls: 5
+        config.minimumNumberOfCalls shouldBe 5
+        // application.yml default: failureRateThreshold: 50
+        config.failureRateThreshold shouldBe 50f
+        // application.yml default: permittedNumberOfCallsInHalfOpenState: 3
+        config.permittedNumberOfCallsInHalfOpenState shouldBe 3
+        // application.yml default: waitDurationInOpenState: 60s — fixed IntervalFunction 은 attempt 와 무관하게 동일 값 반환
+        config.waitIntervalFunctionInOpenState.apply(1) shouldBe Duration.ofSeconds(60).toMillis()
+    }
+}

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentControllerIntegrationTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentControllerIntegrationTest.kt
@@ -3,6 +3,7 @@ package com.ticketqueue.payment.controller
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.external.portone.PortoneCircuitOpenException
 import com.ticketqueue.common.external.portone.PortoneCustomer
 import com.ticketqueue.common.external.portone.PortoneFeignClient
 import com.ticketqueue.common.external.portone.PortonePaymentAmount
@@ -499,6 +500,27 @@ class PaymentControllerIntegrationTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(confirmBody(payment, amount = BigDecimal("-1"))))
             ).andExpect(status().isBadRequest)
+        }
+
+        @Test
+        @DisplayName("PortOne CircuitBreaker Open(FallbackFactory) → 503 PORTONE_CIRCUIT_OPEN, Payment PENDING 유지")
+        fun confirmCircuitBreakerOpen() {
+            val payment = savePendingPayment()
+            every { portoneClient.getPayment(paymentKey, "test-store-id", "Bearer test-token") } throws
+                PortoneCircuitOpenException()
+
+            mockMvc.perform(
+                post("/payments/confirm")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(confirmBody(payment)))
+            )
+                .andExpect(status().isServiceUnavailable)
+                .andExpect(jsonPath("$.code").value(ErrorCode.PORTONE_CIRCUIT_OPEN.code))
+
+            val persisted = paymentRepository.findById(payment.id!!).get()
+            persisted.status shouldBe PaymentStatus.PENDING
         }
     }
 }

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.event.PaymentFailedEvent
 import com.ticketqueue.common.event.PaymentSuccessEvent
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.external.portone.PortoneCircuitOpenException
 import com.ticketqueue.common.external.portone.PortoneCustomer
 import com.ticketqueue.common.external.portone.PortoneFeignClient
 import com.ticketqueue.common.external.portone.PortonePaymentAmount
@@ -396,6 +397,37 @@ class PaymentServiceTest {
             event.reason shouldBe "PortOne pre-register failed: connection refused"
             event.metadata.userId shouldBe userId
         }
+
+        @Test
+        @DisplayName("PortOne CircuitBreaker Open(FallbackFactory) 시 markFailed + Outbox 발행 후 PortoneCircuitOpenException(503) 전파")
+        fun portoneCircuitBreakerOpen() {
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()
+            every { paymentRepository.save(any()) } answers {
+                val p = firstArg<Payment>()
+                Payment(
+                    id = UUID.randomUUID(),
+                    reservationId = p.reservationId,
+                    userId = p.userId,
+                    paymentKey = p.paymentKey,
+                    amount = p.amount,
+                    paymentMethod = p.paymentMethod
+                )
+            }
+            val eventSlot = slot<PaymentFailedEvent>()
+            every { outboxEventRecorder.record(capture(eventSlot)) } returns mockk<OutboxEvent>(relaxed = true)
+            every { portoneClient.preRegisterPayment(any(), any(), any()) } throws PortoneCircuitOpenException()
+
+            val ex = assertThrows<PortoneCircuitOpenException> {
+                paymentService.createPayment(userId, CreateRequest(reservationId = reservationId, amount = amount))
+            }
+
+            ex.errorCode shouldBe ErrorCode.PORTONE_CIRCUIT_OPEN
+            // PENDING 저장 1회 + 트랜잭션 안에서 FAILED 저장 1회 = 총 2회
+            verify(exactly = 2) { paymentRepository.save(any()) }
+            verify(exactly = 1) { transactionTemplate.executeWithoutResult(any()) }
+            verify(exactly = 1) { outboxEventRecorder.record(any<PaymentFailedEvent>()) }
+            eventSlot.captured.reason shouldBe "PortOne circuit breaker open"
+        }
     }
 
     @Nested
@@ -657,6 +689,26 @@ class PaymentServiceTest {
 
             ex.errorCode shouldBe ErrorCode.PORTONE_API_ERROR
             verify(exactly = 0) { outboxEventRecorder.record(any()) }
+        }
+
+        @Test
+        @DisplayName("PortOne CircuitBreaker Open(FallbackFactory) 시 Payment는 PENDING 유지, PortoneCircuitOpenException(503) 전파")
+        fun portoneCircuitBreakerOpen() {
+            val payment = buildPayment(id = paymentId, paymentKey = paymentKey)
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment)
+            every { reservationServiceClient.getReservation(reservationId) } returns buildReservation()
+            every { portoneClient.getPayment(any(), any(), any()) } throws PortoneCircuitOpenException()
+
+            val ex = assertThrows<PortoneCircuitOpenException> {
+                paymentService.confirmPayment(userId, confirmRequest())
+            }
+
+            ex.errorCode shouldBe ErrorCode.PORTONE_CIRCUIT_OPEN
+            // CB Open 분기는 트랜잭션 진입 전이므로 락 재조회/Outbox 모두 호출되지 않아야 한다.
+            verify(exactly = 0) { paymentRepository.findByIdForUpdate(any()) }
+            verify(exactly = 0) { paymentRepository.save(any()) }
+            verify(exactly = 0) { outboxEventRecorder.record(any()) }
+            payment.status shouldBe PaymentStatus.PENDING
         }
     }
 }

--- a/docs/architecture/07_operations.md
+++ b/docs/architecture/07_operations.md
@@ -55,6 +55,18 @@
   2. HALF_OPEN 전환 확인: `resilience4j_circuitbreaker_state{name="redisBlacklist", state="half_open"} == 1`
   3. CLOSED 복구 확인: `resilience4j_circuitbreaker_state{name="redisBlacklist", state="closed"} == 1`
 
+#### PortOne CircuitBreaker OPEN 알림 (REQ-PAY-009)
+- **쿼리**: `resilience4j_circuitbreaker_state{name="portone-v2-client", state="open"} == 1`
+- **심각도**: CRITICAL — PortOne 결제 게이트웨이 차단으로 신규 결제·확인 모두 503 PORTONE_CIRCUIT_OPEN 응답.
+- **CB 설정**: `waitDurationInOpenState: 60s`, `failureRateThreshold: 50`, `slidingWindowSize: 100`, `minimumNumberOfCalls: 5`, `permittedNumberOfCallsInHalfOpenState: 3` (`payment-service/application.yml`)
+- **결제 영향**:
+  - `POST /payments` pre-register 실패 → Payment row 가 `FAILED` 상태 + `PaymentFailedEvent` Outbox 발행, 클라이언트 재시도 권장.
+  - `POST /payments/confirm` 차단 → Payment 는 `PENDING` 유지, hold_expires_at 만료 시 `#54` 배치가 자동 취소.
+- **대응**:
+  1. PortOne 상태 페이지 확인: <https://status.portone.io/>
+  2. HALF_OPEN 전환 확인: `resilience4j_circuitbreaker_state{name="portone-v2-client", state="half_open"} == 1`
+  3. CLOSED 복구 확인: `resilience4j_circuitbreaker_state{name="portone-v2-client", state="closed"} == 1`
+
 **서비스별 포트 매핑 (Prometheus 스크래핑 대상):**
 
 | 서비스 | 서비스 포트 | Management 포트 | 메트릭 경로 |

--- a/docs/architecture/07_operations.md
+++ b/docs/architecture/07_operations.md
@@ -61,7 +61,7 @@
 - **CB 설정**: `waitDurationInOpenState: 60s`, `failureRateThreshold: 50`, `slidingWindowSize: 100`, `minimumNumberOfCalls: 5`, `permittedNumberOfCallsInHalfOpenState: 3` (`payment-service/application.yml`)
 - **결제 영향**:
   - `POST /payments` pre-register 실패 → Payment row 가 `FAILED` 상태 + `PaymentFailedEvent` Outbox 발행, 클라이언트 재시도 권장.
-  - `POST /payments/confirm` 차단 → Payment 는 `PENDING` 유지, hold_expires_at 만료 시 `#54` 배치가 자동 취소.
+  - `POST /payments/confirm` 차단 → Payment 는 `PENDING` 유지, hold_expires_at 만료 시 만료 배치(issue `#54` — 선점 만료 자동 취소)가 자동 정리.
 - **대응**:
   1. PortOne 상태 페이지 확인: <https://status.portone.io/>
   2. HALF_OPEN 전환 확인: `resilience4j_circuitbreaker_state{name="portone-v2-client", state="half_open"} == 1`


### PR DESCRIPTION
## Summary
- PortOne FeignClient에 `FallbackFactory`를 도입해 Resilience4j CircuitBreaker가 차단한 호출(`CallNotPermittedException`)을 도메인 예외 `PortoneCircuitOpenException`(503)으로 변환.
- `spring.cloud.openfeign.circuitbreaker.group.enabled=true`로 FeignClient name `portone-v2-client`를 단일 CB 인스턴스로 매칭.
- `PaymentService`의 두 PortOne 호출 지점(`createPayment.preRegisterPayment`, `confirmPayment.getPayment`)에 CB Open 분기 추가 — create 는 `markFailed + Outbox + 503` 재전파, confirm 은 `Payment PENDING 유지 + 503` 재전파(클라이언트 안전 재시도).
- 매핑/설정/통합 회귀 테스트와 `07_operations.md` Prometheus 알림 섹션 추가.

REQ-PAY-008/009 충족.

## 결정 사항
| 항목 | 선택 | 근거 |
|---|---|---|
| Fallback | `FallbackFactory` + 도메인 예외 throw | 호출자가 503/CIRCUIT_OPEN 의미를 명확히 받음 |
| CB ID 매칭 | `group.enabled=true` | FeignClient name 단일 인스턴스, PortOne 게이트웨이 단위 fail-fast |
| createPayment CB Open | `markFailed + Outbox + 재전파` | 기존 PortOne 실패 분기와 동일 트랜잭션 패턴 |
| confirmPayment CB Open | `Payment PENDING 유지 + 재전파` | #54 expire 배치(이미 머지)가 후속 정리, 클라이언트 안전 재시도 |

## 변경 파일 (12)
- `backend/common-core/.../exception/ErrorCode.kt` — `PORTONE_CIRCUIT_OPEN(503)` 추가
- `backend/common-web/.../portone/PortoneCircuitOpenException.kt` — 신규
- `backend/common-web/.../portone/PortoneFallbackFactory.kt` — 신규 (FallbackFactory + 매핑)
- `backend/common-web/.../portone/PortoneFeignClient.kt` — `fallbackFactory =` 연결
- `backend/common-web/build.gradle.kts` — `compileOnly(resilience4j-circuitbreaker)`
- `backend/common-web/src/test/.../PortoneFallbackFactoryTest.kt` — 신규, 4 case
- `backend/payment-service/.../service/PaymentService.kt` — create/confirm catch 분기 + KDoc
- `backend/payment-service/src/main/resources/application.yml` — `group.enabled=true`
- `backend/payment-service/src/test/.../service/PaymentServiceTest.kt` — CB Open 2 case
- `backend/payment-service/src/test/.../config/CircuitBreakerConfigTest.kt` — 신규, 2 case
- `backend/payment-service/src/test/.../controller/PaymentControllerIntegrationTest.kt` — 503 1 case
- `docs/architecture/07_operations.md` — PortOne CB OPEN 알림 섹션

## Test plan
- [x] `./gradlew :common-core:compileKotlin :common-web:compileKotlin :payment-service:processResources` — BUILD SUCCESSFUL
- [x] `./gradlew :payment-service:test` — BUILD SUCCESSFUL (CircuitBreakerConfigTest 2/2, PaymentServiceTest$CreatePayment 13/13, $ConfirmPayment 16/16, PaymentControllerIntegrationTest$ConfirmEndpoint 8/8)
- [x] `./gradlew :common-web:check :payment-service:check :common-core:check` — BUILD SUCCESSFUL
- [x] Post-deslop regression: `./gradlew :common-web:check :payment-service:test` — BUILD SUCCESSFUL (PortoneFallbackFactoryTest 4/4)
- [ ] PR 머지 후 `TASK.md` row 5(#61) Done 체크 + PR 링크 기입 (메인 세션 책임)
- [ ] Prometheus alert rule 운영 배포 시 `portone-v2-client` OPEN 쿼리 활성화

## 운영 영향
- PortOne 게이트웨이 장애 시 신규 결제는 503 `PORTONE_CIRCUIT_OPEN` + `Payment` row `FAILED` + Outbox `PaymentFailed` 발행.
- 결제 확인은 503 응답 + Payment `PENDING` 유지 → `hold_expires_at` 만료 시 #54 expire 배치가 자동 취소.
- Architect 사전 리뷰: **APPROVED**. `user-service`는 `application.yml`에서 `feign.circuitbreaker.enabled=false`라 fallbackFactory 미적용 — 회귀 없음 확인.

## 의존성
- 사전 머지: #228(OutboxEventRecorder), #55(Reservation Outbox), #63(Payment Outbox), #59(결제 승인 API).
- 후속 영향: #62(SAGA 보상 트랜잭션)에서 CB Open 시나리오를 통합 흐름에 반영 가능.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented circuit breaker protection for PortOne payment gateway, enabling graceful handling of temporary unavailability.
  * Payment creation operations fail safely when gateway is unavailable, while payment confirmations remain pending for automatic retry.

* **Documentation**
  * Added operational documentation covering circuit breaker monitoring, configuration parameters, and recovery procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paircoders/ticket-queue/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->