### PR TITLE
feat: [User] 프로필 조회/수정 API 구현 (#27)

### DIFF
--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/config/SecurityConfig.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/config/SecurityConfig.kt
@@ -1,6 +1,8 @@
 package com.ticketqueue.user.config
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.ticketqueue.common.security.GatewayAuthFilter
+import com.ticketqueue.common.security.SecurityErrorHandlers
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -13,7 +15,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
-class SecurityConfig {
+class SecurityConfig(
+    private val objectMapper: ObjectMapper,
+) {
 
     @Bean
     fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
@@ -29,6 +33,11 @@ class SecurityConfig {
                     .requestMatchers("/auth/signup", "/auth/login", "/auth/refresh").permitAll()
                     .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                     .anyRequest().authenticated()
+            }
+            .exceptionHandling { exceptions ->
+                exceptions
+                    .authenticationEntryPoint(SecurityErrorHandlers.authenticationEntryPoint(objectMapper))
+                    .accessDeniedHandler(SecurityErrorHandlers.accessDeniedHandler(objectMapper))
             }
             .build()
     }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/UserController.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/UserController.kt
@@ -1,0 +1,49 @@
+package com.ticketqueue.user.controller
+
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.user.dto.UserDto
+import com.ticketqueue.user.exception.UserException
+import com.ticketqueue.user.service.UserService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.validation.Valid
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/users")
+class UserController(
+    private val userService: UserService,
+) {
+    private val logger = KotlinLogging.logger {}
+
+    @GetMapping("/me")
+    fun getMyProfile(@AuthenticationPrincipal principal: String?): UserDto.ProfileResponse {
+        val userId = parseUserId(principal)
+        logger.info { "Profile read: userId=$userId" }
+        return userService.getProfile(userId)
+    }
+
+    @PatchMapping("/me")
+    fun updateMyProfile(
+        @AuthenticationPrincipal principal: String?,
+        @Valid @RequestBody request: UserDto.UpdateProfileRequest,
+    ): UserDto.UpdateProfileResponse {
+        val userId = parseUserId(principal)
+        logger.info { "Profile update: userId=$userId" }
+        return userService.updateProfile(userId, request)
+    }
+
+    private fun parseUserId(principal: String?): UUID {
+        if (principal.isNullOrBlank()) throw UserException(ErrorCode.UNAUTHORIZED)
+        return try {
+            UUID.fromString(principal)
+        } catch (e: IllegalArgumentException) {
+            throw UserException(ErrorCode.UNAUTHORIZED, cause = e)
+        }
+    }
+}

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/dto/UserDto.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/dto/UserDto.kt
@@ -1,0 +1,68 @@
+package com.ticketqueue.user.dto
+
+import com.ticketqueue.user.entity.User
+import com.ticketqueue.user.entity.UserRole
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+import java.time.LocalDateTime
+import java.util.UUID
+
+class UserDto {
+
+    data class ProfileResponse(
+        val id: UUID,
+        val email: String,
+        val name: String,
+        val phone: String,
+        val role: UserRole,
+        val createdAt: LocalDateTime?,
+    ) {
+        companion object {
+            fun of(
+                user: User,
+                decryptedEmail: String,
+                decryptedName: String,
+                decryptedPhone: String,
+            ): ProfileResponse = ProfileResponse(
+                id = user.id!!,
+                email = decryptedEmail,
+                name = decryptedName,
+                phone = decryptedPhone,
+                role = user.role,
+                createdAt = user.createdAt,
+            )
+        }
+    }
+
+    data class UpdateProfileRequest(
+        @field:NotBlank(message = "이름은 필수입니다.")
+        @field:Size(min = 1, max = 50, message = "이름은 1~50자여야 합니다.")
+        val name: String,
+
+        @field:NotBlank(message = "전화번호는 필수입니다.")
+        @field:Pattern(
+            regexp = "^01[0-9]-?[0-9]{3,4}-?[0-9]{4}$",
+            message = "유효한 전화번호 형식이 아닙니다.",
+        )
+        val phone: String,
+    )
+
+    data class UpdateProfileResponse(
+        val id: UUID,
+        val name: String,
+        val phone: String,
+    ) {
+        companion object {
+            fun of(
+                user: User,
+                decryptedName: String,
+                decryptedPhone: String,
+            ): UpdateProfileResponse = UpdateProfileResponse(
+                id = user.id!!,
+                name = decryptedName,
+                phone = decryptedPhone,
+            )
+        }
+    }
+}

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/entity/User.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/entity/User.kt
@@ -30,13 +30,13 @@ class User(
     val passwordHash: String,
 
     @Column(nullable = false)
-    val name: String,
+    var name: String,
 
     @Column(nullable = false)
-    val phone: String,
+    var phone: String,
 
     @Column(name = "phone_hash", nullable = false)
-    val phoneHash: String,
+    var phoneHash: String,
 
     @Column(length = 512)
     val ci: String? = null,

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/UserService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/UserService.kt
@@ -1,0 +1,58 @@
+package com.ticketqueue.user.service
+
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.user.dto.UserDto
+import com.ticketqueue.user.entity.UserStatus
+import com.ticketqueue.user.exception.UserException
+import com.ticketqueue.user.repository.UserRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class UserService(
+    private val userRepository: UserRepository,
+    private val encryptionService: EncryptionService,
+) {
+    private val logger = KotlinLogging.logger {}
+
+    @Transactional(readOnly = true)
+    fun getProfile(userId: UUID): UserDto.ProfileResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow { UserException(ErrorCode.RESOURCE_NOT_FOUND) }
+
+        if (user.status == UserStatus.DELETED) {
+            throw UserException(ErrorCode.RESOURCE_NOT_FOUND)
+        }
+
+        return UserDto.ProfileResponse.of(
+            user = user,
+            decryptedEmail = encryptionService.decrypt(user.email),
+            decryptedName = encryptionService.decrypt(user.name),
+            decryptedPhone = encryptionService.decrypt(user.phone),
+        )
+    }
+
+    @Transactional
+    fun updateProfile(userId: UUID, request: UserDto.UpdateProfileRequest): UserDto.UpdateProfileResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow { UserException(ErrorCode.RESOURCE_NOT_FOUND) }
+
+        if (user.status == UserStatus.DELETED) {
+            throw UserException(ErrorCode.RESOURCE_NOT_FOUND)
+        }
+
+        user.name = encryptionService.encrypt(request.name)
+        user.phone = encryptionService.encrypt(request.phone)
+        user.phoneHash = encryptionService.hash(request.phone)
+
+        logger.info { "Profile updated: userId=$userId" }
+
+        return UserDto.UpdateProfileResponse.of(
+            user = user,
+            decryptedName = request.name,
+            decryptedPhone = request.phone,
+        )
+    }
+}

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/controller/UserControllerTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/controller/UserControllerTest.kt
@@ -1,0 +1,212 @@
+package com.ticketqueue.user.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.ninjasquad.springmockk.MockkBean
+import com.ticketqueue.common.exception.BusinessException
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.exception.GlobalExceptionHandler
+import com.ticketqueue.user.config.SecurityConfig
+import com.ticketqueue.user.dto.UserDto
+import com.ticketqueue.user.entity.UserRole
+import com.ticketqueue.user.service.UserService
+import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
+import java.util.UUID
+
+@WebMvcTest(
+    controllers = [UserController::class],
+    useDefaultFilters = false,
+    includeFilters = [
+        ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = [UserController::class, GlobalExceptionHandler::class, SecurityConfig::class]
+        )
+    ],
+    excludeAutoConfiguration = [
+        org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration::class,
+        org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration::class,
+        org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration::class,
+        io.awspring.cloud.autoconfigure.config.secretsmanager.SecretsManagerAutoConfiguration::class,
+        io.awspring.cloud.autoconfigure.config.parameterstore.ParameterStoreAutoConfiguration::class
+    ]
+)
+@ContextConfiguration(classes = [UserController::class, GlobalExceptionHandler::class, SecurityConfig::class])
+@ActiveProfiles("test")
+@TestPropertySource(properties = [
+    "spring.cloud.aws.region.static=us-east-1",
+    "spring.cloud.aws.credentials.access-key=test",
+    "spring.cloud.aws.credentials.secret-key=test"
+])
+@DisplayName("UserController 단위 테스트")
+class UserControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockkBean
+    private lateinit var userService: UserService
+
+    private val userId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        objectMapper.registerModule(JavaTimeModule())
+    }
+
+    @Nested
+    @DisplayName("GET /users/me")
+    inner class GetProfile {
+
+        @Test
+        @DisplayName("정상 요청 시 200 OK 및 프로필 반환")
+        fun shouldReturn200() {
+            val response = UserDto.ProfileResponse(
+                id = userId,
+                email = "test@example.com",
+                name = "홍길동",
+                phone = "010-1234-5678",
+                role = UserRole.USER,
+                createdAt = LocalDateTime.of(2026, 1, 1, 0, 0, 0),
+            )
+            every { userService.getProfile(userId) } returns response
+
+            mockMvc.perform(
+                get("/users/me")
+                    .header("X-User-Id", userId.toString())
+                    .header("X-User-Role", "USER")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.id").value(userId.toString()))
+                .andExpect(jsonPath("$.email").value("test@example.com"))
+                .andExpect(jsonPath("$.name").value("홍길동"))
+                .andExpect(jsonPath("$.phone").value("010-1234-5678"))
+                .andExpect(jsonPath("$.role").value("USER"))
+        }
+
+        @Test
+        @DisplayName("인증 헤더 누락 시 401 UNAUTHORIZED")
+        fun shouldReturn401WhenNoAuth() {
+            mockMvc.perform(get("/users/me"))
+                .andExpect(status().isUnauthorized)
+        }
+
+        @Test
+        @DisplayName("잘못된 Role 헤더 시 401 UNAUTHORIZED")
+        fun shouldReturn401WhenInvalidRole() {
+            mockMvc.perform(
+                get("/users/me")
+                    .header("X-User-Id", userId.toString())
+                    .header("X-User-Role", "GUEST")
+            ).andExpect(status().isUnauthorized)
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /users/me")
+    inner class UpdateProfile {
+
+        private val validRequest = UserDto.UpdateProfileRequest(
+            name = "김철수",
+            phone = "010-9876-5432",
+        )
+
+        private fun performPatch(content: Any?, includeAuth: Boolean = true) = mockMvc.perform(
+            patch("/users/me")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .let { if (includeAuth) it.header("X-User-Id", userId.toString()).header("X-User-Role", "USER") else it }
+                .let { if (content != null) it.content(objectMapper.writeValueAsString(content)) else it }
+        )
+
+        @Test
+        @DisplayName("정상 수정 시 200 OK 및 수정된 필드 반환")
+        fun shouldReturn200() {
+            val response = UserDto.UpdateProfileResponse(
+                id = userId,
+                name = validRequest.name,
+                phone = validRequest.phone,
+            )
+            every { userService.updateProfile(userId, validRequest) } returns response
+
+            performPatch(validRequest)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.id").value(userId.toString()))
+                .andExpect(jsonPath("$.name").value(validRequest.name))
+                .andExpect(jsonPath("$.phone").value(validRequest.phone))
+        }
+
+        @Test
+        @DisplayName("이름 빈 값 시 400 BAD REQUEST")
+        fun shouldReturn400WhenNameBlank() {
+            performPatch(validRequest.copy(name = ""))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("이름")))
+        }
+
+        @Test
+        @DisplayName("전화번호 형식 오류 시 400 BAD REQUEST")
+        fun shouldReturn400WhenPhoneInvalid() {
+            performPatch(validRequest.copy(phone = "abc-1234"))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("전화번호")))
+        }
+
+        @Test
+        @DisplayName("이름 너무 김 시 400 BAD REQUEST")
+        fun shouldReturn400WhenNameTooLong() {
+            performPatch(validRequest.copy(name = "가".repeat(51)))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+        }
+
+        @Test
+        @DisplayName("인증 헤더 누락 시 401 UNAUTHORIZED")
+        fun shouldReturn401WhenNoAuth() {
+            performPatch(validRequest, includeAuth = false)
+                .andExpect(status().isUnauthorized)
+        }
+
+        @Test
+        @DisplayName("요청 body 없을 시 400 BAD REQUEST")
+        fun shouldReturn400WhenBodyMissing() {
+            performPatch(null)
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+        }
+
+        @Test
+        @DisplayName("서비스에서 RESOURCE_NOT_FOUND 시 404 응답")
+        fun shouldReturn404WhenUserMissing() {
+            every { userService.updateProfile(userId, validRequest) } throws
+                BusinessException(ErrorCode.RESOURCE_NOT_FOUND)
+
+            performPatch(validRequest)
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
+        }
+    }
+}

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/UserServiceTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/UserServiceTest.kt
@@ -1,0 +1,161 @@
+package com.ticketqueue.user.service
+
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.user.dto.UserDto
+import com.ticketqueue.user.entity.User
+import com.ticketqueue.user.entity.UserRole
+import com.ticketqueue.user.entity.UserStatus
+import com.ticketqueue.user.exception.UserException
+import com.ticketqueue.user.repository.UserRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+import java.util.Optional
+import java.util.UUID
+
+@DisplayName("UserService 단위 테스트")
+class UserServiceTest {
+
+    private lateinit var userRepository: UserRepository
+    private lateinit var encryptionService: EncryptionService
+    private lateinit var userService: UserService
+
+    private val userId = UUID.randomUUID()
+    private val createdAt = LocalDateTime.now().minusDays(10)
+
+    @BeforeEach
+    fun setUp() {
+        userRepository = mockk()
+        encryptionService = mockk()
+        userService = UserService(userRepository, encryptionService)
+    }
+
+    private fun createUser(
+        id: UUID = userId,
+        email: String = "enc:test@example.com",
+        name: String = "enc:홍길동",
+        phone: String = "enc:01012345678",
+        status: UserStatus = UserStatus.ACTIVE,
+        role: UserRole = UserRole.USER,
+    ) = User(
+        id = id,
+        email = email,
+        emailHash = "email-hash",
+        passwordHash = "password-hash",
+        name = name,
+        phone = phone,
+        phoneHash = "phone-hash",
+        role = role,
+        status = status,
+        createdAt = createdAt,
+    )
+
+    @Nested
+    @DisplayName("getProfile")
+    inner class GetProfile {
+
+        @Test
+        @DisplayName("정상 조회 - 복호화된 필드 반환")
+        fun shouldReturnDecryptedProfile() {
+            val user = createUser()
+            every { userRepository.findById(userId) } returns Optional.of(user)
+            every { encryptionService.decrypt("enc:test@example.com") } returns "test@example.com"
+            every { encryptionService.decrypt("enc:홍길동") } returns "홍길동"
+            every { encryptionService.decrypt("enc:01012345678") } returns "010-1234-5678"
+
+            val response = userService.getProfile(userId)
+
+            response.id shouldBe userId
+            response.email shouldBe "test@example.com"
+            response.name shouldBe "홍길동"
+            response.phone shouldBe "010-1234-5678"
+            response.role shouldBe UserRole.USER
+            response.createdAt shouldBe createdAt
+        }
+
+        @Test
+        @DisplayName("사용자 없음 - RESOURCE_NOT_FOUND")
+        fun shouldThrowWhenUserNotFound() {
+            every { userRepository.findById(userId) } returns Optional.empty()
+
+            val exception = assertThrows<UserException> {
+                userService.getProfile(userId)
+            }
+            exception.errorCode shouldBe ErrorCode.RESOURCE_NOT_FOUND
+        }
+
+        @Test
+        @DisplayName("탈퇴된 사용자 - RESOURCE_NOT_FOUND")
+        fun shouldThrowWhenUserDeleted() {
+            val user = createUser(status = UserStatus.DELETED)
+            every { userRepository.findById(userId) } returns Optional.of(user)
+
+            val exception = assertThrows<UserException> {
+                userService.getProfile(userId)
+            }
+            exception.errorCode shouldBe ErrorCode.RESOURCE_NOT_FOUND
+            verify(exactly = 0) { encryptionService.decrypt(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("updateProfile")
+    inner class UpdateProfile {
+
+        private val request = UserDto.UpdateProfileRequest(
+            name = "김철수",
+            phone = "010-9876-5432",
+        )
+
+        @Test
+        @DisplayName("정상 수정 - 암호화된 name/phone 및 phoneHash 갱신")
+        fun shouldUpdateProfile() {
+            val user = createUser()
+            every { userRepository.findById(userId) } returns Optional.of(user)
+            every { encryptionService.encrypt("김철수") } returns "enc:김철수"
+            every { encryptionService.encrypt("010-9876-5432") } returns "enc:010-9876-5432"
+            every { encryptionService.hash("010-9876-5432") } returns "new-phone-hash"
+
+            val response = userService.updateProfile(userId, request)
+
+            response.id shouldBe userId
+            response.name shouldBe "김철수"
+            response.phone shouldBe "010-9876-5432"
+            user.name shouldBe "enc:김철수"
+            user.phone shouldBe "enc:010-9876-5432"
+            user.phoneHash shouldBe "new-phone-hash"
+        }
+
+        @Test
+        @DisplayName("사용자 없음 - RESOURCE_NOT_FOUND")
+        fun shouldThrowWhenUserNotFound() {
+            every { userRepository.findById(userId) } returns Optional.empty()
+
+            val exception = assertThrows<UserException> {
+                userService.updateProfile(userId, request)
+            }
+            exception.errorCode shouldBe ErrorCode.RESOURCE_NOT_FOUND
+            verify(exactly = 0) { encryptionService.encrypt(any()) }
+        }
+
+        @Test
+        @DisplayName("탈퇴된 사용자 - RESOURCE_NOT_FOUND")
+        fun shouldThrowWhenUserDeleted() {
+            val user = createUser(status = UserStatus.DELETED)
+            every { userRepository.findById(userId) } returns Optional.of(user)
+
+            val exception = assertThrows<UserException> {
+                userService.updateProfile(userId, request)
+            }
+            exception.errorCode shouldBe ErrorCode.RESOURCE_NOT_FOUND
+            verify(exactly = 0) { encryptionService.encrypt(any()) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `GET /users/me`, `PATCH /users/me` 엔드포인트 추가 (REQ-AUTH-012, REQ-AUTH-013)
- 응답은 복호화된 email/name/phone과 role/createdAt 포함
- `EncryptionService.encrypt` 후 저장, `phoneHash`도 함께 갱신
- `SecurityConfig`에 `SecurityErrorHandlers` 등록 — 인증 실패 시 401, 인가 실패 시 403을 표준 ErrorResponse 형식으로 반환 (event/payment/queue/reservation 서비스와 일관)
- `User` entity의 `name`/`phone`/`phoneHash`를 `var`로 전환하여 JPA dirty checking 활용
- 단위 테스트: `UserServiceTest`, `UserControllerTest`

Closes #27

## Test plan
- [x] `./gradlew :user-service:test` — 신규/기존 테스트 모두 통과
- [ ] 통합 환경에서 Gateway 경유 동작 확인 (JWT 검증 후 `X-User-Id`/`X-User-Role` 헤더로 전달)