### PR TITLE
feat: [Event] Internal API batch 엔드포인트 (#52)

### DIFF
--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/InternalEventController.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/InternalEventController.kt
@@ -1,0 +1,43 @@
+package com.ticketqueue.event.controller
+
+import com.ticketqueue.event.dto.EventDto
+import com.ticketqueue.event.service.EventService
+import jakarta.validation.constraints.Size
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+// 내부 서비스 간 통신용 공연 API 컨트롤러
+// 엔드포인트:
+//   GET /internal/events/{eventId}/info       - 단건 공연 메타 조회 (Reservation Service 예매 상세 등)
+//   GET /internal/events/batch?eventIds=...   - 배치 공연 메타 조회 (최대 100, 예매 내역 페이지 일괄 조립)
+// 보안: InternalApiAuthInterceptor가 X-Service-Api-Key 헤더 검증 (API Gateway는 /internal 경로 차단)
+@RestController
+@RequestMapping("/internal/events")
+@Validated
+class InternalEventController(
+    private val eventService: EventService
+) {
+
+    /** 공연 핵심 정보 단건 조회 — 미존재 시 EVENT_NOT_FOUND (404) */
+    @GetMapping("/{eventId}/info")
+    fun getEventInfo(@PathVariable eventId: UUID): EventDto.EventInfoResponse {
+        return eventService.getEventInfo(eventId)
+    }
+
+    /**
+     * 공연 핵심 정보 배치 조회 — 미존재 ID는 응답에서 제외
+     *
+     * 최대 100건까지 한 번에 조회 가능. 0건 또는 100건 초과 시 400 INVALID_INPUT.
+     */
+    @GetMapping("/batch")
+    fun getEventInfoBatch(
+        @RequestParam @Size(min = 1, max = 100, message = "eventIds는 1~100개여야 합니다.") eventIds: List<UUID>
+    ): EventDto.EventInfoBatchResponse {
+        return eventService.getEventInfoBatch(eventIds)
+    }
+}

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/InternalScheduleController.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/controller/InternalScheduleController.kt
@@ -2,17 +2,25 @@ package com.ticketqueue.event.controller
 
 import com.ticketqueue.event.dto.ScheduleDto
 import com.ticketqueue.event.service.ScheduleService
+import jakarta.validation.constraints.Size
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
 // 내부 서비스 간 통신용 회차 API 컨트롤러
-// 엔드포인트: GET /internal/schedules/{scheduleId}/sellable - 티켓 판매 가능 여부 조회 (Queue Service 전용)
+// 엔드포인트:
+//   GET /internal/schedules/{scheduleId}/sellable    - 티켓 판매 가능 여부 조회 (Queue Service 전용)
+//   GET /internal/schedules/ended                    - 종료된 회차 ID 목록 (Queue Service 정리 배치)
+//   GET /internal/schedules/{scheduleId}/info        - 회차 핵심 정보 단건 조회
+//   GET /internal/schedules/batch?scheduleIds=...    - 회차 핵심 정보 배치 조회 (최대 100, Reservation Service)
 // 보안: InternalApiAuthInterceptor가 X-Service-Api-Key 헤더 검증 (API Gateway는 /internal 경로 차단)
 @RestController
 @RequestMapping("/internal/schedules")
+@Validated
 class InternalScheduleController(
     private val scheduleService: ScheduleService
 ) {
@@ -33,5 +41,17 @@ class InternalScheduleController(
     @GetMapping("/{scheduleId}/info")
     fun getScheduleInfo(@PathVariable scheduleId: UUID): ScheduleDto.ScheduleInfoResponse {
         return scheduleService.getScheduleInfo(scheduleId)
+    }
+
+    /**
+     * 회차 핵심 정보 배치 조회 — Reservation Service 예매 내역 페이지당 일괄 조립용
+     *
+     * 미존재 ID는 응답에서 제외. 최대 100건 (0건 또는 100건 초과 시 400 INVALID_INPUT).
+     */
+    @GetMapping("/batch")
+    fun getScheduleInfoBatch(
+        @RequestParam @Size(min = 1, max = 100, message = "scheduleIds는 1~100개여야 합니다.") scheduleIds: List<UUID>
+    ): ScheduleDto.ScheduleInfoBatchResponse {
+        return scheduleService.getScheduleInfoBatch(scheduleIds)
     }
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/EventDto.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/EventDto.kt
@@ -189,4 +189,20 @@ class EventDto {
     data class DeleteResponse(
         val message: String
     )
+
+    /**
+     * 내부 서비스용 공연 핵심 정보 — 예매 내역 조회 등 공용
+     *
+     * Reservation Service가 좌석 → 회차 → 공연 메타 조립 시 사용한다.
+     */
+    data class EventInfoResponse(
+        val eventId: UUID,
+        val title: String,
+        val artist: String,
+        val venueName: String,
+        val hallName: String
+    )
+
+    /** 공연 정보 배치 조회 응답 — 요청 ID 중 미존재 ID는 응답에서 제외된다 */
+    data class EventInfoBatchResponse(val events: List<EventInfoResponse>)
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/ScheduleDto.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/dto/ScheduleDto.kt
@@ -161,4 +161,7 @@ class ScheduleDto {
 
     /** 종료된 회차 ID 목록 응답 (내부 API용 — Queue Service 정리 배치 전용) */
     data class EndedScheduleIdsResponse(val scheduleIds: List<UUID>)
+
+    /** 회차 정보 배치 조회 응답 — 요청 ID 중 미존재 ID는 응답에서 제외된다 */
+    data class ScheduleInfoBatchResponse(val schedules: List<ScheduleInfoResponse>)
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustom.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustom.kt
@@ -30,6 +30,14 @@ interface EventRepositoryCustom {
     fun findEventWithVenueAndHall(eventId: UUID): Event?
 
     /**
+     * 공연 ID 목록을 단일 쿼리로 fetch join 조회한다 (내부 배치 API용)
+     *
+     * Reservation Service의 예매 내역 batch 조회 시 N+1 회피용.
+     * deleted_at IS NULL 필터를 적용하며, 미존재 ID는 결과에서 제외된다.
+     */
+    fun findEventsWithVenueAndHall(eventIds: List<UUID>): List<Event>
+
+    /**
      * AVAILABLE 좌석이 하나라도 존재하는 회차 ID Set 반환
      *
      * N+1 방지를 위해 회차 ID 목록을 단일 쿼리로 일괄 조회한다.

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventRepositoryCustomImpl.kt
@@ -96,6 +96,21 @@ class EventRepositoryCustomImpl(
             .fetchOne()
     }
 
+    override fun findEventsWithVenueAndHall(eventIds: List<UUID>): List<Event> {
+        if (eventIds.isEmpty()) return emptyList()
+        val event = QEvent.event
+
+        return queryFactory
+            .selectFrom(event)
+            .leftJoin(event.venue).fetchJoin()
+            .leftJoin(event.hall).fetchJoin()
+            .where(
+                event.id.`in`(eventIds),
+                event.deletedAt.isNull
+            )
+            .fetch()
+    }
+
     override fun findScheduleIdsWithAvailableSeats(scheduleIds: List<UUID>): Set<UUID> {
         if (scheduleIds.isEmpty()) return emptySet()
         val seat = QSeat.seat

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustom.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustom.kt
@@ -25,4 +25,12 @@ interface EventScheduleRepositoryCustom {
     ): List<ScheduleCleanupCursor>
 
     fun findByIdWithEvent(id: UUID): Optional<EventSchedule>
+
+    /**
+     * 회차 ID 목록을 단일 쿼리로 fetch join 조회한다 (내부 배치 API용)
+     *
+     * Reservation Service의 예매 내역 batch 조회 시 N+1 회피용.
+     * 미존재 ID는 결과에서 제외된다.
+     */
+    fun findByIdsWithEvent(ids: List<UUID>): List<EventSchedule>
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustomImpl.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/repository/EventScheduleRepositoryCustomImpl.kt
@@ -58,4 +58,15 @@ class EventScheduleRepositoryCustomImpl(
                 .fetchOne()
         )
     }
+
+    override fun findByIdsWithEvent(ids: List<UUID>): List<EventSchedule> {
+        if (ids.isEmpty()) return emptyList()
+        val schedule = QEventSchedule.eventSchedule
+        val event = QEvent.event
+        return queryFactory
+            .selectFrom(schedule)
+            .join(schedule.event, event).fetchJoin()
+            .where(schedule.id.`in`(ids))
+            .fetch()
+    }
 }

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/EventService.kt
@@ -339,6 +339,46 @@ class EventService(
         return EventDto.DeleteResponse(message = "Event deleted successfully")
     }
 
+    /**
+     * 공연 핵심 정보 조회 (내부 API용 — Reservation Service 등 타 서비스가 공연 메타 조립 시 사용)
+     *
+     * - 미존재 시: EVENT_NOT_FOUND (404)
+     * - venue/hall은 fetch join으로 함께 로드되어 N+1 회피
+     */
+    fun getEventInfo(eventId: UUID): EventDto.EventInfoResponse {
+        val event = eventRepository.findEventWithVenueAndHall(eventId)
+            ?: throw EventException(ErrorCode.EVENT_NOT_FOUND)
+        return EventDto.EventInfoResponse(
+            eventId = event.id!!,
+            title = event.title,
+            artist = event.artist,
+            venueName = event.venue.name,
+            hallName = event.hall.name
+        )
+    }
+
+    /**
+     * 공연 핵심 정보 배치 조회 (내부 API용 — Reservation Service 예매 내역 페이지당 N개 공연 일괄 조립)
+     *
+     * - 미존재 ID는 응답에서 제외 (요청 size 와 응답 size 불일치 가능)
+     * - venue/hall fetch join으로 단일 쿼리 N+1 회피
+     */
+    fun getEventInfoBatch(eventIds: List<UUID>): EventDto.EventInfoBatchResponse {
+        if (eventIds.isEmpty()) return EventDto.EventInfoBatchResponse(emptyList())
+        val events = eventRepository.findEventsWithVenueAndHall(eventIds)
+        return EventDto.EventInfoBatchResponse(
+            events.map { event ->
+                EventDto.EventInfoResponse(
+                    eventId = event.id!!,
+                    title = event.title,
+                    artist = event.artist,
+                    venueName = event.venue.name,
+                    hallName = event.hall.name
+                )
+            }
+        )
+    }
+
     // ===== Private Helper Methods =====
 
     private fun findActiveEvent(eventId: UUID): Event {

--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/service/ScheduleService.kt
@@ -286,6 +286,29 @@ class ScheduleService(
     }
 
     /**
+     * 회차 핵심 정보 배치 조회 (내부 API용 — Reservation Service 예매 내역 페이지 일괄 조립)
+     *
+     * - 미존재 ID는 응답에서 제외 (요청 size 와 응답 size 불일치 가능)
+     * - event fetch join으로 단일 쿼리 N+1 회피
+     */
+    fun getScheduleInfoBatch(scheduleIds: List<UUID>): ScheduleDto.ScheduleInfoBatchResponse {
+        if (scheduleIds.isEmpty()) return ScheduleDto.ScheduleInfoBatchResponse(emptyList())
+        val schedules = eventScheduleRepository.findByIdsWithEvent(scheduleIds)
+        return ScheduleDto.ScheduleInfoBatchResponse(
+            schedules.map { schedule ->
+                ScheduleDto.ScheduleInfoResponse(
+                    scheduleId = schedule.id!!,
+                    eventId = schedule.event.id!!,
+                    eventStartAt = schedule.eventStartAt,
+                    eventEndAt = schedule.eventEndAt,
+                    saleStartAt = schedule.saleStartAt,
+                    saleEndAt = schedule.saleEndAt
+                )
+            }
+        )
+    }
+
+    /**
      * 종료/취소 후 24시간 이상 경과한 회차 ID 목록을 모두 반환한다 (내부 API용 — Queue Service 정리 배치 전용)
      *
      * 커서 기반 페이지네이션으로 1000건씩 반복 조회하여 1000건 초과 데이터도 누락 없이 처리한다.

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalEventControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalEventControllerTest.kt
@@ -1,0 +1,161 @@
+package com.ticketqueue.event.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.exception.GlobalExceptionHandler
+import com.ticketqueue.event.dto.EventDto
+import com.ticketqueue.event.exception.EventException
+import com.ticketqueue.event.service.EventService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.validation.Validation
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.aop.framework.ProxyFactory
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.validation.beanvalidation.MethodValidationInterceptor
+import java.util.UUID
+
+/**
+ * 내부 공연 API 컨트롤러 단위 테스트
+ *
+ * @Validated + @Size 검증을 standalone MockMvc 에서 동작시키기 위해
+ * ProxyFactory + MethodValidationInterceptor 로 컨트롤러를 AOP 래핑한다.
+ * (실제 Spring 컨테이너의 MethodValidationPostProcessor 와 동일한 효과)
+ */
+class InternalEventControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var eventService: EventService
+    private val objectMapper: ObjectMapper = jacksonObjectMapper().apply {
+        registerModule(JavaTimeModule())
+    }
+
+    private val eventId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        eventService = mockk()
+        val rawController = InternalEventController(eventService)
+        // @Validated + @Size 동작을 위해 MethodValidationInterceptor 로 AOP 프록시 래핑
+        val proxyFactory = ProxyFactory(rawController).apply {
+            addAdvice(MethodValidationInterceptor(Validation.buildDefaultValidatorFactory().validator))
+        }
+        val controller = proxyFactory.proxy as InternalEventController
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(GlobalExceptionHandler())
+            .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
+            .build()
+    }
+
+    @Nested
+    @DisplayName("GET /internal/events/{eventId}/info")
+    inner class GetEventInfo {
+
+        @Test
+        @DisplayName("200 OK - 공연 핵심 정보를 반환한다")
+        fun success() {
+            val response = EventDto.EventInfoResponse(
+                eventId = eventId,
+                title = "BTS World Tour",
+                artist = "BTS",
+                venueName = "올림픽공원",
+                hallName = "KSPO DOME"
+            )
+            every { eventService.getEventInfo(eventId) } returns response
+
+            mockMvc.perform(get("/internal/events/{eventId}/info", eventId))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.eventId").value(eventId.toString()))
+                .andExpect(jsonPath("$.title").value("BTS World Tour"))
+                .andExpect(jsonPath("$.artist").value("BTS"))
+                .andExpect(jsonPath("$.venueName").value("올림픽공원"))
+                .andExpect(jsonPath("$.hallName").value("KSPO DOME"))
+
+            verify { eventService.getEventInfo(eventId) }
+        }
+
+        @Test
+        @DisplayName("404 Not Found - 존재하지 않는 eventId 는 EVENT_NOT_FOUND 를 반환한다")
+        fun notFound() {
+            every { eventService.getEventInfo(eventId) } throws EventException(ErrorCode.EVENT_NOT_FOUND)
+
+            mockMvc.perform(get("/internal/events/{eventId}/info", eventId))
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.code").value("EVENT_NOT_FOUND"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /internal/events/batch")
+    inner class GetEventInfoBatch {
+
+        @Test
+        @DisplayName("200 OK - 요청한 공연 메타 목록을 반환한다")
+        fun success() {
+            val id1 = UUID.randomUUID()
+            val id2 = UUID.randomUUID()
+            val response = EventDto.EventInfoBatchResponse(
+                events = listOf(
+                    EventDto.EventInfoResponse(id1, "BTS World Tour", "BTS", "올림픽공원", "KSPO DOME"),
+                    EventDto.EventInfoResponse(id2, "BLACKPINK Concert", "BLACKPINK", "고척돔", "메인홀")
+                )
+            )
+            every { eventService.getEventInfoBatch(listOf(id1, id2)) } returns response
+
+            mockMvc.perform(get("/internal/events/batch").param("eventIds", id1.toString(), id2.toString()))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.events.length()").value(2))
+                .andExpect(jsonPath("$.events[0].eventId").value(id1.toString()))
+                .andExpect(jsonPath("$.events[0].title").value("BTS World Tour"))
+                .andExpect(jsonPath("$.events[1].eventId").value(id2.toString()))
+                .andExpect(jsonPath("$.events[1].artist").value("BLACKPINK"))
+        }
+
+        @Test
+        @DisplayName("200 OK - 미존재 ID 는 응답에서 제외 (요청 size 와 응답 size 불일치 가능)")
+        fun missingIdsExcluded() {
+            val id1 = UUID.randomUUID()
+            val missingId = UUID.randomUUID()
+            val response = EventDto.EventInfoBatchResponse(
+                events = listOf(
+                    EventDto.EventInfoResponse(id1, "BTS World Tour", "BTS", "올림픽공원", "KSPO DOME")
+                )
+            )
+            every { eventService.getEventInfoBatch(listOf(id1, missingId)) } returns response
+
+            mockMvc.perform(get("/internal/events/batch").param("eventIds", id1.toString(), missingId.toString()))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.events.length()").value(1))
+                .andExpect(jsonPath("$.events[0].eventId").value(id1.toString()))
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - eventIds 파라미터 누락 시 INVALID_INPUT")
+        fun missingParameter() {
+            mockMvc.perform(get("/internal/events/batch"))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - eventIds size 가 100을 초과하면 INVALID_INPUT")
+        fun sizeTooLarge() {
+            val ids = (1..101).map { UUID.randomUUID().toString() }.toTypedArray()
+            mockMvc.perform(get("/internal/events/batch").param("eventIds", *ids))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+        }
+    }
+}

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalScheduleControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/InternalScheduleControllerTest.kt
@@ -10,10 +10,12 @@ import com.ticketqueue.event.exception.EventException
 import com.ticketqueue.event.service.ScheduleService
 import io.mockk.every
 import io.mockk.mockk
+import jakarta.validation.Validation
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.aop.framework.ProxyFactory
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -23,6 +25,8 @@ import org.hamcrest.Matchers.not
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.validation.beanvalidation.MethodValidationInterceptor
+import java.time.LocalDateTime
 import java.util.UUID
 
 class InternalScheduleControllerTest {
@@ -38,7 +42,12 @@ class InternalScheduleControllerTest {
     @BeforeEach
     fun setUp() {
         scheduleService = mockk()
-        val controller = InternalScheduleController(scheduleService)
+        val rawController = InternalScheduleController(scheduleService)
+        // @Validated + @Size 가 standalone MockMvc 에서 동작하도록 AOP 프록시 래핑
+        val proxyFactory = ProxyFactory(rawController).apply {
+            addAdvice(MethodValidationInterceptor(Validation.buildDefaultValidatorFactory().validator))
+        }
+        val controller = proxyFactory.proxy as InternalScheduleController
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
             .setControllerAdvice(GlobalExceptionHandler())
             .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
@@ -150,6 +159,71 @@ class InternalScheduleControllerTest {
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.sellable").value(false))
                 .andExpect(jsonPath("$.reason").value("SCHEDULE_NOT_AVAILABLE"))
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /internal/schedules/batch")
+    inner class GetScheduleInfoBatch {
+
+        @Test
+        @DisplayName("200 OK - 회차 핵심 정보 목록을 반환한다")
+        fun success() {
+            val id1 = UUID.randomUUID()
+            val id2 = UUID.randomUUID()
+            val eventIdFixture = UUID.randomUUID()
+            val now = LocalDateTime.of(2026, 6, 1, 19, 0)
+            val response = ScheduleDto.ScheduleInfoBatchResponse(
+                schedules = listOf(
+                    ScheduleDto.ScheduleInfoResponse(id1, eventIdFixture, now, now.plusHours(2), now.minusDays(10), now.minusHours(1)),
+                    ScheduleDto.ScheduleInfoResponse(id2, eventIdFixture, now.plusDays(1), now.plusDays(1).plusHours(2), now.minusDays(10), now.plusDays(1).minusHours(1))
+                )
+            )
+            every { scheduleService.getScheduleInfoBatch(listOf(id1, id2)) } returns response
+
+            mockMvc.perform(get("/internal/schedules/batch").param("scheduleIds", id1.toString(), id2.toString()))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.schedules.length()").value(2))
+                .andExpect(jsonPath("$.schedules[0].scheduleId").value(id1.toString()))
+                .andExpect(jsonPath("$.schedules[0].eventId").value(eventIdFixture.toString()))
+                .andExpect(jsonPath("$.schedules[1].scheduleId").value(id2.toString()))
+        }
+
+        @Test
+        @DisplayName("200 OK - 미존재 ID 는 응답에서 제외된다")
+        fun missingIdsExcluded() {
+            val id1 = UUID.randomUUID()
+            val missingId = UUID.randomUUID()
+            val eventIdFixture = UUID.randomUUID()
+            val now = LocalDateTime.of(2026, 6, 1, 19, 0)
+            val response = ScheduleDto.ScheduleInfoBatchResponse(
+                schedules = listOf(
+                    ScheduleDto.ScheduleInfoResponse(id1, eventIdFixture, now, now.plusHours(2), now.minusDays(10), now.minusHours(1))
+                )
+            )
+            every { scheduleService.getScheduleInfoBatch(listOf(id1, missingId)) } returns response
+
+            mockMvc.perform(get("/internal/schedules/batch").param("scheduleIds", id1.toString(), missingId.toString()))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.schedules.length()").value(1))
+                .andExpect(jsonPath("$.schedules[0].scheduleId").value(id1.toString()))
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - scheduleIds 파라미터 누락 시 INVALID_INPUT")
+        fun missingParameter() {
+            mockMvc.perform(get("/internal/schedules/batch"))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+        }
+
+        @Test
+        @DisplayName("400 Bad Request - scheduleIds size 가 100을 초과하면 INVALID_INPUT")
+        fun sizeTooLarge() {
+            val ids = (1..101).map { UUID.randomUUID().toString() }.toTypedArray()
+            mockMvc.perform(get("/internal/schedules/batch").param("scheduleIds", *ids))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
         }
     }
 }

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/EventServiceTest.kt
@@ -1051,4 +1051,85 @@ class EventServiceTest {
             verify { redisTemplate.execute(any<RedisCallback<Any?>>()) }  // list cache SCAN
         }
     }
+
+    @Nested
+    @DisplayName("getEventInfo")
+    inner class GetEventInfo {
+
+        @Test
+        @DisplayName("공연 핵심 정보(EventInfoResponse)를 반환한다")
+        fun success() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+
+            every { eventRepository.findEventWithVenueAndHall(eventId) } returns event
+
+            val result = eventService.getEventInfo(eventId)
+
+            assertEquals(eventId, result.eventId)
+            assertEquals("BTS World Tour", result.title)
+            assertEquals("BTS", result.artist)
+            assertEquals("올림픽공원", result.venueName)
+            assertEquals("KSPO DOME", result.hallName)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 공연 조회 시 EVENT_NOT_FOUND 예외가 발생한다")
+        fun notFound() {
+            every { eventRepository.findEventWithVenueAndHall(eventId) } returns null
+
+            val ex = assertThrows<EventException> { eventService.getEventInfo(eventId) }
+            assertEquals(ErrorCode.EVENT_NOT_FOUND, ex.errorCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("getEventInfoBatch")
+    inner class GetEventInfoBatch {
+
+        @Test
+        @DisplayName("요청한 공연들의 핵심 정보 목록을 반환한다")
+        fun success() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val ids = listOf(eventId)
+
+            every { eventRepository.findEventsWithVenueAndHall(ids) } returns listOf(event)
+
+            val result = eventService.getEventInfoBatch(ids)
+
+            assertEquals(1, result.events.size)
+            assertEquals(eventId, result.events[0].eventId)
+            assertEquals("BTS", result.events[0].artist)
+            assertEquals("올림픽공원", result.events[0].venueName)
+        }
+
+        @Test
+        @DisplayName("미존재 ID는 응답에서 제외된다 (요청 size 와 응답 size 불일치 가능)")
+        fun missingIdsExcluded() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val missingId = UUID.randomUUID()
+            val ids = listOf(eventId, missingId)
+
+            every { eventRepository.findEventsWithVenueAndHall(ids) } returns listOf(event)
+
+            val result = eventService.getEventInfoBatch(ids)
+
+            assertEquals(1, result.events.size)
+            assertEquals(eventId, result.events[0].eventId)
+        }
+
+        @Test
+        @DisplayName("빈 목록 입력 시 빈 응답을 반환하고 DB 조회를 생략한다")
+        fun emptyInput() {
+            val result = eventService.getEventInfoBatch(emptyList())
+
+            assertEquals(0, result.events.size)
+            verify(exactly = 0) { eventRepository.findEventsWithVenueAndHall(any()) }
+        }
+    }
 }

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/ScheduleServiceTest.kt
@@ -646,4 +646,56 @@ class ScheduleServiceTest {
             verify { eventService.invalidateEventListCaches() }
         }
     }
+
+    @Nested
+    @DisplayName("getScheduleInfoBatch")
+    inner class GetScheduleInfoBatch {
+
+        @Test
+        @DisplayName("요청한 회차들의 핵심 정보를 단일 fetch join 쿼리로 반환한다")
+        fun success() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+            val ids = listOf(scheduleId)
+
+            every { eventScheduleRepository.findByIdsWithEvent(ids) } returns listOf(schedule)
+
+            val result = scheduleService.getScheduleInfoBatch(ids)
+
+            assertEquals(1, result.schedules.size)
+            assertEquals(scheduleId, result.schedules[0].scheduleId)
+            assertEquals(eventId, result.schedules[0].eventId)
+            assertEquals(schedule.eventStartAt, result.schedules[0].eventStartAt)
+            assertEquals(schedule.saleEndAt, result.schedules[0].saleEndAt)
+        }
+
+        @Test
+        @DisplayName("미존재 ID는 응답에서 제외된다 (요청 size 와 응답 size 불일치 가능)")
+        fun missingIdsExcluded() {
+            val venue = createVenue()
+            val hall = createHall(venue)
+            val event = createEvent(venue, hall)
+            val schedule = createSchedule(event)
+            val missingId = UUID.randomUUID()
+            val ids = listOf(scheduleId, missingId)
+
+            every { eventScheduleRepository.findByIdsWithEvent(ids) } returns listOf(schedule)
+
+            val result = scheduleService.getScheduleInfoBatch(ids)
+
+            assertEquals(1, result.schedules.size)
+            assertEquals(scheduleId, result.schedules[0].scheduleId)
+        }
+
+        @Test
+        @DisplayName("빈 목록 입력 시 빈 응답을 반환하고 DB 조회를 생략한다")
+        fun emptyInput() {
+            val result = scheduleService.getScheduleInfoBatch(emptyList())
+
+            assertEquals(0, result.schedules.size)
+            verify(exactly = 0) { eventScheduleRepository.findByIdsWithEvent(any()) }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Reservation Service의 예매 내역 페이지 한 번 조회 시 N개 공연·회차 메타를 일괄 조립할 수 있도록 Event Service에 내부 배치 조회 API를 추가했다.
- 신규 엔드포인트
  - `GET /internal/events/{eventId}/info` — 공연 핵심 정보 단건 조회
  - `GET /internal/events/batch?eventIds=...` — 공연 메타 배치 조회 (최대 100건)
  - `GET /internal/schedules/batch?scheduleIds=...` — 회차 메타 배치 조회 (최대 100건)
- venue/hall 및 event를 fetch join한 단일 QueryDSL 쿼리로 N+1을 회피한다.
- 미존재 ID는 응답에서 제외 — 요청 size와 응답 size가 다를 수 있다 (호출자가 결손 인지).
- `@Validated` + `@Size(1..100)`로 요청 크기 검증 → 0건 또는 100건 초과 시 `400 INVALID_INPUT`.
- 보안: 기존 `InternalApiAuthInterceptor`가 `X-Service-Api-Key` 검증을 담당 (Gateway가 외부 `/internal/**` 차단).

## Why
- #54 (선점 만료 배치)가 머지되면서 후속 작업으로 #52 (예매 내역 조회 API)가 풀렸다.
- 예매 내역 조회는 페이지당 다수 예약 → 다수 회차 → 다수 공연 메타가 필요한 fan-out 구조이므로, 단건 호출 N회 대신 배치 호출 1회로 처리할 수 있는 사전(pre) PR이 필요했다.

## Implementation Notes
- `EventRepositoryCustom.findEventsWithVenueAndHall(ids)` / `EventScheduleRepositoryCustom.findByIdsWithEvent(ids)` 추가 — 빈 입력 short-circuit 및 fetch join 으로 N+1 차단.
- 신규 DTO: `EventDto.EventInfoResponse` / `EventInfoBatchResponse`, `ScheduleDto.ScheduleInfoBatchResponse`.
- `InternalScheduleController`에 기존 단건 `/info` 와 일관된 `/batch` 엔드포인트 동거.
- 컨트롤러 단위 테스트는 `ProxyFactory + MethodValidationInterceptor`로 AOP 래핑하여 standalone MockMvc에서도 `@Size` 검증이 실제로 트리거되도록 처리.

## Test plan
- [x] `./gradlew :event-service:test --tests InternalEventControllerTest` — happy path / 404 / batch / missing param / size > 100 모두 통과
- [x] `./gradlew :event-service:test --tests InternalScheduleControllerTest` — 기존 케이스 + 신규 batch 검증 통과
- [x] `./gradlew :event-service:test --tests EventServiceTest` — `GetEventInfo` / `GetEventInfoBatch` (happy + missing IDs + empty input) 통과
- [x] `./gradlew :event-service:test --tests ScheduleServiceTest` — `GetScheduleInfoBatch` (happy + missing IDs + empty input) 통과
- [ ] CI에서 `:event-service:test` 전체 그린 확인
- [ ] (후속 #52 main PR에서) Reservation Service가 batch 엔드포인트를 호출해 예매 내역을 조립하는 e2e 흐름 검증

## Note on Unrelated Pre-existing Failures
사전 로컬 빌드(`./gradlew :event-service:build`)에서 본 PR과 무관한 3개 테스트가 실패했다:
- `EventControllerTest$GetSeats.success` (200 expected but was 404)
- `EventControllerTest$Security$PublicAccess.getSeats_shouldReturnOk_whenNoAuth` (200 expected but was 404)
- `SeatServiceTest$ReleaseHoldSeats` (mockk verify on Redis `SetOperations.remove`)

세 파일 모두 본 브랜치에서 한 줄도 수정하지 않았다 (`git diff HEAD -- ...` 결과 빈 출력). 별도 이슈로 다루기 권장.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added internal API endpoints for retrieving single and batch event metadata by ID
- Added internal API endpoint for batch schedule metadata retrieval
- Batch endpoints support requests with up to 100 IDs per call

## Tests
- Added comprehensive test coverage for new internal API endpoints including validation and error handling scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paircoders/ticket-queue/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->