### PR TITLE
feat: [Reservation] Kafka Consumer - 결제 이벤트 처리 (#53)

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -85,7 +85,7 @@ Outbox 위에서 동작하거나 완전히 독립적인 핵심 백엔드 API. **
 
 | # | Done | Issue | Title | Deps | Claim | Branch | PR |
 |---|------|-------|-------|------|-------|--------|----|
-| 9 | [ ] | [#53](https://github.com/paircoders/ticket-queue/issues/53) | [Reservation] Kafka Consumer - 결제 이벤트 처리 | #55, #63, #59 | session-7f37ba3c | `feature/53-reservation-payment-consumer` |  |
+| 9 | [ ] | [#53](https://github.com/paircoders/ticket-queue/issues/53) | [Reservation] Kafka Consumer - 결제 이벤트 처리 | #55, #63, #59 | session-7f37ba3c | `feature/53-reservation-payment-consumer` | [#239](https://github.com/paircoders/ticket-queue/pull/239) |
 | 10 | [ ] | [#62](https://github.com/paircoders/ticket-queue/issues/62) | [Payment] SAGA 패턴 - 보상 트랜잭션 구현 | #59, #53 |  | `feature/62-payment-saga-compensation` |  |
 
 ---

--- a/TASK.md
+++ b/TASK.md
@@ -85,7 +85,7 @@ Outbox 위에서 동작하거나 완전히 독립적인 핵심 백엔드 API. **
 
 | # | Done | Issue | Title | Deps | Claim | Branch | PR |
 |---|------|-------|-------|------|-------|--------|----|
-| 9 | [ ] | [#53](https://github.com/paircoders/ticket-queue/issues/53) | [Reservation] Kafka Consumer - 결제 이벤트 처리 | #55, #63, #59 |  | `feature/53-reservation-payment-consumer` |  |
+| 9 | [ ] | [#53](https://github.com/paircoders/ticket-queue/issues/53) | [Reservation] Kafka Consumer - 결제 이벤트 처리 | #55, #63, #59 | session-7f37ba3c | `feature/53-reservation-payment-consumer` |  |
 | 10 | [ ] | [#62](https://github.com/paircoders/ticket-queue/issues/62) | [Payment] SAGA 패턴 - 보상 트랜잭션 구현 | #59, #53 |  | `feature/62-payment-saga-compensation` |  |
 
 ---

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/config/KafkaConfig.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/config/KafkaConfig.kt
@@ -1,0 +1,8 @@
+package com.ticketqueue.reservation.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafka
+
+@Configuration
+@EnableKafka
+class KafkaConfig

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/consumer/PaymentEventConsumer.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/consumer/PaymentEventConsumer.kt
@@ -1,0 +1,94 @@
+package com.ticketqueue.reservation.consumer
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ticketqueue.common.event.PaymentFailedEvent
+import com.ticketqueue.common.event.PaymentSuccessEvent
+import com.ticketqueue.common.kafka.IdempotentConsumerTemplate
+import com.ticketqueue.reservation.service.ReservationService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+
+/**
+ * payment.events 토픽 Consumer (REQ-RSV-004)
+ *
+ * Reservation Service 측 SAGA 패턴 처리:
+ * - PaymentSuccess → 예매 상태 CONFIRMED + 티켓 번호 발급 ([ReservationService.confirmFromPaymentSuccess])
+ * - PaymentFailed  → 예매 상태 CANCELLED + ReservationCancelled outbox 발행
+ *                    ([ReservationService.cancelFromPaymentFailure])
+ *
+ * Consumer Group: reservation-payment-consumer (application.yml 에 정의)
+ *
+ * ## 동일 토픽의 다중 이벤트 타입 핸들링
+ * payment.events 에는 PaymentSuccess / PaymentFailed 두 종류가 흐른다.
+ * application.yml 기본 deserializer 는 JsonDeserializer 이지만, listener 단위로
+ * StringDeserializer override 후 raw JSON 에서 `eventType` 을 먼저 파싱해 분기한다.
+ * 이렇게 하면 Producer / Consumer 가 동일한 Wire 포맷(전체 JSON)을 공유하면서도
+ * Consumer 가 타입별로 안전하게 typed 변환을 할 수 있다.
+ *
+ * ## DLQ 처리 전략 (REQ-RSV-020)
+ * @RetryableTopic 대신 KafkaErrorHandlerConfig 전역 DefaultErrorHandler 를 사용한다.
+ * - 지수 백오프: 1초 → 2초 → 4초 (최대 10초), 최대 3회 재시도
+ * - Non-retryable 예외(DataIntegrityViolationException, JsonProcessingException 등) → 즉시 dlq.payment 이동
+ * - Retryable 예외(TimeoutException, KafkaException 등) → 3회 재시도 후 dlq.payment 이동
+ */
+@Component
+class PaymentEventConsumer(
+    private val idempotentConsumerTemplate: IdempotentConsumerTemplate,
+    private val reservationService: ReservationService,
+    private val objectMapper: ObjectMapper,
+) {
+
+    private val log = KotlinLogging.logger {}
+
+    @KafkaListener(
+        topics = ["payment.events"],
+        groupId = "reservation-payment-consumer",
+        properties = ["value.deserializer=org.apache.kafka.common.serialization.StringDeserializer"]
+    )
+    fun consume(record: ConsumerRecord<String, String>, ack: Acknowledgment) {
+        val rawJson = record.value()
+        val eventType = try {
+            objectMapper.readTree(rawJson).get("eventType")?.asText()
+        } catch (e: JsonProcessingException) {
+            log.error(e) { "Malformed JSON in payment.events, sending to DLQ: $rawJson" }
+            throw e
+        }
+
+        when (eventType) {
+            "PaymentSuccess" -> {
+                val event = try {
+                    objectMapper.readValue(rawJson, PaymentSuccessEvent::class.java)
+                } catch (e: JsonProcessingException) {
+                    log.error(e) { "Malformed PaymentSuccess JSON, sending to DLQ: $rawJson" }
+                    throw e
+                }
+                idempotentConsumerTemplate.process(event, CONSUMER_SERVICE, ack) { e ->
+                    reservationService.confirmFromPaymentSuccess(e)
+                }
+            }
+            "PaymentFailed" -> {
+                val event = try {
+                    objectMapper.readValue(rawJson, PaymentFailedEvent::class.java)
+                } catch (e: JsonProcessingException) {
+                    log.error(e) { "Malformed PaymentFailed JSON, sending to DLQ: $rawJson" }
+                    throw e
+                }
+                idempotentConsumerTemplate.process(event, CONSUMER_SERVICE, ack) { e ->
+                    reservationService.cancelFromPaymentFailure(e)
+                }
+            }
+            else -> {
+                log.warn { "Unknown payment event type=$eventType in reservation consumer, skipping" }
+                ack.acknowledge()
+            }
+        }
+    }
+
+    companion object {
+        private const val CONSUMER_SERVICE = "reservation-service"
+    }
+}

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
@@ -3,6 +3,8 @@ package com.ticketqueue.reservation.service
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.event.EventMetadata
 import java.math.BigDecimal
+import com.ticketqueue.common.event.PaymentFailedEvent
+import com.ticketqueue.common.event.PaymentSuccessEvent
 import com.ticketqueue.common.event.ReservationCancelledEvent
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.common.outbox.OutboxEventRecorder
@@ -32,6 +34,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
@@ -73,6 +76,7 @@ class ReservationService(
         private const val HOLD_MINUTES = 5L
         private const val HOLD_TTL_SECONDS = 300L
         private const val HOLD_SEATS_SET_TTL_SECONDS = 600L
+        private val TICKET_DATE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
     }
 
     /**
@@ -338,6 +342,100 @@ class ReservationService(
 
         log.info { "Reservation cancelled: userId=$userId, reservationId=$reservationId, status=${reservation.status}" }
         return CancelResponse(id = reservationId, status = reservation.status, refundAmount = refundAmount)
+    }
+
+    /**
+     * 결제 성공 이벤트 수신 시 예매 확정 (REQ-RSV-004, SAGA happy path)
+     *
+     * `PaymentEventConsumer` 가 `IdempotentConsumerTemplate` 으로 멱등성을 보장한 뒤 호출한다.
+     * processed_events 가 1차 가드를 책임지므로 이 메서드는 비즈니스 가드(status == PENDING)만 확인한다.
+     *
+     * - 이미 CONFIRMED 인 경우 no-op (멱등성 보강)
+     * - PENDING 외 상태(CANCELLED) 는 `RESERVATION_NOT_CHANGEABLE` 로 거부 → 즉시 DLQ 이동
+     */
+    fun confirmFromPaymentSuccess(event: PaymentSuccessEvent) {
+        val reservationId = event.reservationId
+        transactionTemplate.executeWithoutResult {
+            val reservation = reservationRepository.findById(reservationId).orElseThrow {
+                ReservationException(ErrorCode.RESERVATION_NOT_FOUND, "PaymentSuccess 처리 대상 예매 없음: $reservationId")
+            }
+
+            if (reservation.status == ReservationStatus.CONFIRMED) {
+                log.info { "Reservation already confirmed (idempotent skip): reservationId=$reservationId" }
+                return@executeWithoutResult
+            }
+            if (reservation.status != ReservationStatus.PENDING) {
+                throw ReservationException(
+                    ErrorCode.RESERVATION_NOT_CHANGEABLE,
+                    "PaymentSuccess 처리 불가 상태: reservationId=$reservationId, status=${reservation.status}"
+                )
+            }
+
+            val ticketNumber = generateTicketNumber()
+            reservation.confirm(paymentId = event.aggregateId, ticketNumber = ticketNumber)
+            log.info {
+                "Reservation confirmed via PaymentSuccess: reservationId=$reservationId, " +
+                    "paymentId=${event.aggregateId}, ticketNumber=$ticketNumber"
+            }
+        }
+    }
+
+    /**
+     * 결제 실패 이벤트 수신 시 예매 취소 + ReservationCancelled outbox 발행 (REQ-RSV-004, SAGA 보상 체인)
+     *
+     * `PaymentFailed` 의 `eventId` 를 `ReservationCancelled.metadata.causationId` 로 전파하여
+     * Payment → Reservation → Event 보상 체인을 이벤트 그래프 상에서 추적 가능하게 한다.
+     * 좌석 hold_seats SET 정리는 `cancelReservation` 과 동일하게 afterCommit 콜백으로 위임한다.
+     */
+    fun cancelFromPaymentFailure(event: PaymentFailedEvent) {
+        val reservationId = event.reservationId
+        transactionTemplate.executeWithoutResult {
+            val reservation = reservationRepository.findById(reservationId).orElseThrow {
+                ReservationException(ErrorCode.RESERVATION_NOT_FOUND, "PaymentFailed 처리 대상 예매 없음: $reservationId")
+            }
+
+            if (reservation.status == ReservationStatus.CANCELLED) {
+                log.info { "Reservation already cancelled (idempotent skip): reservationId=$reservationId" }
+                return@executeWithoutResult
+            }
+            if (reservation.status != ReservationStatus.PENDING) {
+                throw ReservationException(
+                    ErrorCode.RESERVATION_NOT_CHANGEABLE,
+                    "PaymentFailed 처리 불가 상태: reservationId=$reservationId, status=${reservation.status}"
+                )
+            }
+
+            val seatIds = reservationSeatRepository.findByReservationId(reservationId).map { it.seatId }
+            reservation.cancel()
+            outboxEventRecorder.record(
+                ReservationCancelledEvent(
+                    aggregateId = reservationId,
+                    scheduleId = reservation.scheduleId,
+                    seatIds = seatIds,
+                    userId = reservation.userId,
+                    reason = "PAYMENT_FAILED",
+                    metadata = EventMetadata(
+                        correlationId = event.metadata.correlationId,
+                        causationId = event.eventId,
+                        userId = reservation.userId
+                    )
+                )
+            )
+            registerAfterCommit {
+                scheduleHoldSeatsReconciliation(reservation.scheduleId, seatIds, emptyList())
+            }
+
+            log.info {
+                "Reservation cancelled via PaymentFailed: reservationId=$reservationId, " +
+                    "paymentId=${event.aggregateId}, reason=${event.reason}"
+            }
+        }
+    }
+
+    private fun generateTicketNumber(): String {
+        val datePart = LocalDateTime.now(ZoneOffset.UTC).format(TICKET_DATE_FORMAT)
+        val randomPart = UUID.randomUUID().toString().substring(0, 8).uppercase()
+        return "TKT-$datePart-$randomPart"
     }
 
     private fun validateForChange(reservation: Reservation) {

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/consumer/PaymentEventConsumerTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/consumer/PaymentEventConsumerTest.kt
@@ -1,0 +1,191 @@
+package com.ticketqueue.reservation.consumer
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.event.PaymentFailedEvent
+import com.ticketqueue.common.event.PaymentSuccessEvent
+import com.ticketqueue.common.kafka.IdempotentConsumerTemplate
+import com.ticketqueue.reservation.service.ReservationService
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.kafka.support.Acknowledgment
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Reservation Service 의 payment.events 토픽 Consumer 단위 테스트.
+ *
+ * 검증 범위:
+ * - eventType 분기 라우팅 (PaymentSuccess / PaymentFailed / Unknown)
+ * - IdempotentConsumerTemplate 위임 시 consumerService 식별자 ("reservation-service")
+ * - ReservationService 비즈니스 메서드 호출 여부
+ * - malformed JSON 시 DLQ 이동을 위한 JsonProcessingException 전파
+ *
+ * 멱등성/트랜잭션 흐름은 ReservationServiceTest 와 IdempotentConsumerTemplateTest 가 별도 커버한다.
+ */
+@DisplayName("PaymentEventConsumer (reservation-service)")
+class PaymentEventConsumerTest {
+
+    private lateinit var idempotentConsumerTemplate: IdempotentConsumerTemplate
+    private lateinit var reservationService: ReservationService
+    private lateinit var consumer: PaymentEventConsumer
+
+    private val objectMapper = jacksonObjectMapper().apply {
+        registerModule(JavaTimeModule())
+    }
+
+    private val ack = mockk<Acknowledgment>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        idempotentConsumerTemplate = mockk()
+        reservationService = mockk(relaxed = true)
+        consumer = PaymentEventConsumer(idempotentConsumerTemplate, reservationService, objectMapper)
+    }
+
+    private fun record(json: String) =
+        ConsumerRecord<String, String>("payment.events", 0, 0L, null, json)
+
+    @Nested
+    @DisplayName("PaymentSuccess")
+    inner class PaymentSuccess {
+
+        @Test
+        @DisplayName("PaymentSuccessEvent 수신 시 ReservationService.confirmFromPaymentSuccess 를 호출한다")
+        fun routesToConfirmFromPaymentSuccess() {
+            val event = PaymentSuccessEvent(
+                aggregateId = UUID.randomUUID(),
+                reservationId = UUID.randomUUID(),
+                paymentKey = "pay_key_123",
+                amount = BigDecimal("100000"),
+                paidAt = LocalDateTime.now(),
+                scheduleId = UUID.randomUUID(),
+                seatIds = listOf(UUID.randomUUID()),
+                portoneTransactionId = "portone_tx_123"
+            )
+            val json = objectMapper.writeValueAsString(event)
+
+            every {
+                idempotentConsumerTemplate.process(any<PaymentSuccessEvent>(), any(), any(), any())
+            } answers {
+                val businessLogic = arg<(PaymentSuccessEvent) -> Unit>(3)
+                businessLogic(firstArg())
+            }
+
+            consumer.consume(record(json), ack)
+
+            verify {
+                idempotentConsumerTemplate.process(
+                    any<PaymentSuccessEvent>(),
+                    eq("reservation-service"),
+                    eq(ack),
+                    any()
+                )
+            }
+            verify { reservationService.confirmFromPaymentSuccess(any()) }
+            verify(exactly = 0) { reservationService.cancelFromPaymentFailure(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("PaymentFailed")
+    inner class PaymentFailed {
+
+        @Test
+        @DisplayName("PaymentFailedEvent 수신 시 ReservationService.cancelFromPaymentFailure 를 호출한다")
+        fun routesToCancelFromPaymentFailure() {
+            val event = PaymentFailedEvent(
+                aggregateId = UUID.randomUUID(),
+                reservationId = UUID.randomUUID(),
+                reason = "INSUFFICIENT_BALANCE"
+            )
+            val json = objectMapper.writeValueAsString(event)
+
+            every {
+                idempotentConsumerTemplate.process(any<PaymentFailedEvent>(), any(), any(), any())
+            } answers {
+                val businessLogic = arg<(PaymentFailedEvent) -> Unit>(3)
+                businessLogic(firstArg())
+            }
+
+            consumer.consume(record(json), ack)
+
+            verify {
+                idempotentConsumerTemplate.process(
+                    any<PaymentFailedEvent>(),
+                    eq("reservation-service"),
+                    eq(ack),
+                    any()
+                )
+            }
+            verify { reservationService.cancelFromPaymentFailure(any()) }
+            verify(exactly = 0) { reservationService.confirmFromPaymentSuccess(any()) }
+        }
+
+        @Test
+        @DisplayName("Template 호출만 받고 비즈니스 로직 실행이 지연되어도 confirmFromPaymentSuccess 는 호출되지 않는다")
+        fun delegatesEvenWhenBusinessLogicNotInvoked() {
+            val event = PaymentFailedEvent(
+                aggregateId = UUID.randomUUID(),
+                reservationId = UUID.randomUUID(),
+                reason = "INSUFFICIENT_BALANCE"
+            )
+            val json = objectMapper.writeValueAsString(event)
+
+            every {
+                idempotentConsumerTemplate.process(any<PaymentFailedEvent>(), any(), any(), any())
+            } just runs
+
+            consumer.consume(record(json), ack)
+
+            verify { idempotentConsumerTemplate.process(any<PaymentFailedEvent>(), eq("reservation-service"), eq(ack), any()) }
+            verify(exactly = 0) { reservationService.confirmFromPaymentSuccess(any()) }
+            verify(exactly = 0) { reservationService.cancelFromPaymentFailure(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("Unknown eventType")
+    inner class UnknownEventType {
+
+        @Test
+        @DisplayName("알 수 없는 eventType 수신 시 ack 만 수행하고 ReservationService / Template 모두 호출하지 않는다")
+        fun acknowledgesAndSkips() {
+            val json = """{"eventType":"UnknownEvent","eventId":"${UUID.randomUUID()}"}"""
+
+            consumer.consume(record(json), ack)
+
+            verify { ack.acknowledge() }
+            verify(exactly = 0) { idempotentConsumerTemplate.process(any(), any(), any(), any()) }
+            verify(exactly = 0) { reservationService.confirmFromPaymentSuccess(any()) }
+            verify(exactly = 0) { reservationService.cancelFromPaymentFailure(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("Malformed JSON (Poison Pill)")
+    inner class MalformedJson {
+
+        @Test
+        @DisplayName("malformed JSON 수신 시 JsonProcessingException 을 던져 DLQ 로 이동한다 (ack 없음)")
+        fun throwsAndSkipsAck() {
+            val malformedJson = "{broken json"
+
+            assertThrows<JsonProcessingException> {
+                consumer.consume(record(malformedJson), ack)
+            }
+            verify(exactly = 0) { ack.acknowledge() }
+        }
+    }
+}

--- a/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ReservationServiceTest.kt
+++ b/backend/reservation-service/src/test/kotlin/com/ticketqueue/reservation/service/ReservationServiceTest.kt
@@ -3,6 +3,9 @@ package com.ticketqueue.reservation.service
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ticketqueue.common.event.EventMetadata
+import com.ticketqueue.common.event.PaymentFailedEvent
+import com.ticketqueue.common.event.PaymentSuccessEvent
 import com.ticketqueue.common.event.ReservationCancelledEvent
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.common.outbox.OutboxEventRecorder
@@ -517,5 +520,185 @@ class ReservationServiceTest {
         }
         every { reservationRepository.save(any()) } returns savedReservation
         every { reservationSeatRepository.saveAll(any<List<ReservationSeat>>()) } returns emptyList()
+    }
+
+    @Nested
+    @DisplayName("PaymentSuccess 수신 시 예매 확정")
+    inner class ConfirmFromPaymentSuccess {
+
+        private val reservationId = UUID.randomUUID()
+        private val paymentId = UUID.randomUUID()
+        private val seatId = UUID.randomUUID()
+
+        @Test
+        @DisplayName("PENDING 예매가 CONFIRMED 로 전이되고 ticketNumber 가 발급된다")
+        fun confirmsPendingReservation() {
+            val ticketSlot = slot<String>()
+            val reservation = mockk<Reservation>(relaxed = true) {
+                every { id } returns reservationId
+                every { status } returns ReservationStatus.PENDING
+            }
+            every { reservationRepository.findById(reservationId) } returns java.util.Optional.of(reservation)
+            stubExecuteWithoutResult()
+
+            reservationService.confirmFromPaymentSuccess(paymentSuccessEvent())
+
+            verify { reservation.confirm(paymentId, capture(ticketSlot)) }
+            assert(ticketSlot.captured.matches(Regex("""^TKT-\d{8}-[A-Z0-9]{8}$"""))) {
+                "ticketNumber must match TKT-yyyyMMdd-XXXXXXXX, got ${ticketSlot.captured}"
+            }
+        }
+
+        @Test
+        @DisplayName("이미 CONFIRMED 상태면 멱등 처리하여 no-op 한다")
+        fun isIdempotentWhenAlreadyConfirmed() {
+            val reservation = mockk<Reservation>(relaxed = true) {
+                every { id } returns reservationId
+                every { status } returns ReservationStatus.CONFIRMED
+            }
+            every { reservationRepository.findById(reservationId) } returns java.util.Optional.of(reservation)
+            stubExecuteWithoutResult()
+
+            reservationService.confirmFromPaymentSuccess(paymentSuccessEvent())
+
+            verify(exactly = 0) { reservation.confirm(any(), any()) }
+        }
+
+        @Test
+        @DisplayName("CANCELLED 상태면 RESERVATION_NOT_CHANGEABLE 예외를 던진다")
+        fun rejectsCancelledReservation() {
+            val reservation = mockk<Reservation>(relaxed = true) {
+                every { id } returns reservationId
+                every { status } returns ReservationStatus.CANCELLED
+            }
+            every { reservationRepository.findById(reservationId) } returns java.util.Optional.of(reservation)
+            stubExecuteWithoutResult()
+
+            val ex = assertThrows<ReservationException> {
+                reservationService.confirmFromPaymentSuccess(paymentSuccessEvent())
+            }
+            ex.errorCode shouldBe ErrorCode.RESERVATION_NOT_CHANGEABLE
+        }
+
+        @Test
+        @DisplayName("예매를 찾지 못하면 RESERVATION_NOT_FOUND 예외를 던진다")
+        fun throwsWhenReservationMissing() {
+            every { reservationRepository.findById(reservationId) } returns java.util.Optional.empty()
+            stubExecuteWithoutResult()
+
+            val ex = assertThrows<ReservationException> {
+                reservationService.confirmFromPaymentSuccess(paymentSuccessEvent())
+            }
+            ex.errorCode shouldBe ErrorCode.RESERVATION_NOT_FOUND
+        }
+
+        private fun paymentSuccessEvent() = PaymentSuccessEvent(
+            aggregateId = paymentId,
+            reservationId = reservationId,
+            paymentKey = "pk_test_123",
+            amount = BigDecimal("300000"),
+            paidAt = LocalDateTime.now(ZoneOffset.UTC),
+            scheduleId = scheduleId,
+            seatIds = listOf(seatId),
+            portoneTransactionId = "portone-tx-1",
+            metadata = EventMetadata(userId = userId)
+        )
+    }
+
+    @Nested
+    @DisplayName("PaymentFailed 수신 시 예매 취소 + ReservationCancelled outbox 발행")
+    inner class CancelFromPaymentFailure {
+
+        private val reservationId = UUID.randomUUID()
+        private val paymentId = UUID.randomUUID()
+        private val paymentEventId = UUID.randomUUID()
+        private val correlationId = UUID.randomUUID()
+        private val seatId = UUID.randomUUID()
+
+        @Test
+        @DisplayName("PENDING 예매를 CANCELLED 로 전이하고 ReservationCancelled outbox 를 PAYMENT_FAILED 사유로 발행한다")
+        fun cancelsPendingReservationAndPublishesEvent() {
+            val outboxSlot = slot<ReservationCancelledEvent>()
+            val reservation = mockk<Reservation>(relaxed = true) {
+                every { id } returns reservationId
+                every { userId } returns this@ReservationServiceTest.userId
+                every { scheduleId } returns this@ReservationServiceTest.scheduleId
+                every { status } returns ReservationStatus.PENDING
+            }
+            every { reservationRepository.findById(reservationId) } returns java.util.Optional.of(reservation)
+            every { reservationSeatRepository.findByReservationId(reservationId) } returns
+                listOf(mockk { every { seatId } returns this@CancelFromPaymentFailure.seatId })
+            every { outboxEventRecorder.record(capture(outboxSlot)) } returns mockk(relaxed = true)
+            every { setOps.remove(any<String>(), *anyVararg()) } returns 1L
+            stubExecuteWithoutResultWithAfterCommit()
+
+            reservationService.cancelFromPaymentFailure(paymentFailedEvent())
+
+            verify { reservation.cancel() }
+            outboxSlot.captured.reason shouldBe "PAYMENT_FAILED"
+            outboxSlot.captured.scheduleId shouldBe scheduleId
+            outboxSlot.captured.seatIds shouldBe listOf(seatId)
+            outboxSlot.captured.metadata.causationId shouldBe paymentEventId
+            outboxSlot.captured.metadata.correlationId shouldBe correlationId
+            verify { setOps.remove(any<String>(), *anyVararg()) }
+        }
+
+        @Test
+        @DisplayName("이미 CANCELLED 상태면 멱등 처리하여 outbox 발행을 하지 않는다")
+        fun isIdempotentWhenAlreadyCancelled() {
+            val reservation = mockk<Reservation>(relaxed = true) {
+                every { id } returns reservationId
+                every { status } returns ReservationStatus.CANCELLED
+            }
+            every { reservationRepository.findById(reservationId) } returns java.util.Optional.of(reservation)
+            stubExecuteWithoutResultWithAfterCommit()
+
+            reservationService.cancelFromPaymentFailure(paymentFailedEvent())
+
+            verify(exactly = 0) { outboxEventRecorder.record(any()) }
+            verify(exactly = 0) { reservation.cancel() }
+        }
+
+        @Test
+        @DisplayName("CONFIRMED 상태면 RESERVATION_NOT_CHANGEABLE 예외를 던진다")
+        fun rejectsConfirmedReservation() {
+            val reservation = mockk<Reservation>(relaxed = true) {
+                every { id } returns reservationId
+                every { status } returns ReservationStatus.CONFIRMED
+            }
+            every { reservationRepository.findById(reservationId) } returns java.util.Optional.of(reservation)
+            stubExecuteWithoutResultWithAfterCommit()
+
+            val ex = assertThrows<ReservationException> {
+                reservationService.cancelFromPaymentFailure(paymentFailedEvent())
+            }
+            ex.errorCode shouldBe ErrorCode.RESERVATION_NOT_CHANGEABLE
+        }
+
+        private fun paymentFailedEvent() = PaymentFailedEvent(
+            eventId = paymentEventId,
+            aggregateId = paymentId,
+            reservationId = reservationId,
+            reason = "INSUFFICIENT_BALANCE",
+            metadata = EventMetadata(correlationId = correlationId, causationId = null, userId = userId)
+        )
+    }
+
+    private fun stubExecuteWithoutResult() {
+        every { transactionTemplate.executeWithoutResult(any()) } answers {
+            firstArg<Consumer<TransactionStatus>>().accept(mockk(relaxed = true))
+        }
+    }
+
+    private fun stubExecuteWithoutResultWithAfterCommit() {
+        every { transactionTemplate.executeWithoutResult(any()) } answers {
+            TransactionSynchronizationManager.initSynchronization()
+            try {
+                firstArg<Consumer<TransactionStatus>>().accept(mockk(relaxed = true))
+                TransactionSynchronizationManager.getSynchronizations().forEach { it.afterCommit() }
+            } finally {
+                TransactionSynchronizationManager.clearSynchronization()
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `payment.events` 토픽을 `reservation-payment-consumer` 그룹으로 구독하는 `PaymentEventConsumer` 추가
- `ReservationService` 에 SAGA 진입점 2 메서드 추가
  - `confirmFromPaymentSuccess`: PENDING → CONFIRMED, ticketNumber 발급
  - `cancelFromPaymentFailure`: PENDING → CANCELLED, `ReservationCancelled` outbox 발행 (causationId 전파)
- `IdempotentConsumerTemplate` + `processed_events` 로 멱등성 보장, `MANUAL_IMMEDIATE` 수동 커밋
- `@EnableKafka` 활성화 (KafkaConfig)

REQ-RSV-004 / docs/architecture/05_kafka.md 4.2 ~ 4.3

## SAGA 보상 체인
```
PortOne 실패 → PaymentService.outbox(PaymentFailed)
            → reservation-payment-consumer (이 PR)
            → ReservationService.cancelFromPaymentFailure
              ├ Reservation.cancel()
              └ outbox(ReservationCancelled, causationId = PaymentFailed.eventId)
            → event-reservation-consumer (기존)
              └ 좌석 AVAILABLE 복원
```

## 핵심 설계 결정
- **Consumer 얇게 / Service 두껍게**: Consumer 는 eventType 분기 + IdempotentConsumerTemplate 위임만, 비즈니스 상태 전이는 ReservationService 책임
- **단일 토픽 다중 이벤트 타입**: listener properties 로 `StringDeserializer` override → raw JSON 에서 `eventType` 파싱 후 typed 변환 (event-service 패턴 일치)
- **2중 멱등성 가드**: `processed_events` 가 메시지 중복 차단(1차), `status == PENDING` 비즈니스 가드(2차)로 late-arriving / 다중 인스턴스 시나리오 안전 처리
- **`causationId` 전파**: `PaymentFailed.eventId` → `ReservationCancelled.metadata.causationId` 로 SAGA 체인이 이벤트 그래프에서 추적 가능
- **티켓 번호 포맷**: `TKT-yyyyMMdd-XXXXXXXX` (50자 컬럼 한도 내)

## Test plan
- [x] `ReservationServiceTest$ConfirmFromPaymentSuccess` — PENDING→CONFIRMED 전이, 멱등 처리, 잘못된 상태 거부, 미존재 예매 거부 (4 cases)
- [x] `ReservationServiceTest$CancelFromPaymentFailure` — PENDING→CANCELLED + outbox 발행, 멱등 처리, CONFIRMED 거부 (3 cases)
- [x] `PaymentEventConsumerTest` — PaymentSuccess/PaymentFailed 라우팅, Unknown eventType 스킵, malformed JSON DLQ 이동 (5 cases)
- [ ] Integration test (TestContainers): 본 PR 머지 후 #62 SAGA 통합 테스트에서 end-to-end 검증 예정

## Notes for reviewer
- 전체 reservation-service 단위 테스트는 그린. 기존 integration test 30 cases 는 로컬 docker 환경 이슈로 fail (Hikari connection InterruptedException) 이며 신규 코드와 무관
- TASK.md claim 커밋(`session-7f37ba3c`) 포함