### PR TITLE
feat: [User] 비밀번호 변경 + 회원 탈퇴 API (#28, #29)

### DIFF
--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/UserController.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/UserController.kt
@@ -5,9 +5,11 @@ import com.ticketqueue.user.dto.UserDto
 import com.ticketqueue.user.exception.UserException
 import com.ticketqueue.user.service.UserService
 import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -50,6 +52,19 @@ class UserController(
         val userId = parseUserId(principal)
         logger.info { "Password change request: userId=$userId" }
         userService.changePassword(userId, request)
+    }
+
+    @DeleteMapping("/me")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun withdraw(
+        @AuthenticationPrincipal principal: String?,
+        httpRequest: HttpServletRequest,
+    ) {
+        val userId = parseUserId(principal)
+        val authHeader = httpRequest.getHeader("Authorization")
+            ?: throw UserException(ErrorCode.UNAUTHORIZED)
+        logger.info { "Withdraw request: userId=$userId" }
+        userService.withdraw(userId, authHeader)
     }
 
     private fun parseUserId(principal: String?): UUID {

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/UserController.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/UserController.kt
@@ -6,11 +6,14 @@ import com.ticketqueue.user.exception.UserException
 import com.ticketqueue.user.service.UserService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -36,6 +39,17 @@ class UserController(
         val userId = parseUserId(principal)
         logger.info { "Profile update: userId=$userId" }
         return userService.updateProfile(userId, request)
+    }
+
+    @PutMapping("/me/password")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun changeMyPassword(
+        @AuthenticationPrincipal principal: String?,
+        @Valid @RequestBody request: UserDto.ChangePasswordRequest,
+    ) {
+        val userId = parseUserId(principal)
+        logger.info { "Password change request: userId=$userId" }
+        userService.changePassword(userId, request)
     }
 
     private fun parseUserId(principal: String?): UUID {

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/dto/UserDto.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/dto/UserDto.kt
@@ -65,4 +65,13 @@ class UserDto {
             )
         }
     }
+
+    data class ChangePasswordRequest(
+        @field:NotBlank(message = "현재 비밀번호는 필수입니다.")
+        val currentPassword: String,
+
+        @field:NotBlank(message = "새 비밀번호는 필수입니다.")
+        @field:Size(min = 8, max = 100, message = "새 비밀번호는 8~100자여야 합니다.")
+        val newPassword: String,
+    )
 }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/entity/User.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/entity/User.kt
@@ -27,7 +27,7 @@ class User(
     val emailHash: String,
 
     @Column(name = "password_hash", nullable = false)
-    val passwordHash: String,
+    var passwordHash: String,
 
     @Column(nullable = false)
     var name: String,

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/entity/User.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/entity/User.kt
@@ -53,7 +53,7 @@ class User(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    val status: UserStatus = UserStatus.ACTIVE,
+    var status: UserStatus = UserStatus.ACTIVE,
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepositoryCustom.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepositoryCustom.kt
@@ -5,4 +5,6 @@ import java.util.UUID
 
 interface RefreshTokenRepositoryCustom {
     fun revokeAllActiveByTokenFamily(tokenFamily: UUID, now: LocalDateTime): Long
+
+    fun revokeAllActiveByUserId(userId: UUID, now: LocalDateTime): Long
 }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepositoryCustomImpl.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepositoryCustomImpl.kt
@@ -21,4 +21,17 @@ class RefreshTokenRepositoryCustomImpl(
             )
             .execute()
     }
+
+    override fun revokeAllActiveByUserId(userId: UUID, now: LocalDateTime): Long {
+        val token = QRefreshToken.refreshToken
+        return queryFactory
+            .update(token)
+            .set(token.revoked, true)
+            .set(token.revokedAt, now)
+            .where(
+                token.user.id.eq(userId),
+                token.revoked.isFalse
+            )
+            .execute()
+    }
 }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/UserService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/UserService.kt
@@ -6,6 +6,7 @@ import com.ticketqueue.user.entity.UserStatus
 import com.ticketqueue.user.exception.UserException
 import com.ticketqueue.user.repository.UserRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -14,6 +15,7 @@ import java.util.UUID
 class UserService(
     private val userRepository: UserRepository,
     private val encryptionService: EncryptionService,
+    private val passwordEncoder: PasswordEncoder,
 ) {
     private val logger = KotlinLogging.logger {}
 
@@ -54,5 +56,24 @@ class UserService(
             decryptedName = request.name,
             decryptedPhone = request.phone,
         )
+    }
+
+    @Transactional
+    fun changePassword(userId: UUID, request: UserDto.ChangePasswordRequest) {
+        val user = userRepository.findById(userId)
+            .orElseThrow { UserException(ErrorCode.RESOURCE_NOT_FOUND) }
+
+        if (user.status == UserStatus.DELETED) {
+            throw UserException(ErrorCode.RESOURCE_NOT_FOUND)
+        }
+
+        if (!passwordEncoder.matches(request.currentPassword, user.passwordHash)) {
+            logger.warn { "Password change failed: currentPassword mismatch userId=$userId" }
+            throw UserException(ErrorCode.INVALID_CREDENTIALS)
+        }
+
+        user.passwordHash = passwordEncoder.encode(request.newPassword)
+
+        logger.info { "Password changed: userId=$userId" }
     }
 }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/UserService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/UserService.kt
@@ -1,14 +1,18 @@
 package com.ticketqueue.user.service
 
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.user.config.JwtProperties
 import com.ticketqueue.user.dto.UserDto
 import com.ticketqueue.user.entity.UserStatus
 import com.ticketqueue.user.exception.UserException
+import com.ticketqueue.user.repository.RefreshTokenRepository
 import com.ticketqueue.user.repository.UserRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 @Service
@@ -16,6 +20,10 @@ class UserService(
     private val userRepository: UserRepository,
     private val encryptionService: EncryptionService,
     private val passwordEncoder: PasswordEncoder,
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val tokenBlacklistService: TokenBlacklistService,
+    private val jwtProperties: JwtProperties,
 ) {
     private val logger = KotlinLogging.logger {}
 
@@ -75,5 +83,30 @@ class UserService(
         user.passwordHash = passwordEncoder.encode(request.newPassword)
 
         logger.info { "Password changed: userId=$userId" }
+    }
+
+    @Transactional
+    fun withdraw(userId: UUID, authorizationHeader: String) {
+        if (!authorizationHeader.startsWith("Bearer ")) {
+            throw UserException(ErrorCode.UNAUTHORIZED)
+        }
+        val accessToken = authorizationHeader.removePrefix("Bearer ")
+        val jti = jwtTokenProvider.parseAccessTokenJti(accessToken)
+
+        val user = userRepository.findById(userId)
+            .orElseThrow { UserException(ErrorCode.RESOURCE_NOT_FOUND) }
+
+        if (user.status == UserStatus.DELETED) {
+            throw UserException(ErrorCode.RESOURCE_NOT_FOUND)
+        }
+
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        user.status = UserStatus.DELETED
+        user.deletedAt = now
+
+        val revokedCount = refreshTokenRepository.revokeAllActiveByUserId(userId, now)
+        tokenBlacklistService.addToBlacklist(jti, jwtProperties.accessTokenExpiry)
+
+        logger.info { "User withdrawn: userId=$userId, refreshTokensRevoked=$revokedCount" }
     }
 }

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/controller/UserControllerTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/controller/UserControllerTest.kt
@@ -10,7 +10,9 @@ import com.ticketqueue.user.config.SecurityConfig
 import com.ticketqueue.user.dto.UserDto
 import com.ticketqueue.user.entity.UserRole
 import com.ticketqueue.user.service.UserService
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -27,6 +29,7 @@ import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDateTime
@@ -205,6 +208,96 @@ class UserControllerTest {
                 BusinessException(ErrorCode.RESOURCE_NOT_FOUND)
 
             performPatch(validRequest)
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /users/me/password")
+    inner class ChangePassword {
+
+        private val validRequest = UserDto.ChangePasswordRequest(
+            currentPassword = "oldPassword!",
+            newPassword = "newSecurePassword123!",
+        )
+
+        private fun performPut(content: Any?, includeAuth: Boolean = true) = mockMvc.perform(
+            put("/users/me/password")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .let { if (includeAuth) it.header("X-User-Id", userId.toString()).header("X-User-Role", "USER") else it }
+                .let { if (content != null) it.content(objectMapper.writeValueAsString(content)) else it }
+        )
+
+        @Test
+        @DisplayName("정상 변경 시 204 NO CONTENT")
+        fun shouldReturn204() {
+            every { userService.changePassword(userId, validRequest) } just Runs
+
+            performPut(validRequest)
+                .andExpect(status().isNoContent)
+        }
+
+        @Test
+        @DisplayName("현재 비밀번호 빈 값 시 400 BAD REQUEST")
+        fun shouldReturn400WhenCurrentBlank() {
+            performPut(validRequest.copy(currentPassword = ""))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("현재 비밀번호")))
+        }
+
+        @Test
+        @DisplayName("새 비밀번호 빈 값 시 400 BAD REQUEST")
+        fun shouldReturn400WhenNewBlank() {
+            performPut(validRequest.copy(newPassword = ""))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("새 비밀번호")))
+        }
+
+        @Test
+        @DisplayName("새 비밀번호 너무 짧음 시 400 BAD REQUEST")
+        fun shouldReturn400WhenNewTooShort() {
+            performPut(validRequest.copy(newPassword = "short"))
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+        }
+
+        @Test
+        @DisplayName("인증 헤더 누락 시 401 UNAUTHORIZED")
+        fun shouldReturn401WhenNoAuth() {
+            performPut(validRequest, includeAuth = false)
+                .andExpect(status().isUnauthorized)
+        }
+
+        @Test
+        @DisplayName("요청 body 없을 시 400 BAD REQUEST")
+        fun shouldReturn400WhenBodyMissing() {
+            performPut(null)
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+        }
+
+        @Test
+        @DisplayName("현재 비밀번호 불일치 시 401 UNAUTHORIZED")
+        fun shouldReturn401WhenCurrentPasswordWrong() {
+            every { userService.changePassword(userId, validRequest) } throws
+                BusinessException(ErrorCode.INVALID_CREDENTIALS)
+
+            performPut(validRequest)
+                .andExpect(status().isUnauthorized)
+                .andExpect(jsonPath("$.code").value("INVALID_CREDENTIALS"))
+        }
+
+        @Test
+        @DisplayName("사용자 미존재 시 404 NOT FOUND")
+        fun shouldReturn404WhenUserMissing() {
+            every { userService.changePassword(userId, validRequest) } throws
+                BusinessException(ErrorCode.RESOURCE_NOT_FOUND)
+
+            performPut(validRequest)
                 .andExpect(status().isNotFound)
                 .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
         }

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/controller/UserControllerTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/controller/UserControllerTest.kt
@@ -27,6 +27,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
@@ -300,6 +301,84 @@ class UserControllerTest {
             performPut(validRequest)
                 .andExpect(status().isNotFound)
                 .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /users/me")
+    inner class Withdraw {
+
+        private val authHeader = "Bearer valid.access.token"
+
+        @Test
+        @DisplayName("정상 탈퇴 시 204 NO CONTENT")
+        fun shouldReturn204() {
+            every { userService.withdraw(userId, authHeader) } just Runs
+
+            mockMvc.perform(
+                delete("/users/me")
+                    .with(csrf())
+                    .header("X-User-Id", userId.toString())
+                    .header("X-User-Role", "USER")
+                    .header("Authorization", authHeader)
+            ).andExpect(status().isNoContent)
+        }
+
+        @Test
+        @DisplayName("Authorization 헤더 누락 시 401 UNAUTHORIZED")
+        fun shouldReturn401WhenAuthHeaderMissing() {
+            mockMvc.perform(
+                delete("/users/me")
+                    .with(csrf())
+                    .header("X-User-Id", userId.toString())
+                    .header("X-User-Role", "USER")
+            )
+                .andExpect(status().isUnauthorized)
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+        }
+
+        @Test
+        @DisplayName("Gateway 인증 헤더 누락 시 401 UNAUTHORIZED")
+        fun shouldReturn401WhenGatewayHeadersMissing() {
+            mockMvc.perform(
+                delete("/users/me")
+                    .with(csrf())
+                    .header("Authorization", authHeader)
+            ).andExpect(status().isUnauthorized)
+        }
+
+        @Test
+        @DisplayName("이미 탈퇴된 사용자 시 404 NOT FOUND")
+        fun shouldReturn404WhenAlreadyDeleted() {
+            every { userService.withdraw(userId, authHeader) } throws
+                BusinessException(ErrorCode.RESOURCE_NOT_FOUND)
+
+            mockMvc.perform(
+                delete("/users/me")
+                    .with(csrf())
+                    .header("X-User-Id", userId.toString())
+                    .header("X-User-Role", "USER")
+                    .header("Authorization", authHeader)
+            )
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
+        }
+
+        @Test
+        @DisplayName("Access Token 검증 실패 시 401 UNAUTHORIZED")
+        fun shouldReturn401WhenTokenInvalid() {
+            every { userService.withdraw(userId, authHeader) } throws
+                BusinessException(ErrorCode.INVALID_TOKEN)
+
+            mockMvc.perform(
+                delete("/users/me")
+                    .with(csrf())
+                    .header("X-User-Id", userId.toString())
+                    .header("X-User-Role", "USER")
+                    .header("Authorization", authHeader)
+            )
+                .andExpect(status().isUnauthorized)
+                .andExpect(jsonPath("$.code").value("INVALID_TOKEN"))
         }
     }
 }

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/UserServiceTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/UserServiceTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
 import java.util.Optional
 import java.util.UUID
@@ -25,6 +26,7 @@ class UserServiceTest {
 
     private lateinit var userRepository: UserRepository
     private lateinit var encryptionService: EncryptionService
+    private lateinit var passwordEncoder: PasswordEncoder
     private lateinit var userService: UserService
 
     private val userId = UUID.randomUUID()
@@ -34,7 +36,8 @@ class UserServiceTest {
     fun setUp() {
         userRepository = mockk()
         encryptionService = mockk()
-        userService = UserService(userRepository, encryptionService)
+        passwordEncoder = mockk()
+        userService = UserService(userRepository, encryptionService, passwordEncoder)
     }
 
     private fun createUser(
@@ -42,13 +45,14 @@ class UserServiceTest {
         email: String = "enc:test@example.com",
         name: String = "enc:홍길동",
         phone: String = "enc:01012345678",
+        passwordHash: String = "password-hash",
         status: UserStatus = UserStatus.ACTIVE,
         role: UserRole = UserRole.USER,
     ) = User(
         id = id,
         email = email,
         emailHash = "email-hash",
-        passwordHash = "password-hash",
+        passwordHash = passwordHash,
         name = name,
         phone = phone,
         phoneHash = "phone-hash",
@@ -156,6 +160,72 @@ class UserServiceTest {
             }
             exception.errorCode shouldBe ErrorCode.RESOURCE_NOT_FOUND
             verify(exactly = 0) { encryptionService.encrypt(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("changePassword")
+    inner class ChangePassword {
+
+        private val request = UserDto.ChangePasswordRequest(
+            currentPassword = "oldPassword!",
+            newPassword = "newSecurePassword123!",
+        )
+
+        @Test
+        @DisplayName("정상 변경 - 새 비밀번호 해시 저장")
+        fun shouldChangePassword() {
+            val user = createUser(passwordHash = "old-hash")
+            every { userRepository.findById(userId) } returns Optional.of(user)
+            every { passwordEncoder.matches("oldPassword!", "old-hash") } returns true
+            every { passwordEncoder.encode("newSecurePassword123!") } returns "new-hash"
+
+            userService.changePassword(userId, request)
+
+            user.passwordHash shouldBe "new-hash"
+            verify(exactly = 1) { passwordEncoder.matches("oldPassword!", "old-hash") }
+            verify(exactly = 1) { passwordEncoder.encode("newSecurePassword123!") }
+        }
+
+        @Test
+        @DisplayName("사용자 없음 - RESOURCE_NOT_FOUND")
+        fun shouldThrowWhenUserNotFound() {
+            every { userRepository.findById(userId) } returns Optional.empty()
+
+            val exception = assertThrows<UserException> {
+                userService.changePassword(userId, request)
+            }
+            exception.errorCode shouldBe ErrorCode.RESOURCE_NOT_FOUND
+            verify(exactly = 0) { passwordEncoder.matches(any(), any()) }
+            verify(exactly = 0) { passwordEncoder.encode(any()) }
+        }
+
+        @Test
+        @DisplayName("탈퇴된 사용자 - RESOURCE_NOT_FOUND")
+        fun shouldThrowWhenUserDeleted() {
+            val user = createUser(status = UserStatus.DELETED)
+            every { userRepository.findById(userId) } returns Optional.of(user)
+
+            val exception = assertThrows<UserException> {
+                userService.changePassword(userId, request)
+            }
+            exception.errorCode shouldBe ErrorCode.RESOURCE_NOT_FOUND
+            verify(exactly = 0) { passwordEncoder.matches(any(), any()) }
+        }
+
+        @Test
+        @DisplayName("현재 비밀번호 불일치 - INVALID_CREDENTIALS, 새 비밀번호 인코딩 미수행")
+        fun shouldThrowWhenCurrentPasswordMismatch() {
+            val user = createUser(passwordHash = "old-hash")
+            every { userRepository.findById(userId) } returns Optional.of(user)
+            every { passwordEncoder.matches("oldPassword!", "old-hash") } returns false
+
+            val exception = assertThrows<UserException> {
+                userService.changePassword(userId, request)
+            }
+            exception.errorCode shouldBe ErrorCode.INVALID_CREDENTIALS
+            user.passwordHash shouldBe "old-hash"
+            verify(exactly = 0) { passwordEncoder.encode(any()) }
         }
     }
 }

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/UserServiceTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/UserServiceTest.kt
@@ -1,16 +1,21 @@
 package com.ticketqueue.user.service
 
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.user.config.JwtProperties
 import com.ticketqueue.user.dto.UserDto
 import com.ticketqueue.user.entity.User
 import com.ticketqueue.user.entity.UserRole
 import com.ticketqueue.user.entity.UserStatus
 import com.ticketqueue.user.exception.UserException
+import com.ticketqueue.user.repository.RefreshTokenRepository
 import com.ticketqueue.user.repository.UserRepository
 import io.kotest.matchers.shouldBe
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.verifyOrder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -27,6 +32,10 @@ class UserServiceTest {
     private lateinit var userRepository: UserRepository
     private lateinit var encryptionService: EncryptionService
     private lateinit var passwordEncoder: PasswordEncoder
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+    private lateinit var tokenBlacklistService: TokenBlacklistService
+    private lateinit var jwtProperties: JwtProperties
     private lateinit var userService: UserService
 
     private val userId = UUID.randomUUID()
@@ -37,7 +46,19 @@ class UserServiceTest {
         userRepository = mockk()
         encryptionService = mockk()
         passwordEncoder = mockk()
-        userService = UserService(userRepository, encryptionService, passwordEncoder)
+        refreshTokenRepository = mockk()
+        jwtTokenProvider = mockk()
+        tokenBlacklistService = mockk(relaxed = true)
+        jwtProperties = mockk()
+        userService = UserService(
+            userRepository,
+            encryptionService,
+            passwordEncoder,
+            refreshTokenRepository,
+            jwtTokenProvider,
+            tokenBlacklistService,
+            jwtProperties,
+        )
     }
 
     private fun createUser(
@@ -226,6 +247,90 @@ class UserServiceTest {
             exception.errorCode shouldBe ErrorCode.INVALID_CREDENTIALS
             user.passwordHash shouldBe "old-hash"
             verify(exactly = 0) { passwordEncoder.encode(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("withdraw")
+    inner class Withdraw {
+
+        private val jti = "test-jti-uuid"
+        private val accessToken = "valid.access.token"
+        private val authHeader = "Bearer $accessToken"
+
+        @Test
+        @DisplayName("정상 탈퇴 - status DELETED, deleted_at 기록, refresh token revoke, 블랙리스트 등록")
+        fun shouldWithdrawSuccessfully() {
+            val user = createUser()
+            every { jwtTokenProvider.parseAccessTokenJti(accessToken) } returns jti
+            every { userRepository.findById(userId) } returns Optional.of(user)
+            every { refreshTokenRepository.revokeAllActiveByUserId(eq(userId), any()) } returns 3L
+            every { jwtProperties.accessTokenExpiry } returns 3_600_000L
+
+            userService.withdraw(userId, authHeader)
+
+            user.status shouldBe UserStatus.DELETED
+            (user.deletedAt != null) shouldBe true
+            verifyOrder {
+                refreshTokenRepository.revokeAllActiveByUserId(eq(userId), any())
+                tokenBlacklistService.addToBlacklist(jti, 3_600_000L)
+            }
+        }
+
+        @Test
+        @DisplayName("Authorization 헤더에 Bearer 접두사 없음 - UNAUTHORIZED")
+        fun shouldThrowWhenInvalidAuthHeader() {
+            val exception = assertThrows<UserException> {
+                userService.withdraw(userId, "InvalidHeader")
+            }
+            exception.errorCode shouldBe ErrorCode.UNAUTHORIZED
+            verify(exactly = 0) { jwtTokenProvider.parseAccessTokenJti(any()) }
+            verify(exactly = 0) { userRepository.findById(any()) }
+            verify(exactly = 0) { refreshTokenRepository.revokeAllActiveByUserId(any(), any()) }
+            verify(exactly = 0) { tokenBlacklistService.addToBlacklist(any(), any()) }
+        }
+
+        @Test
+        @DisplayName("Access Token 검증 실패 - 예외 전파, DB/Redis 미호출")
+        fun shouldPropagateJwtError() {
+            every { jwtTokenProvider.parseAccessTokenJti(accessToken) } throws
+                UserException(ErrorCode.INVALID_TOKEN)
+
+            val exception = assertThrows<UserException> {
+                userService.withdraw(userId, authHeader)
+            }
+            exception.errorCode shouldBe ErrorCode.INVALID_TOKEN
+            verify(exactly = 0) { userRepository.findById(any()) }
+            verify(exactly = 0) { tokenBlacklistService.addToBlacklist(any(), any()) }
+        }
+
+        @Test
+        @DisplayName("사용자 없음 - RESOURCE_NOT_FOUND, 블랙리스트 미등록")
+        fun shouldThrowWhenUserNotFound() {
+            every { jwtTokenProvider.parseAccessTokenJti(accessToken) } returns jti
+            every { userRepository.findById(userId) } returns Optional.empty()
+
+            val exception = assertThrows<UserException> {
+                userService.withdraw(userId, authHeader)
+            }
+            exception.errorCode shouldBe ErrorCode.RESOURCE_NOT_FOUND
+            verify(exactly = 0) { refreshTokenRepository.revokeAllActiveByUserId(any(), any()) }
+            verify(exactly = 0) { tokenBlacklistService.addToBlacklist(any(), any()) }
+        }
+
+        @Test
+        @DisplayName("이미 탈퇴된 사용자 - RESOURCE_NOT_FOUND, 추가 작업 없음")
+        fun shouldThrowWhenAlreadyDeleted() {
+            val user = createUser(status = UserStatus.DELETED)
+            every { jwtTokenProvider.parseAccessTokenJti(accessToken) } returns jti
+            every { userRepository.findById(userId) } returns Optional.of(user)
+
+            val exception = assertThrows<UserException> {
+                userService.withdraw(userId, authHeader)
+            }
+            exception.errorCode shouldBe ErrorCode.RESOURCE_NOT_FOUND
+            verify(exactly = 0) { refreshTokenRepository.revokeAllActiveByUserId(any(), any()) }
+            verify(exactly = 0) { tokenBlacklistService.addToBlacklist(any(), any()) }
         }
     }
 }


### PR DESCRIPTION
## Summary
> **Note (rebase 반영)**: 원래 #28(비밀번호 변경)만 다루던 PR이지만, PR #243이 잘못된 base(`feature/28-user-password-change`)로 머지되면서 #29(회원 탈퇴) commit이 같은 브랜치에 추가된 상태로 잔류했습니다. develop으로 깨끗하게 머지될 수 있도록 #28 + #29 두 commit을 develop tip 위로 rebase했고, 따라서 본 PR이 머지되면 두 변경이 함께 develop에 반영됩니다.

### #28 비밀번호 변경 API (REQ-AUTH-016)
- `PUT /users/me/password` 엔드포인트, 204 No Content
- 현재 비밀번호 BCrypt 검증 → 일치 시 신규 비밀번호 해시 저장, 불일치 시 `INVALID_CREDENTIALS`(401)
- `ChangePasswordRequest`: `@NotBlank` + `@Size(min=8, max=100)`
- `User.passwordHash`를 `var`로 전환하여 JPA dirty checking 활용

### #29 회원 탈퇴 API (REQ-AUTH-017)
- `DELETE /users/me` 엔드포인트, 204 No Content
- Soft delete: `user.status = DELETED`, `user.deletedAt = now()` (UTC)
- 모든 활성 Refresh Token 일괄 무효화 (`revokeAllActiveByUserId` 신설)
- 현재 Access Token jti를 Redis 블랙리스트에 등록 (TTL = `accessTokenExpiry`)
- `AuthService.logout` 패턴 차용 — Authorization 헤더 파싱 → jti 추출 → DB 트랜잭션 → Redis
- `User.status`를 `var`로 전환

### 테스트
- `UserServiceTest.ChangePassword` 4개, `UserControllerTest.ChangePassword` 8개
- `UserServiceTest.Withdraw` 5개, `UserControllerTest.Withdraw` 5개
- 전체 user-service 테스트 통과

Closes #28
Closes #29

> 개인정보 30일 파기 배치는 deleted_at 컬럼을 기반으로 동작할 예정 (별도 이슈)

## Test plan
- [x] \`./gradlew :user-service:test\` — rebase 후 BUILD SUCCESSFUL
- [ ] Gateway 경유 통합 테스트: PUT/DELETE 호출 후 토큰 동작 검증