### PR TITLE
feat: [Payment] SAGA 패턴 - 보상 트랜잭션 검증 강화 (#62)

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -86,7 +86,7 @@ Outbox 위에서 동작하거나 완전히 독립적인 핵심 백엔드 API. **
 | # | Done | Issue | Title | Deps | Claim | Branch | PR |
 |---|------|-------|-------|------|-------|--------|----|
 | 9 | [ ] | [#53](https://github.com/paircoders/ticket-queue/issues/53) | [Reservation] Kafka Consumer - 결제 이벤트 처리 | #55, #63, #59 |  | `feature/53-reservation-payment-consumer` |  |
-| 10 | [ ] | [#62](https://github.com/paircoders/ticket-queue/issues/62) | [Payment] SAGA 패턴 - 보상 트랜잭션 구현 | #59, #53 | session-7f37ba3c | `feature/62-payment-saga-compensation` |  |
+| 10 | [ ] | [#62](https://github.com/paircoders/ticket-queue/issues/62) | [Payment] SAGA 패턴 - 보상 트랜잭션 구현 | #59, #53 | session-7f37ba3c | `feature/62-payment-saga-compensation` | [#242](https://github.com/paircoders/ticket-queue/pull/242) |
 
 ---
 

--- a/TASK.md
+++ b/TASK.md
@@ -86,7 +86,7 @@ Outbox 위에서 동작하거나 완전히 독립적인 핵심 백엔드 API. **
 | # | Done | Issue | Title | Deps | Claim | Branch | PR |
 |---|------|-------|-------|------|-------|--------|----|
 | 9 | [ ] | [#53](https://github.com/paircoders/ticket-queue/issues/53) | [Reservation] Kafka Consumer - 결제 이벤트 처리 | #55, #63, #59 |  | `feature/53-reservation-payment-consumer` |  |
-| 10 | [ ] | [#62](https://github.com/paircoders/ticket-queue/issues/62) | [Payment] SAGA 패턴 - 보상 트랜잭션 구현 | #59, #53 |  | `feature/62-payment-saga-compensation` |  |
+| 10 | [ ] | [#62](https://github.com/paircoders/ticket-queue/issues/62) | [Payment] SAGA 패턴 - 보상 트랜잭션 구현 | #59, #53 | session-7f37ba3c | `feature/62-payment-saga-compensation` |  |
 
 ---
 

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/service/PaymentService.kt
@@ -132,7 +132,7 @@ class PaymentService(
     }
 
     /**
-     * 결제 승인 서비스 (REQ-PAY-010)
+     * 결제 승인 서비스 (REQ-PAY-010 / REQ-PAY-011 / REQ-PAY-012)
      *
      * ## 승인 프로세스
      * 1. Payment 조회 — 소유권/요청 본문 정합성/상태 머신으로 조기 거절
@@ -145,6 +145,26 @@ class PaymentService(
      * 실패하면 502 PORTONE_API_ERROR 로, Resilience4j CircuitBreaker 가 차단한 경우(CallNotPermittedException →
      * FallbackFactory) 503 PORTONE_CIRCUIT_OPEN 으로 즉시 전파한다 — Payment 는 PENDING 으로 남아 클라이언트가
      * 안전하게 재시도할 수 있다. 동시 confirm race 는 락 재검증으로 차단되어 중복 outbox 발행이 발생하지 않는다.
+     *
+     * ## SAGA 보상 체인 진입점 (#62)
+     * 본 메서드가 `payment.events` 토픽으로 발행하는 두 이벤트가 모든 후속 보상/확정 체인의 출발점이다.
+     *
+     * Happy path (PAID):
+     * ```
+     * confirmPayment → markSuccess + recordPaymentSuccess (outbox PaymentSuccess)
+     *  └ reservation-payment-consumer → Reservation.confirm()  (예매 CONFIRMED + ticketNumber)
+     *  └ event-payment-consumer        → SeatService.markSeatsAsSold (좌석 SOLD)
+     * ```
+     *
+     * Compensation path (PAID 아님 또는 amount/tx_id mismatch):
+     * ```
+     * confirmPayment → markFailed + recordPaymentFailed (outbox PaymentFailed)
+     *  └ reservation-payment-consumer → Reservation.cancel() + outbox ReservationCancelled (causationId)
+     *      └ event-reservation-consumer → SeatService.releaseHoldSeats (좌석 AVAILABLE 복원)
+     * ```
+     *
+     * 두 outbox 발행 모두 비즈니스 상태 변경과 동일 트랜잭션 내부에서 일어나므로,
+     * Payment 상태와 메시지 발행이 원자적이며 SAGA 의 atomicity 가 보장된다.
      */
     fun confirmPayment(userId: UUID, request: ConfirmRequest): ConfirmResponse {
         val payment = paymentRepository.findById(request.paymentId)
@@ -296,11 +316,20 @@ class PaymentService(
     }
 
     /**
-     * Transactional Outbox 발행 헬퍼 — PaymentSuccess.
+     * Transactional Outbox 발행 헬퍼 — PaymentSuccess. (REQ-PAY-011, SAGA happy path)
      *
      * 호출자는 활성 트랜잭션 내부에서 호출해야 한다 ([OutboxEventRecorder] PROPAGATION_MANDATORY).
      * payment 는 markSuccess() 가 이미 호출되어 paidAt / portoneTransactionId 가 채워진 상태여야 한다.
      * 결제 승인 API (#59) 가 confirm 트랜잭션 내부에서 호출하기 위한 재사용 진입점.
+     *
+     * ## SAGA 보상 체인에서의 위치
+     * Payment Service 는 SAGA 의 root 이므로 [EventMetadata.causationId] 는 항상 `null` 이다.
+     * downstream consumer (reservation-payment-consumer) 가 본 이벤트의 eventId 를
+     * [com.ticketqueue.common.event.ReservationConfirmedEvent.metadata] 의 causationId 로
+     * 전파하여 체인을 잇는다 (docs/architecture/05_kafka.md §3.1 / §4.3.1).
+     *
+     * `metadata.userId` 는 분산 추적용 cross-cutting 필드로, 파티션 키(aggregateId) 와는 별도로
+     * 항상 payment.userId 를 채워 downstream observability 를 보장한다.
      */
     private fun recordPaymentSuccess(payment: Payment, reservation: ReservationDetailResponse) {
         val paidAt = requireNotNull(payment.paidAt) { "payment.paidAt must be set before recording PaymentSuccess" }
@@ -321,10 +350,24 @@ class PaymentService(
     }
 
     /**
-     * Transactional Outbox 발행 헬퍼 — PaymentFailed.
+     * Transactional Outbox 발행 헬퍼 — PaymentFailed. (REQ-PAY-012, SAGA 보상 체인 root)
      *
      * 호출자는 활성 트랜잭션 내부에서 호출해야 한다 ([OutboxEventRecorder] PROPAGATION_MANDATORY).
      * createPayment 의 PortOne pre-register 실패 분기 / 결제 승인 실패 분기에서 공통 사용.
+     *
+     * ## SAGA 보상 체인에서의 역할
+     * 본 이벤트가 SAGA 의 **보상 트랜잭션 시작점**이다. [EventMetadata.causationId] 는 `null` 이며,
+     * 보상 체인은 다음 순서로 흐른다 (docs/architecture/05_kafka.md §4.3.2 ~ §4.3.3):
+     *
+     * ```
+     * PaymentService     → outbox(PaymentFailed)       — 본 메서드 (causationId = null, SAGA root)
+     * Reservation Consumer → cancelFromPaymentFailure
+     *                       → outbox(ReservationCancelled, causationId = PaymentFailed.eventId)
+     * Event Consumer       → releaseHoldSeats (좌석 DB AVAILABLE 복원)
+     * ```
+     *
+     * `aggregateId = payment.id` 로 파티션 키가 결제 단위로 묶여 SAGA 순서가 보장되며,
+     * `reservationId` 는 downstream consumer 가 reservation 도메인 쿼리에 사용한다.
      */
     private fun recordPaymentFailed(payment: Payment, reason: String) {
         outboxEventRecorder.record(

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/integration/PaymentOutboxIntegrationTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/integration/PaymentOutboxIntegrationTest.kt
@@ -4,8 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.ninjasquad.springmockk.MockkBean
 import com.ticketqueue.common.event.PaymentFailedEvent
+import com.ticketqueue.common.event.PaymentSuccessEvent
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.common.external.portone.PortoneCustomer
 import com.ticketqueue.common.external.portone.PortoneFeignClient
+import com.ticketqueue.common.external.portone.PortonePaymentAmount
+import com.ticketqueue.common.external.portone.PortonePaymentResponse
+import com.ticketqueue.common.external.portone.PortoneSelectedChannel
 import com.ticketqueue.common.external.portone.PortoneTokenService
 import com.ticketqueue.common.outbox.OutboxEventRepository
 import com.ticketqueue.payment.client.ReservationServiceClient
@@ -13,6 +18,7 @@ import com.ticketqueue.payment.entity.PaymentStatus
 import com.ticketqueue.payment.repository.PaymentRepository
 import io.kotest.matchers.shouldBe
 import io.mockk.every
+import io.mockk.justRun
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -33,6 +39,7 @@ import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 import java.math.BigDecimal
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
 
@@ -121,6 +128,171 @@ class PaymentOutboxIntegrationTest {
     }
 
     @Test
+    @DisplayName("SAGA happy path: PortOne PAID 응답 시 PaymentSuccess outbox row 가 INSERT 되고 causationId=null (SAGA root) 이 보장된다")
+    fun confirmSuccessInsertsPaymentSuccessOutboxRow() {
+        // 1) Payment(PENDING) 생성 — pre-register stub 통과
+        val scheduleId = UUID.randomUUID()
+        val seatIds = listOf(UUID.randomUUID(), UUID.randomUUID())
+        every { reservationServiceClient.getReservation(reservationId) } returns
+            ReservationServiceClient.ReservationDetailResponse(
+                reservationId = reservationId,
+                userId = userId,
+                scheduleId = scheduleId,
+                totalAmount = amount,
+                status = ReservationServiceClient.ReservationStatus.PENDING,
+                holdExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5),
+                seatIds = seatIds
+            )
+        justRun { portoneClient.preRegisterPayment(any(), any(), any()) }
+        val createResp = mockMvc.perform(
+            post("/payments")
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        mapOf("reservationId" to reservationId, "amount" to amount, "paymentMethod" to "CARD")
+                    )
+                )
+        ).andExpect(status().isOk).andReturn()
+
+        val createBody = objectMapper.readTree(createResp.response.contentAsString)
+        val paymentId = UUID.fromString(createBody.get("paymentId").asText())
+        val paymentKey = createBody.get("paymentKey").asText()
+        outboxEventRepository.deleteAll() // create 단계에서 발행된 outbox row 가 없어야 하지만 정합성 보장 위해 clear
+
+        // 2) PortOne getPayment stub — PAID 응답
+        val transactionId = "portone-tx-${UUID.randomUUID()}"
+        every { portoneClient.getPayment(eq(paymentKey), any(), any()) } returns
+            portonePaidResponse(paymentKey, transactionId, amount.longValueExact())
+
+        // 3) /payments/confirm 호출
+        mockMvc.perform(
+            post("/payments/confirm")
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        mapOf(
+                            "reservationId" to reservationId,
+                            "paymentId" to paymentId,
+                            "paymentKey" to paymentKey,
+                            "transactionId" to transactionId,
+                            "amount" to amount
+                        )
+                    )
+                )
+        ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("SUCCESS"))
+
+        // 4) Payment 상태 검증
+        val payment = paymentRepository.findById(paymentId).orElseThrow()
+        payment.status shouldBe PaymentStatus.SUCCESS
+        payment.portoneTransactionId shouldBe transactionId
+
+        // 5) outbox PaymentSuccess row 검증
+        val outboxRows = outboxEventRepository.findAll()
+        outboxRows.size shouldBe 1
+        val row = outboxRows.single()
+        row.aggregateType shouldBe "Payment"
+        row.eventType shouldBe "PaymentSuccess"
+        row.aggregateId shouldBe paymentId
+        row.published shouldBe false
+
+        // 6) SOT 계약: row.id == payload.eventId
+        val payload = objectMapper.readValue<PaymentSuccessEvent>(row.payload)
+        row.id shouldBe payload.eventId
+        payload.reservationId shouldBe reservationId
+        payload.paymentKey shouldBe paymentKey
+        payload.portoneTransactionId shouldBe transactionId
+        payload.scheduleId shouldBe scheduleId
+        payload.seatIds shouldBe seatIds
+        payload.amount.compareTo(amount) shouldBe 0
+        // SAGA root 컨벤션
+        payload.metadata.causationId shouldBe null
+        payload.metadata.userId shouldBe userId
+    }
+
+    @Test
+    @DisplayName("SAGA compensation: PortOne 응답 status != PAID 시 PaymentFailed outbox row 가 INSERT 되고 causationId=null (보상 체인 root)")
+    fun confirmFailureInsertsPaymentFailedOutboxRow() {
+        // 1) Payment(PENDING) 생성
+        val scheduleId = UUID.randomUUID()
+        val seatIds = listOf(UUID.randomUUID())
+        every { reservationServiceClient.getReservation(reservationId) } returns
+            ReservationServiceClient.ReservationDetailResponse(
+                reservationId = reservationId,
+                userId = userId,
+                scheduleId = scheduleId,
+                totalAmount = amount,
+                status = ReservationServiceClient.ReservationStatus.PENDING,
+                holdExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5),
+                seatIds = seatIds
+            )
+        justRun { portoneClient.preRegisterPayment(any(), any(), any()) }
+        val createResp = mockMvc.perform(
+            post("/payments")
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        mapOf("reservationId" to reservationId, "amount" to amount, "paymentMethod" to "CARD")
+                    )
+                )
+        ).andExpect(status().isOk).andReturn()
+        val createBody = objectMapper.readTree(createResp.response.contentAsString)
+        val paymentId = UUID.fromString(createBody.get("paymentId").asText())
+        val paymentKey = createBody.get("paymentKey").asText()
+        outboxEventRepository.deleteAll()
+
+        // 2) PortOne stub — FAILED 응답
+        val transactionId = "portone-tx-${UUID.randomUUID()}"
+        every { portoneClient.getPayment(eq(paymentKey), any(), any()) } returns
+            portoneFailedResponse(paymentKey, transactionId, amount.longValueExact())
+
+        // 3) /payments/confirm
+        mockMvc.perform(
+            post("/payments/confirm")
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        mapOf(
+                            "reservationId" to reservationId,
+                            "paymentId" to paymentId,
+                            "paymentKey" to paymentKey,
+                            "transactionId" to transactionId,
+                            "amount" to amount
+                        )
+                    )
+                )
+        ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("FAILED"))
+
+        // 4) Payment 상태
+        val payment = paymentRepository.findById(paymentId).orElseThrow()
+        payment.status shouldBe PaymentStatus.FAILED
+
+        // 5) outbox PaymentFailed row + SAGA root 컨벤션
+        val outboxRows = outboxEventRepository.findAll()
+        outboxRows.size shouldBe 1
+        val row = outboxRows.single()
+        row.aggregateType shouldBe "Payment"
+        row.eventType shouldBe "PaymentFailed"
+        row.aggregateId shouldBe paymentId
+
+        val payload = objectMapper.readValue<PaymentFailedEvent>(row.payload)
+        row.id shouldBe payload.eventId
+        payload.reservationId shouldBe reservationId
+        payload.reason.startsWith("PORTONE_STATUS_") shouldBe true
+        payload.metadata.causationId shouldBe null
+        payload.metadata.userId shouldBe userId
+    }
+
+    @Test
     @DisplayName("PortOne pre-register 실패 시 payment.status=FAILED 와 outbox_events row 1건이 INSERT 된다 (id == payload.eventId)")
     fun portoneFailureInsertsOutboxRowAtomically() {
         every { portoneClient.preRegisterPayment(any(), any(), any()) } throws
@@ -169,4 +341,41 @@ class PaymentOutboxIntegrationTest {
         payload.reservationId shouldBe reservationId
         payload.metadata.userId shouldBe userId
     }
+
+    private fun portonePaidResponse(paymentKey: String, transactionId: String, totalAmount: Long): PortonePaymentResponse =
+        portoneBaseResponse(paymentKey, transactionId, totalAmount, status = "PAID", includePaidAt = true)
+
+    private fun portoneFailedResponse(paymentKey: String, transactionId: String, totalAmount: Long): PortonePaymentResponse =
+        portoneBaseResponse(paymentKey, transactionId, totalAmount, status = "FAILED", includePaidAt = false)
+
+    private fun portoneBaseResponse(
+        paymentKey: String,
+        transactionId: String,
+        totalAmount: Long,
+        status: String,
+        includePaidAt: Boolean,
+    ): PortonePaymentResponse = PortonePaymentResponse(
+        id = paymentKey,
+        transactionId = transactionId,
+        merchantId = "m",
+        storeId = "store-test",
+        status = status,
+        amount = PortonePaymentAmount(
+            total = totalAmount,
+            taxFree = 0,
+            discount = 0,
+            paid = totalAmount,
+            cancelled = 0,
+            cancelledTaxFree = 0,
+        ),
+        currency = "KRW",
+        channel = PortoneSelectedChannel(type = "TEST", pgProvider = "stub", pgMerchantId = "m"),
+        version = "v2",
+        requestedAt = OffsetDateTime.now(ZoneOffset.UTC),
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC),
+        statusChangedAt = OffsetDateTime.now(ZoneOffset.UTC),
+        orderName = "saga-int-test",
+        customer = PortoneCustomer(),
+        paidAt = if (includePaidAt) OffsetDateTime.now(ZoneOffset.UTC) else null,
+    )
 }

--- a/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
+++ b/backend/payment-service/src/test/kotlin/com/ticketqueue/payment/service/PaymentServiceTest.kt
@@ -485,6 +485,9 @@ class PaymentServiceTest {
             captured.captured.scheduleId shouldBe scheduleId
             captured.captured.seatIds shouldBe seatIds
             captured.captured.portoneTransactionId shouldBe transactionId
+            // SAGA root 컨벤션 (#62) — Payment Service 가 발행하는 이벤트는 보상 체인의 시작점
+            captured.captured.metadata.causationId shouldBe null
+            captured.captured.metadata.userId shouldBe userId
             verify(exactly = 1) { outboxEventRecorder.record(any<PaymentSuccessEvent>()) }
         }
 
@@ -568,6 +571,9 @@ class PaymentServiceTest {
             payment.status shouldBe PaymentStatus.FAILED
             payment.failureReason shouldBe "PORTONE_STATUS_FAILED"
             captured.captured.reason shouldBe "PORTONE_STATUS_FAILED"
+            // SAGA root 컨벤션 (#62) — PaymentFailed 가 보상 체인의 시작점이므로 causationId 는 null
+            captured.captured.metadata.causationId shouldBe null
+            captured.captured.metadata.userId shouldBe userId
             verify(exactly = 1) { outboxEventRecorder.record(any<PaymentFailedEvent>()) }
         }
 


### PR DESCRIPTION
## Summary
PaymentService 가 발행하는 `PaymentSuccess` / `PaymentFailed` 이벤트가 SAGA 보상 체인의 **root** 임을 KDoc + 통합 테스트 + 단위 테스트 보강으로 잠근다.

실제 발행 로직(`recordPaymentSuccess` / `recordPaymentFailed`)은 이미 #59 (결제 승인 API), #63 (Payment Outbox) 에서 구현되었고, 보상 체인의 다음 hop (Reservation 측) 은 #53 (PR #239) 에서 구현 중이다. 본 PR 은 체인 시작점의 컨벤션과 회귀 방어 레이어를 더한다.

REQ-PAY-011 / REQ-PAY-012 / docs/architecture/05_kafka.md §3.1, §4.3

## SAGA 보상 체인 (전체)

```
Happy path:
PaymentService.confirmPayment
  └ outbox PaymentSuccess (causationId=null, SAGA root)
      ├ reservation-payment-consumer  → Reservation CONFIRMED + ticketNumber (#53)
      └ event-payment-consumer         → Seat SOLD (기존)

Compensation path:
PaymentService.confirmPayment (PortOne 실패 / amount mismatch / tx_id mismatch)
  └ outbox PaymentFailed (causationId=null, 보상 체인 root)
      └ reservation-payment-consumer  → Reservation CANCELLED
                                       + outbox ReservationCancelled
                                         (causationId = PaymentFailed.eventId)
          └ event-reservation-consumer → 좌석 AVAILABLE 복원
```

## Changes
- `PaymentService`
  - `confirmPayment` KDoc 에 happy / compensation SAGA 흐름 다이어그램 명시
  - `recordPaymentSuccess` KDoc 에 SAGA root 컨벤션 (`causationId=null`) + downstream consumer 책임 명시
  - `recordPaymentFailed` KDoc 에 보상 체인 hop 순서 + `aggregateId = payment.id` 파티션 키 설명
- `PaymentOutboxIntegrationTest` (+2 cases)
  - `confirmSuccessInsertsPaymentSuccessOutboxRow` — POST `/payments/confirm` (PortOne PAID) → `Payment(SUCCESS)` + `outbox(PaymentSuccess)` row 검증
  - `confirmFailureInsertsPaymentFailedOutboxRow`  — POST `/payments/confirm` (PortOne FAILED) → `Payment(FAILED)` + `outbox(PaymentFailed)` row 검증
  - 두 케이스 모두 `row.id == payload.eventId` (SOT 계약) + `metadata.causationId == null` (SAGA root) 까지 검증
- `PaymentServiceTest`
  - `ConfirmPayment.success` / `ConfirmPayment.portoneNotPaid` 단위 테스트에 `metadata.causationId` / `metadata.userId` SAGA root 검증 라인 추가

## Test plan
- [x] `PaymentServiceTest` 단위 테스트 — BUILD SUCCESSFUL (모든 케이스 PASS, SAGA root 검증 라인 포함)
- [x] `PaymentOutboxIntegrationTest` (TestContainers + Postgres 18-alpine) 3 cases — 모두 PASS
  - SAGA happy path (PaymentSuccess outbox)
  - SAGA compensation (PaymentFailed outbox)
  - PortOne pre-register failure (기존)
- [ ] End-to-end Kafka 체인 검증은 #53 (PR #239) 머지 후 후속 ralph 또는 통합 환경에서 수행 예정

## Notes for reviewer
- 본 PR 은 비즈니스 동작 변경 0건이며, **KDoc + 테스트 보강**만 포함한다 (회귀 위험 최소화)
- causationId / correlationId 컨벤션의 핵심은: **Payment Service 는 항상 SAGA root** → causationId 는 `null` 이어야 한다. 단위/통합 테스트가 이를 강제하므로 향후 의도치 않은 변경이 PR 시점에 잡힌다
- TASK.md claim 커밋 (`session-7f37ba3c`) 포함