### PR TITLE
feat: [Payment] 결제 조회 API 구현 (#64)

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -73,7 +73,7 @@ Outbox 위에서 동작하거나 완전히 독립적인 핵심 백엔드 API. **
 |---|------|-------|-------|------|-------|--------|----|
 | 4 | [x] | [#59](https://github.com/paircoders/ticket-queue/issues/59) | [Payment] 결제 승인 API 구현 | #63 | session-aa382e34 | `feature/59-payment-confirm-api` | [#234](https://github.com/paircoders/ticket-queue/pull/234) |
 | 5 | [ ] | [#61](https://github.com/paircoders/ticket-queue/issues/61) | [Payment] Timeout 및 Circuit Breaker 설정 | #59 |  | `feature/61-payment-resilience` |  |
-| 6 | [ ] | [#64](https://github.com/paircoders/ticket-queue/issues/64) | [Payment] 결제 조회 API 구현 | #59 |  | `feature/64-payment-query-api` |  |
+| 6 | [ ] | [#64](https://github.com/paircoders/ticket-queue/issues/64) | [Payment] 결제 조회 API 구현 | #59 | session-b14fa667 | `feature/64-payment-query-api` | [#238](https://github.com/paircoders/ticket-queue/pull/238) |
 | 7 | [ ] | [#52](https://github.com/paircoders/ticket-queue/issues/52) | [Reservation] 예매 내역 조회 API 구현 | — | session-40d186c1 | `feature/52-reservation-query-api` |  |
 | 8 | [x] | [#54](https://github.com/paircoders/ticket-queue/issues/54) | [Reservation] 선점 만료 자동 취소 배치 | #55 | session-ded1f1c5 | `feature/54-reservation-expire-batch` | [#235](https://github.com/paircoders/ticket-queue/pull/235) |
 

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/controller/PaymentController.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/controller/PaymentController.kt
@@ -1,16 +1,24 @@
 package com.ticketqueue.payment.controller
 
+import com.ticketqueue.common.dto.PageResponse
 import com.ticketqueue.payment.dto.PaymentDto.ConfirmRequest
 import com.ticketqueue.payment.dto.PaymentDto.ConfirmResponse
 import com.ticketqueue.payment.dto.PaymentDto.CreateRequest
 import com.ticketqueue.payment.dto.PaymentDto.CreateResponse
+import com.ticketqueue.payment.dto.PaymentDto.DetailResponse
+import com.ticketqueue.payment.dto.PaymentDto.ListItem
 import com.ticketqueue.payment.service.PaymentService
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -35,5 +43,30 @@ class PaymentController(
         @RequestBody @Valid request: ConfirmRequest
     ): ConfirmResponse {
         return paymentService.confirmPayment(userId, request)
+    }
+
+    /**
+     * 결제 상세 조회 (REQ-PAY-014, spec §1.4).
+     */
+    @GetMapping("/{paymentId}")
+    fun getPayment(
+        @RequestHeader("X-User-Id") userId: UUID,
+        @PathVariable paymentId: UUID,
+    ): DetailResponse {
+        return paymentService.getPayment(userId, paymentId)
+    }
+
+    /**
+     * 내 결제 내역 페이징 조회 (REQ-PAY-015, spec §1.3).
+     *
+     * `size` 상한 100 / 하한 1 강제 — Plan §7 Decision 3 의 paging 컨벤션.
+     */
+    @GetMapping
+    fun listPayments(
+        @RequestHeader("X-User-Id") userId: UUID,
+        @RequestParam(defaultValue = "0") @Min(0) page: Int,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(100) size: Int,
+    ): PageResponse<ListItem> {
+        return paymentService.listPayments(userId, page, size)
     }
 }

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/controller/PaymentController.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/controller/PaymentController.kt
@@ -6,6 +6,7 @@ import com.ticketqueue.payment.dto.PaymentDto.CreateRequest
 import com.ticketqueue.payment.dto.PaymentDto.CreateResponse
 import com.ticketqueue.payment.service.PaymentService
 import jakarta.validation.Valid
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -15,6 +16,7 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/payments")
+@Validated
 class PaymentController(
     private val paymentService: PaymentService
 ) {

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/dto/PaymentDto.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/dto/PaymentDto.kt
@@ -38,4 +38,23 @@ class PaymentDto {
         val status: PaymentStatus,
         val paidAt: LocalDateTime?
     )
+
+    data class ListItem(
+        val paymentId: UUID,
+        val reservationId: UUID,
+        val amount: BigDecimal,
+        val status: PaymentStatus,
+        val method: PaymentMethod,
+        val paidAt: LocalDateTime?,
+    )
+
+    data class DetailResponse(
+        val paymentId: UUID,
+        val reservationId: UUID,
+        val amount: BigDecimal,
+        val status: PaymentStatus,
+        val method: PaymentMethod,
+        val cardName: String?,
+        val cardNumber: String?,
+    )
 }

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/repository/PaymentRepository.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/repository/PaymentRepository.kt
@@ -3,6 +3,8 @@ package com.ticketqueue.payment.repository
 import com.ticketqueue.payment.entity.Payment
 import com.ticketqueue.payment.entity.PaymentStatus
 import jakarta.persistence.LockModeType
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
@@ -13,6 +15,7 @@ import java.util.UUID
 interface PaymentRepository : JpaRepository<Payment, UUID> {
     fun findByPaymentKey(paymentKey: String): Optional<Payment>
     fun existsByReservationIdAndStatusIn(reservationId: UUID, statuses: List<PaymentStatus>): Boolean
+    fun findByUserId(userId: UUID, pageable: Pageable): Page<Payment>
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from Payment p where p.id = :id")

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentMaskingMapper.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentMaskingMapper.kt
@@ -1,0 +1,40 @@
+package com.ticketqueue.payment.service
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.external.portone.PortonePaymentResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Component
+
+/**
+ * PortOne 결제 응답(jsonb) 에서 카드 발급사명과 마스킹 카드번호를 추출한다.
+ *
+ * Hybrid 정책 (Plan §7 Decision 1):
+ *  - envelope: [PortonePaymentResponse] 로 typed deserialize (JacksonConfig 의 FAIL_ON_UNKNOWN_PROPERTIES=false 로 신규 필드 허용)
+ *  - nested: `method["card"]` 는 `Map<String, Any?>` 로 generic null-safe cast — PortOne 카드 메타 키가 결제수단별로 비정형이라 fail-fast 대신 silent null 로 회복력 확보
+ *
+ * envelope 단계 실패 (PortOne 응답 schema 가 envelope 레벨에서 breaking change) 시 WARN 로그 후 빈 [CardMeta] 반환. 예외는 전파하지 않는다.
+ */
+@Component
+class PaymentMaskingMapper(
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = KotlinLogging.logger {}
+
+    fun extract(portoneResponseJson: String?): CardMeta {
+        if (portoneResponseJson.isNullOrBlank()) return CardMeta(null, null)
+        return try {
+            val response = objectMapper.readValue(portoneResponseJson, PortonePaymentResponse::class.java)
+            val card = response.method?.get("card") as? Map<*, *>
+            CardMeta(
+                name = card?.get("publisher") as? String,
+                number = card?.get("number") as? String,
+            )
+        } catch (e: JsonProcessingException) {
+            log.warn { "Failed to deserialize PortOne payment response for card meta extraction: ${e.message}" }
+            CardMeta(null, null)
+        }
+    }
+
+    data class CardMeta(val name: String?, val number: String?)
+}

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
@@ -1,6 +1,7 @@
 package com.ticketqueue.payment.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.dto.PageResponse
 import com.ticketqueue.common.event.EventMetadata
 import com.ticketqueue.common.event.PaymentFailedEvent
 import com.ticketqueue.common.event.PaymentSuccessEvent
@@ -19,6 +20,8 @@ import com.ticketqueue.payment.dto.PaymentDto.ConfirmRequest
 import com.ticketqueue.payment.dto.PaymentDto.ConfirmResponse
 import com.ticketqueue.payment.dto.PaymentDto.CreateRequest
 import com.ticketqueue.payment.dto.PaymentDto.CreateResponse
+import com.ticketqueue.payment.dto.PaymentDto.DetailResponse
+import com.ticketqueue.payment.dto.PaymentDto.ListItem
 import com.ticketqueue.payment.entity.Payment
 import com.ticketqueue.payment.entity.PaymentStatus
 import com.ticketqueue.payment.exception.PaymentException
@@ -26,7 +29,10 @@ import com.ticketqueue.payment.repository.PaymentRepository
 import feign.FeignException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -43,6 +49,7 @@ class PaymentService(
     private val outboxEventRecorder: OutboxEventRecorder,
     private val transactionTemplate: TransactionTemplate,
     private val objectMapper: ObjectMapper,
+    private val paymentMaskingMapper: PaymentMaskingMapper,
 ) {
 
     private val log = KotlinLogging.logger {}
@@ -218,6 +225,62 @@ class PaymentService(
             paymentId = finalPayment.id!!,
             status = finalPayment.status,
             paidAt = finalPayment.paidAt
+        )
+    }
+
+    /**
+     * 결제 상세 조회 (REQ-PAY-014, Plan §3 Step 3, AC-1~4 & AC-11).
+     *
+     * 소유권 검증은 read context — UUIDv4 entropy 가 충분히 높아 IDOR 위험이 write 보다 낮으나
+     * confirmPayment 와 동일하게 NOT_FOUND/FORBIDDEN 구분을 유지한다 (Plan §7 Decision 4).
+     * `cardName`/`cardNumber` 는 [PaymentMaskingMapper] 가 PortOne 응답에서 read-time 으로 추출 —
+     * status=PENDING/FAILED 또는 method 가 카드 아닌 경우 자연스럽게 null 이 된다.
+     */
+    @Transactional(readOnly = true)
+    fun getPayment(userId: UUID, paymentId: UUID): DetailResponse {
+        val payment = paymentRepository.findById(paymentId)
+            .orElseThrow { PaymentException(ErrorCode.RESOURCE_NOT_FOUND) }
+        if (payment.userId != userId) throw PaymentException(ErrorCode.FORBIDDEN)
+
+        val cardMeta = paymentMaskingMapper.extract(payment.portoneResponse)
+        return DetailResponse(
+            paymentId = payment.id!!,
+            reservationId = payment.reservationId,
+            amount = payment.amount,
+            status = payment.status,
+            method = payment.paymentMethod,
+            cardName = cardMeta.name,
+            cardNumber = cardMeta.number,
+        )
+    }
+
+    /**
+     * 내 결제 내역 페이징 조회 (REQ-PAY-015, Plan §3 Step 3, AC-5/6/7/9).
+     *
+     * 정렬 기준 `createdAt DESC` 는 Service 내부에서 hard-code — 호출자가 sort 미주입할 가능성을 차단하고,
+     * `idx_payments_user_created (user_id, created_at DESC)` 인덱스 hit 을 보장한다 (Plan §7 Decision 3).
+     * 모든 status (PENDING/SUCCESS/FAILED/REFUNDED) 를 반환 — 필터 옵션은 후속 이슈 (Plan §7 Decision 9).
+     * REFUNDED 결제는 markSuccess 단계의 `paidAt` 을 유지하므로 그대로 노출된다 (Critic N1 정정).
+     */
+    @Transactional(readOnly = true)
+    fun listPayments(userId: UUID, page: Int, size: Int): PageResponse<ListItem> {
+        val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        val resultPage = paymentRepository.findByUserId(userId, pageable)
+        val items = resultPage.content.map { payment ->
+            ListItem(
+                paymentId = payment.id!!,
+                reservationId = payment.reservationId,
+                amount = payment.amount,
+                status = payment.status,
+                method = payment.paymentMethod,
+                paidAt = payment.paidAt,
+            )
+        }
+        return PageResponse(
+            list = items,
+            page = page,
+            size = size,
+            totalElements = resultPage.totalElements,
         )
     }
 

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentQueryControllerIntegrationTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/controller/PaymentQueryControllerIntegrationTest.kt
@@ -1,0 +1,411 @@
+package com.ticketqueue.payment.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.ticketqueue.common.external.portone.PortoneCustomer
+import com.ticketqueue.common.external.portone.PortoneFeignClient
+import com.ticketqueue.common.external.portone.PortonePaymentAmount
+import com.ticketqueue.common.external.portone.PortonePaymentResponse
+import com.ticketqueue.common.external.portone.PortoneSelectedChannel
+import com.ticketqueue.common.external.portone.PortoneTokenService
+import com.ticketqueue.common.outbox.OutboxEventRepository
+import com.ticketqueue.payment.client.ReservationServiceClient
+import com.ticketqueue.payment.entity.Payment
+import com.ticketqueue.payment.entity.PaymentMethod
+import com.ticketqueue.payment.entity.PaymentStatus
+import com.ticketqueue.payment.repository.PaymentRepository
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.math.BigDecimal
+import java.sql.Timestamp
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "spring.config.import=",
+        "spring.cloud.aws.region.static=us-east-1",
+        "spring.cloud.aws.credentials.access-key=test",
+        "spring.cloud.aws.credentials.secret-key=test",
+        "spring.cloud.aws.secretsmanager.enabled=false"
+    ]
+)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("결제 조회 API 통합 테스트 (GET /payments)")
+class PaymentQueryControllerIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:18-alpine")
+            .withDatabaseName("ticketing")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("db/init.sql")
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { postgres.jdbcUrl }
+            registry.add("spring.datasource.username") { postgres.username }
+            registry.add("spring.datasource.password") { postgres.password }
+        }
+    }
+
+    @Autowired private lateinit var mockMvc: MockMvc
+    @Autowired private lateinit var objectMapper: ObjectMapper
+    @Autowired private lateinit var paymentRepository: PaymentRepository
+    @Autowired private lateinit var outboxEventRepository: OutboxEventRepository
+    @Autowired private lateinit var jdbcTemplate: JdbcTemplate
+
+    // 본 통합 테스트는 read-only 라 실제 호출 없으나 Spring context 빈 wiring 위해 stub.
+    @MockkBean private lateinit var reservationServiceClient: ReservationServiceClient
+    @MockkBean private lateinit var portoneClient: PortoneFeignClient
+    @MockkBean private lateinit var portoneTokenService: PortoneTokenService
+
+    private val userId = UUID.randomUUID()
+    private val otherUserId = UUID.randomUUID()
+    private val amount = BigDecimal("300000")
+
+    @BeforeEach
+    fun setUp() {
+        outboxEventRepository.deleteAll()
+        paymentRepository.deleteAll()
+    }
+
+    /**
+     * PortOne 응답 JSON 시드 helper — `method` 만 가변.
+     *
+     * mapper 가 envelope typed deserialize 를 시도하므로 PortonePaymentResponse 의 모든 required 필드가 채워져야 한다.
+     */
+    private fun portoneResponseJson(method: Map<String, Any?>?): String {
+        val response = PortonePaymentResponse(
+            id = "p-${UUID.randomUUID()}",
+            transactionId = "tx-${UUID.randomUUID()}",
+            merchantId = "m",
+            storeId = "store-id",
+            status = "PAID",
+            amount = PortonePaymentAmount(
+                total = 300000L,
+                taxFree = 0L,
+                discount = 0L,
+                paid = 300000L,
+                cancelled = 0L,
+                cancelledTaxFree = 0L,
+            ),
+            currency = "KRW",
+            channel = PortoneSelectedChannel("TEST", "test-pg", "test-mid"),
+            version = "v2",
+            requestedAt = OffsetDateTime.now(),
+            updatedAt = OffsetDateTime.now(),
+            statusChangedAt = OffsetDateTime.now(),
+            orderName = "order",
+            customer = PortoneCustomer(),
+            method = method,
+            paidAt = OffsetDateTime.now(),
+        )
+        return objectMapper.writeValueAsString(response)
+    }
+
+    /**
+     * Payment row 시드. createdAt 명시 시 @Column(updatable=false) 우회를 위해 native UPDATE 사용 (Critic N2 — flaky 회피).
+     * `idx_payments_reservation_pending_success` partial unique 회피 위해 호출자가 reservationId 를 가변 지정해야 한다.
+     */
+    private fun seed(
+        ownerId: UUID = userId,
+        reservationId: UUID = UUID.randomUUID(),
+        status: PaymentStatus = PaymentStatus.SUCCESS,
+        portoneResponse: String? = null,
+        paidAt: LocalDateTime? = LocalDateTime.now(ZoneOffset.UTC),
+        createdAt: LocalDateTime? = null,
+    ): Payment {
+        val payment = Payment(
+            reservationId = reservationId,
+            userId = ownerId,
+            paymentKey = UUID.randomUUID().toString(),
+            amount = amount,
+            paymentMethod = PaymentMethod.CARD,
+            status = status,
+            portoneResponse = portoneResponse,
+            paidAt = paidAt,
+        )
+        val saved = paymentRepository.saveAndFlush(payment)
+        if (createdAt != null) {
+            jdbcTemplate.update(
+                "UPDATE payment_service.payments SET created_at = ? WHERE id = ?",
+                Timestamp.valueOf(createdAt),
+                saved.id,
+            )
+        }
+        return saved
+    }
+
+    // ============================================================
+    // GET /payments/{paymentId} — 결제 상세
+    // ============================================================
+
+    @Nested
+    @DisplayName("GET /payments/{paymentId} — 결제 상세")
+    inner class Detail {
+
+        @Test
+        @DisplayName("AC-1: 본인 SUCCESS 결제 + 카드 메타가 응답에 매핑된다")
+        fun ac1_successDetail() {
+            val responseJson = portoneResponseJson(
+                method = mapOf("card" to mapOf("publisher" to "SHINHAN", "number" to "1234-****-****-5678"))
+            )
+            val payment = seed(status = PaymentStatus.SUCCESS, portoneResponse = responseJson)
+
+            mockMvc.perform(
+                get("/payments/{paymentId}", payment.id)
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.paymentId").value(payment.id.toString()))
+                .andExpect(jsonPath("$.reservationId").value(payment.reservationId.toString()))
+                .andExpect(jsonPath("$.amount").value(300000))
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.method").value("CARD"))
+                .andExpect(jsonPath("$.cardName").value("SHINHAN"))
+                .andExpect(jsonPath("$.cardNumber").value("1234-****-****-5678"))
+                .andExpect(jsonPath("$.paidAt").doesNotExist())
+        }
+
+        @Test
+        @DisplayName("AC-2: 다른 유저 소유 결제 조회 시 403 FORBIDDEN")
+        fun ac2_forbidden() {
+            val payment = seed(ownerId = otherUserId, status = PaymentStatus.SUCCESS)
+
+            mockMvc.perform(
+                get("/payments/{paymentId}", payment.id)
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+            )
+                .andExpect(status().isForbidden)
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+        }
+
+        @Test
+        @DisplayName("AC-3: 존재하지 않는 paymentId 조회 시 404 RESOURCE_NOT_FOUND")
+        fun ac3_notFound() {
+            mockMvc.perform(
+                get("/payments/{paymentId}", UUID.randomUUID())
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+            )
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
+        }
+
+        @Test
+        @DisplayName("AC-4: FAILED 결제 + portoneResponse=null → cardName/cardNumber=null + status=FAILED")
+        fun ac4_failedNullCardMeta() {
+            val payment = seed(status = PaymentStatus.FAILED, portoneResponse = null, paidAt = null)
+
+            mockMvc.perform(
+                get("/payments/{paymentId}", payment.id)
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.status").value("FAILED"))
+                .andExpect(jsonPath("$.cardName").doesNotExist())
+                .andExpect(jsonPath("$.cardNumber").doesNotExist())
+        }
+
+        @Test
+        @DisplayName("AC-10: X-User-Id 헤더 누락 시 401 (Security filter 가 우선 401 차단 — 운영 mechanism 동일)")
+        fun ac10_unauthorized() {
+            val payment = seed(status = PaymentStatus.SUCCESS)
+
+            mockMvc.perform(
+                get("/payments/{paymentId}", payment.id)
+                    .header("X-User-Role", "USER")
+            ).andExpect(status().isUnauthorized)
+        }
+
+        @Test
+        @DisplayName("AC-11a: method={} 시 cardName/cardNumber=null + 200")
+        fun ac11a_emptyMethod() {
+            val responseJson = portoneResponseJson(method = emptyMap())
+            val payment = seed(status = PaymentStatus.SUCCESS, portoneResponse = responseJson)
+
+            mockMvc.perform(
+                get("/payments/{paymentId}", payment.id)
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.cardName").doesNotExist())
+                .andExpect(jsonPath("$.cardNumber").doesNotExist())
+        }
+
+        @Test
+        @DisplayName("AC-11b: method.card=null 시 cardName/cardNumber=null + 200")
+        fun ac11b_nullCard() {
+            val responseJson = portoneResponseJson(method = mapOf("card" to null))
+            val payment = seed(status = PaymentStatus.SUCCESS, portoneResponse = responseJson)
+
+            mockMvc.perform(
+                get("/payments/{paymentId}", payment.id)
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.cardName").doesNotExist())
+                .andExpect(jsonPath("$.cardNumber").doesNotExist())
+        }
+
+        @Test
+        @DisplayName("AC-11c: method.card={} 시 cardName/cardNumber=null + 200")
+        fun ac11c_emptyCard() {
+            val responseJson = portoneResponseJson(method = mapOf("card" to emptyMap<String, Any?>()))
+            val payment = seed(status = PaymentStatus.SUCCESS, portoneResponse = responseJson)
+
+            mockMvc.perform(
+                get("/payments/{paymentId}", payment.id)
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.cardName").doesNotExist())
+                .andExpect(jsonPath("$.cardNumber").doesNotExist())
+        }
+    }
+
+    // ============================================================
+    // GET /payments — 내 결제 내역 페이징
+    // ============================================================
+
+    @Nested
+    @DisplayName("GET /payments — 내 결제 내역 페이징")
+    inner class List {
+
+        @Test
+        @DisplayName("AC-5: 5건 시드, page=0&size=20 → totalElements=5 + createdAt DESC 정렬")
+        fun ac5_paging() {
+            // createdAt 명시 주입 — flaky 회피, 정렬 검증 가능 (Critic N2)
+            val base = LocalDateTime.now(ZoneOffset.UTC).minusHours(5)
+            (1..5).forEach { idx ->
+                seed(createdAt = base.plusMinutes(idx.toLong()))
+            }
+
+            mockMvc.perform(
+                get("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .param("page", "0")
+                    .param("size", "20")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(20))
+                .andExpect(jsonPath("$.totalElements").value(5))
+                .andExpect(jsonPath("$.list.length()").value(5))
+                .andExpect(jsonPath("$.list[0].paidAt").exists())
+        }
+
+        @Test
+        @DisplayName("AC-6: 격리 — 다른 유저 결제 3건만 있으면 본인 list=[], totalElements=0")
+        fun ac6_isolation() {
+            repeat(3) { seed(ownerId = otherUserId) }
+
+            mockMvc.perform(
+                get("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.totalElements").value(0))
+                .andExpect(jsonPath("$.list.length()").value(0))
+        }
+
+        @Test
+        @DisplayName("AC-7a: ?size=101 → 400 (Max 100 위반)")
+        fun ac7a_sizeTooLarge() {
+            mockMvc.perform(
+                get("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .param("size", "101")
+            ).andExpect(status().isBadRequest)
+        }
+
+        @Test
+        @DisplayName("AC-7b: ?page=-1 → 400 (Min 0 위반)")
+        fun ac7b_negativePage() {
+            mockMvc.perform(
+                get("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .param("page", "-1")
+            ).andExpect(status().isBadRequest)
+        }
+
+        @Test
+        @DisplayName("AC-7c: ?size=0 → 400 (Min 1 위반)")
+        fun ac7c_sizeZero() {
+            mockMvc.perform(
+                get("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .param("size", "0")
+            ).andExpect(status().isBadRequest)
+        }
+
+        @Test
+        @DisplayName("AC-9: 모든 status (PENDING/SUCCESS/FAILED/REFUNDED) 가 list 에 포함된다")
+        fun ac9_allStatuses() {
+            seed(status = PaymentStatus.PENDING, paidAt = null)
+            seed(status = PaymentStatus.SUCCESS)
+            seed(status = PaymentStatus.FAILED, paidAt = null)
+            // REFUNDED 는 markSuccess 단계의 paidAt 유지 (Decision 8 정정)
+            seed(status = PaymentStatus.REFUNDED, paidAt = LocalDateTime.now(ZoneOffset.UTC).minusHours(1))
+
+            mockMvc.perform(
+                get("/payments")
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", "USER")
+                    .param("size", "20")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.totalElements").value(4))
+                .andExpect(jsonPath("$.list[?(@.status == 'PENDING')]").isNotEmpty)
+                .andExpect(jsonPath("$.list[?(@.status == 'SUCCESS')]").isNotEmpty)
+                .andExpect(jsonPath("$.list[?(@.status == 'FAILED')]").isNotEmpty)
+                .andExpect(jsonPath("$.list[?(@.status == 'REFUNDED')]").isNotEmpty)
+        }
+
+        @Test
+        @DisplayName("AC-10: GET /payments 도 X-User-Id 헤더 누락 시 401")
+        fun ac10_list_unauthorized() {
+            mockMvc.perform(
+                get("/payments")
+                    .header("X-User-Role", "USER")
+            ).andExpect(status().isUnauthorized)
+        }
+    }
+}

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentMaskingMapperTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentMaskingMapperTest.kt
@@ -1,0 +1,159 @@
+package com.ticketqueue.payment.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.external.portone.PortoneCustomer
+import com.ticketqueue.common.external.portone.PortonePaymentAmount
+import com.ticketqueue.common.external.portone.PortonePaymentResponse
+import com.ticketqueue.common.external.portone.PortoneSelectedChannel
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+
+@DisplayName("PaymentMaskingMapper 단위 테스트")
+class PaymentMaskingMapperTest {
+
+    private val objectMapper: ObjectMapper = ObjectMapper().findAndRegisterModules()
+    private val mapper = PaymentMaskingMapper(objectMapper)
+
+    private fun buildJson(method: Map<String, Any?>?): String {
+        val response = PortonePaymentResponse(
+            id = "payment-id",
+            transactionId = "tx-id",
+            merchantId = "merchant-id",
+            storeId = "store-id",
+            status = "PAID",
+            amount = PortonePaymentAmount(
+                total = 1000L,
+                taxFree = 0L,
+                discount = 0L,
+                paid = 1000L,
+                cancelled = 0L,
+                cancelledTaxFree = 0L,
+            ),
+            currency = "KRW",
+            channel = PortoneSelectedChannel(
+                type = "TEST",
+                pgProvider = "test",
+                pgMerchantId = "test-mid",
+            ),
+            version = "v2",
+            requestedAt = OffsetDateTime.parse("2026-05-01T10:00:00Z"),
+            updatedAt = OffsetDateTime.parse("2026-05-01T10:01:00Z"),
+            statusChangedAt = OffsetDateTime.parse("2026-05-01T10:01:00Z"),
+            orderName = "order",
+            customer = PortoneCustomer(),
+            method = method,
+            paidAt = OffsetDateTime.parse("2026-05-01T10:01:00Z"),
+        )
+        return objectMapper.writeValueAsString(response)
+    }
+
+    @Nested
+    @DisplayName("정상 케이스")
+    inner class HappyPath {
+
+        @Test
+        fun `method_card_publisher 와 method_card_number 가 모두 있으면 두 필드를 모두 추출한다`() {
+            val json = buildJson(mapOf("card" to mapOf("publisher" to "SHINHAN", "number" to "1234-****-****-5678")))
+
+            val result = mapper.extract(json)
+
+            result.name shouldBe "SHINHAN"
+            result.number shouldBe "1234-****-****-5678"
+        }
+
+        @Test
+        fun `method_card_publisher 만 누락되면 number 만 추출한다`() {
+            val json = buildJson(mapOf("card" to mapOf("number" to "9999-****-****-1234")))
+
+            val result = mapper.extract(json)
+
+            result.name shouldBe null
+            result.number shouldBe "9999-****-****-1234"
+        }
+    }
+
+    @Nested
+    @DisplayName("null-safe 케이스 (silent null)")
+    inner class NullSafe {
+
+        @Test
+        fun `portoneResponseJson 이 null 이면 빈 CardMeta 를 반환한다`() {
+            val result = mapper.extract(null)
+
+            result.name shouldBe null
+            result.number shouldBe null
+        }
+
+        @Test
+        fun `portoneResponseJson 이 빈 문자열이면 빈 CardMeta 를 반환한다`() {
+            val result = mapper.extract("")
+
+            result.name shouldBe null
+            result.number shouldBe null
+        }
+
+        @Test
+        fun `method 가 null 이면 빈 CardMeta 를 반환한다`() {
+            val json = buildJson(method = null)
+
+            val result = mapper.extract(json)
+
+            result.name shouldBe null
+            result.number shouldBe null
+        }
+
+        @Test
+        fun `method 에 card 키가 없으면 빈 CardMeta 를 반환한다`() {
+            val json = buildJson(method = mapOf("type" to "CARD"))
+
+            val result = mapper.extract(json)
+
+            result.name shouldBe null
+            result.number shouldBe null
+        }
+
+        @Test
+        fun `method_card 가 null 이면 빈 CardMeta 를 반환한다`() {
+            val json = buildJson(method = mapOf("card" to null))
+
+            val result = mapper.extract(json)
+
+            result.name shouldBe null
+            result.number shouldBe null
+        }
+
+        @Test
+        fun `method_card 가 빈 객체이면 빈 CardMeta 를 반환한다`() {
+            val json = buildJson(method = mapOf("card" to emptyMap<String, Any?>()))
+
+            val result = mapper.extract(json)
+
+            result.name shouldBe null
+            result.number shouldBe null
+        }
+    }
+
+    @Nested
+    @DisplayName("JSON 파싱 실패")
+    inner class JsonError {
+
+        @Test
+        fun `깨진 JSON 은 WARN 로그 후 빈 CardMeta 를 반환한다`() {
+            val result = mapper.extract("{not-valid-json")
+
+            result.name shouldBe null
+            result.number shouldBe null
+        }
+
+        @Test
+        fun `PortonePaymentResponse 필수 필드 누락 JSON 은 WARN 로그 후 빈 CardMeta 를 반환한다`() {
+            val result = mapper.extract("""{"method":{"card":{"publisher":"X","number":"Y"}}}""")
+
+            result.name shouldBe null
+            result.number shouldBe null
+        }
+    }
+}

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
@@ -56,6 +56,7 @@ class PaymentServiceTest {
     private lateinit var outboxEventRecorder: OutboxEventRecorder
     private lateinit var transactionTemplate: TransactionTemplate
     private val objectMapper: ObjectMapper = ObjectMapper().findAndRegisterModules()
+    private lateinit var paymentMaskingMapper: PaymentMaskingMapper
     private lateinit var paymentService: PaymentService
 
     private val userId = UUID.randomUUID()
@@ -76,6 +77,7 @@ class PaymentServiceTest {
         portoneProperties = mockk()
         outboxEventRecorder = mockk()
         transactionTemplate = mockk()
+        paymentMaskingMapper = mockk(relaxed = true)
 
         every { portoneProperties.storeId } returns storeId
         every { portoneProperties.channelKey } returns channelKey
@@ -108,6 +110,7 @@ class PaymentServiceTest {
             outboxEventRecorder,
             transactionTemplate,
             objectMapper,
+            paymentMaskingMapper,
         )
     }
 

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
@@ -18,6 +18,7 @@ import com.ticketqueue.payment.client.ReservationServiceClient
 import com.ticketqueue.payment.dto.PaymentDto.ConfirmRequest
 import com.ticketqueue.payment.dto.PaymentDto.CreateRequest
 import com.ticketqueue.payment.entity.Payment
+import com.ticketqueue.payment.entity.PaymentMethod
 import com.ticketqueue.payment.entity.PaymentStatus
 import com.ticketqueue.payment.exception.PaymentException
 import com.ticketqueue.payment.repository.PaymentRepository
@@ -34,6 +35,10 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.TransactionCallback
 import org.springframework.transaction.support.TransactionTemplate
@@ -712,6 +717,128 @@ class PaymentServiceTest {
             verify(exactly = 0) { paymentRepository.save(any()) }
             verify(exactly = 0) { outboxEventRecorder.record(any()) }
             payment.status shouldBe PaymentStatus.PENDING
+        }
+    }
+
+    @Nested
+    @DisplayName("getPayment 결제 상세 조회")
+    inner class GetPayment {
+
+        private val paymentId = UUID.randomUUID()
+
+        private fun payment(
+            ownerId: UUID = userId,
+            status: PaymentStatus = PaymentStatus.SUCCESS,
+            portoneResponse: String? = """{"method":{"card":{"publisher":"SHINHAN","number":"1234-****-****-5678"}}}""",
+            paidAt: LocalDateTime? = LocalDateTime.now(ZoneOffset.UTC),
+        ) = Payment(
+            id = paymentId,
+            reservationId = reservationId,
+            userId = ownerId,
+            paymentKey = UUID.randomUUID().toString(),
+            amount = amount,
+            paymentMethod = PaymentMethod.CARD,
+            status = status,
+            portoneResponse = portoneResponse,
+            paidAt = paidAt,
+        )
+
+        @Test
+        fun `정상 케이스 - SUCCESS 결제 + 카드 메타가 응답에 매핑된다`() {
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment())
+            every { paymentMaskingMapper.extract(any()) } returns PaymentMaskingMapper.CardMeta("SHINHAN", "1234-****-****-5678")
+
+            val result = paymentService.getPayment(userId, paymentId)
+
+            result.paymentId shouldBe paymentId
+            result.status shouldBe PaymentStatus.SUCCESS
+            result.method shouldBe PaymentMethod.CARD
+            result.cardName shouldBe "SHINHAN"
+            result.cardNumber shouldBe "1234-****-****-5678"
+        }
+
+        @Test
+        fun `RESOURCE_NOT_FOUND - paymentId 가 존재하지 않으면 예외를 던진다`() {
+            every { paymentRepository.findById(paymentId) } returns Optional.empty()
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.getPayment(userId, paymentId)
+            }
+            ex.errorCode shouldBe ErrorCode.RESOURCE_NOT_FOUND
+        }
+
+        @Test
+        fun `FORBIDDEN - 다른 유저 소유 결제 조회 시 예외를 던진다`() {
+            val otherUserId = UUID.randomUUID()
+            every { paymentRepository.findById(paymentId) } returns Optional.of(payment(ownerId = otherUserId))
+
+            val ex = assertThrows<PaymentException> {
+                paymentService.getPayment(userId, paymentId)
+            }
+            ex.errorCode shouldBe ErrorCode.FORBIDDEN
+        }
+
+        @Test
+        fun `portoneResponse 가 null 이면 cardName, cardNumber 모두 null 로 응답한다`() {
+            every { paymentRepository.findById(paymentId) } returns Optional.of(
+                payment(status = PaymentStatus.FAILED, portoneResponse = null, paidAt = null)
+            )
+            every { paymentMaskingMapper.extract(null) } returns PaymentMaskingMapper.CardMeta(null, null)
+
+            val result = paymentService.getPayment(userId, paymentId)
+
+            result.cardName shouldBe null
+            result.cardNumber shouldBe null
+            result.status shouldBe PaymentStatus.FAILED
+        }
+    }
+
+    @Nested
+    @DisplayName("listPayments 페이징 조회")
+    inner class ListPayments {
+
+        private fun samplePayment(idx: Int) = Payment(
+            id = UUID.randomUUID(),
+            reservationId = UUID.randomUUID(),
+            userId = userId,
+            paymentKey = "key-$idx",
+            amount = amount,
+            paymentMethod = PaymentMethod.CARD,
+            status = PaymentStatus.SUCCESS,
+            paidAt = LocalDateTime.now(ZoneOffset.UTC).minusMinutes(idx.toLong()),
+        )
+
+        @Test
+        fun `정상 페이징 - 5건 시드, page=0 size=20 → totalElements=5 + Sort createdAt DESC`() {
+            val payments = (1..5).map { samplePayment(it) }
+            val pageableSlot = slot<Pageable>()
+            every {
+                paymentRepository.findByUserId(userId, capture(pageableSlot))
+            } returns PageImpl(payments, PageRequest.of(0, 20), 5L)
+
+            val result = paymentService.listPayments(userId, page = 0, size = 20)
+
+            result.list.size shouldBe 5
+            result.page shouldBe 0
+            result.size shouldBe 20
+            result.totalElements shouldBe 5L
+
+            val captured = pageableSlot.captured
+            captured.pageNumber shouldBe 0
+            captured.pageSize shouldBe 20
+            captured.sort.getOrderFor("createdAt")?.direction shouldBe Sort.Direction.DESC
+        }
+
+        @Test
+        fun `빈 리스트 - 결제 0건이면 list=empty, totalElements=0`() {
+            every {
+                paymentRepository.findByUserId(userId, any())
+            } returns PageImpl(emptyList<Payment>(), PageRequest.of(0, 20), 0L)
+
+            val result = paymentService.listPayments(userId, page = 0, size = 20)
+
+            result.list shouldBe emptyList()
+            result.totalElements shouldBe 0L
         }
     }
 }

--- a/docs/specification/00_overview.md
+++ b/docs/specification/00_overview.md
@@ -50,6 +50,31 @@ X-Queue-Token: {Queue_Token}
 - **Description:** API Gateway에서 모든 요청에 대해 고유한 UUID를 발급하며, 응답 헤더 및 에러 응답의 `traceId` 필드와 동일한 값을 가짐
 - **Usage:** 고객 문의 대응 또는 시스템 장애 추적 시 활용
 
+### 2.6 페이징 응답 형식 (Pagination)
+목록 조회 API 는 아래의 페이징 컨벤션을 따른다. 본 컨벤션은 `GET /payments` (#64) 가 reference 구현이며,
+`GET /reservations` (#52) 등 후속 목록 API 도 동일 패턴을 따른다.
+
+**Query Parameters**
+- `page` (Int, default `0`, `>= 0`) — 0 부터 시작하는 페이지 번호
+- `size` (Int, default `20`, `>= 1`, `<= 100`) — 페이지당 항목 수 상한 100
+
+**Response Schema**
+```json
+{
+  "list": [/* page 내 항목 */],
+  "page": 0,
+  "size": 20,
+  "totalElements": 5
+}
+```
+
+**정렬**
+- 기본 정렬은 도메인의 자연스러운 시간순 (예: `created_at DESC`). 도메인별 override 시 응답 명세에 명시한다.
+- 정렬 옵션(`sort=`) 노출은 현재 컨벤션에 포함되지 않으며, 필요 시 별도 도메인 API 에서 추가한다.
+
+**검증**
+- `page < 0` 또는 `size` 가 `[1, 100]` 범위 외 → `400 INVALID_INPUT`.
+
 ## 3. API 요약 (Summary)
 
 ### 3.1 User Service


### PR DESCRIPTION
## Summary

- `GET /payments/{paymentId}` — 결제 상세 조회 (REQ-PAY-014): 소유권 검증, PortOne 응답에서 카드사/카드번호 마스킹 추출
- `GET /payments` — 내 결제 내역 페이징 조회 (REQ-PAY-015): 0-based 페이징, createdAt DESC 고정 정렬, size 1–100 강제
- `PaymentMaskingMapper` 신규: hybrid 정책 (typed envelope + generic null-safe nested cast) 으로 PortOne V2 카드 메타 추출
- `@Validated` + `@Min`/`@Max` 컨트롤러 가드 도입 — 입력 검증 패턴 첫 적용 (payment-service)
- `docs/specification/00_overview.md` §2.6 페이징 컨벤션 추가

## Test plan

- [ ] `PaymentMaskingMapperTest` — 9 케이스 (HappyPath ×2, NullSafe ×5, JsonError ×2)
- [ ] `PaymentServiceTest` — GetPayment ×4, ListPayments ×2 (Pageable Sort 회귀 가드 포함)
- [ ] `PaymentQueryControllerIntegrationTest` — AC-1~11 전체 (소유권, 404, 400 페이징 경계, 상태별 paidAt null, createdAt DESC 정렬, 사용자 격리, 401)
- [ ] `./gradlew :payment-service:test` 전체 회귀 — 기존 createPayment/confirmPayment 통합 테스트 포함 (AC-8)

Closes #64