### PR TITLE
feat: [User] 회원 탈퇴 API 구현 (#29)

### DIFF
--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/UserController.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/controller/UserController.kt
@@ -5,9 +5,11 @@ import com.ticketqueue.user.dto.UserDto
 import com.ticketqueue.user.exception.UserException
 import com.ticketqueue.user.service.UserService
 import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -50,6 +52,19 @@ class UserController(
         val userId = parseUserId(principal)
         logger.info { "Password change request: userId=$userId" }
         userService.changePassword(userId, request)
+    }
+
+    @DeleteMapping("/me")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun withdraw(
+        @AuthenticationPrincipal principal: String?,
+        httpRequest: HttpServletRequest,
+    ) {
+        val userId = parseUserId(principal)
+        val authHeader = httpRequest.getHeader("Authorization")
+            ?: throw UserException(ErrorCode.UNAUTHORIZED)
+        logger.info { "Withdraw request: userId=$userId" }
+        userService.withdraw(userId, authHeader)
     }
 
     private fun parseUserId(principal: String?): UUID {

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/entity/User.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/entity/User.kt
@@ -53,7 +53,7 @@ class User(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    val status: UserStatus = UserStatus.ACTIVE,
+    var status: UserStatus = UserStatus.ACTIVE,
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepositoryCustom.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepositoryCustom.kt
@@ -5,4 +5,6 @@ import java.util.UUID
 
 interface RefreshTokenRepositoryCustom {
     fun revokeAllActiveByTokenFamily(tokenFamily: UUID, now: LocalDateTime): Long
+
+    fun revokeAllActiveByUserId(userId: UUID, now: LocalDateTime): Long
 }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepositoryCustomImpl.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/repository/RefreshTokenRepositoryCustomImpl.kt
@@ -21,4 +21,17 @@ class RefreshTokenRepositoryCustomImpl(
             )
             .execute()
     }
+
+    override fun revokeAllActiveByUserId(userId: UUID, now: LocalDateTime): Long {
+        val token = QRefreshToken.refreshToken
+        return queryFactory
+            .update(token)
+            .set(token.revoked, true)
+            .set(token.revokedAt, now)
+            .where(
+                token.user.id.eq(userId),
+                token.revoked.isFalse
+            )
+            .execute()
+    }
 }

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/UserService.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/service/UserService.kt
@@ -1,14 +1,18 @@
 package com.ticketqueue.user.service
 
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.user.config.JwtProperties
 import com.ticketqueue.user.dto.UserDto
 import com.ticketqueue.user.entity.UserStatus
 import com.ticketqueue.user.exception.UserException
+import com.ticketqueue.user.repository.RefreshTokenRepository
 import com.ticketqueue.user.repository.UserRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 @Service
@@ -16,6 +20,10 @@ class UserService(
     private val userRepository: UserRepository,
     private val encryptionService: EncryptionService,
     private val passwordEncoder: PasswordEncoder,
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val tokenBlacklistService: TokenBlacklistService,
+    private val jwtProperties: JwtProperties,
 ) {
     private val logger = KotlinLogging.logger {}
 
@@ -75,5 +83,30 @@ class UserService(
         user.passwordHash = passwordEncoder.encode(request.newPassword)
 
         logger.info { "Password changed: userId=$userId" }
+    }
+
+    @Transactional
+    fun withdraw(userId: UUID, authorizationHeader: String) {
+        if (!authorizationHeader.startsWith("Bearer ")) {
+            throw UserException(ErrorCode.UNAUTHORIZED)
+        }
+        val accessToken = authorizationHeader.removePrefix("Bearer ")
+        val jti = jwtTokenProvider.parseAccessTokenJti(accessToken)
+
+        val user = userRepository.findById(userId)
+            .orElseThrow { UserException(ErrorCode.RESOURCE_NOT_FOUND) }
+
+        if (user.status == UserStatus.DELETED) {
+            throw UserException(ErrorCode.RESOURCE_NOT_FOUND)
+        }
+
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        user.status = UserStatus.DELETED
+        user.deletedAt = now
+
+        val revokedCount = refreshTokenRepository.revokeAllActiveByUserId(userId, now)
+        tokenBlacklistService.addToBlacklist(jti, jwtProperties.accessTokenExpiry)
+
+        logger.info { "User withdrawn: userId=$userId, refreshTokensRevoked=$revokedCount" }
     }
 }

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/controller/UserControllerTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/controller/UserControllerTest.kt
@@ -27,6 +27,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
@@ -300,6 +301,84 @@ class UserControllerTest {
             performPut(validRequest)
                 .andExpect(status().isNotFound)
                 .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /users/me")
+    inner class Withdraw {
+
+        private val authHeader = "Bearer valid.access.token"
+
+        @Test
+        @DisplayName("정상 탈퇴 시 204 NO CONTENT")
+        fun shouldReturn204() {
+            every { userService.withdraw(userId, authHeader) } just Runs
+
+            mockMvc.perform(
+                delete("/users/me")
+                    .with(csrf())
+                    .header("X-User-Id", userId.toString())
+                    .header("X-User-Role", "USER")
+                    .header("Authorization", authHeader)
+            ).andExpect(status().isNoContent)
+        }
+
+        @Test
+        @DisplayName("Authorization 헤더 누락 시 401 UNAUTHORIZED")
+        fun shouldReturn401WhenAuthHeaderMissing() {
+            mockMvc.perform(
+                delete("/users/me")
+                    .with(csrf())
+                    .header("X-User-Id", userId.toString())
+                    .header("X-User-Role", "USER")
+            )
+                .andExpect(status().isUnauthorized)
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+        }
+
+        @Test
+        @DisplayName("Gateway 인증 헤더 누락 시 401 UNAUTHORIZED")
+        fun shouldReturn401WhenGatewayHeadersMissing() {
+            mockMvc.perform(
+                delete("/users/me")
+                    .with(csrf())
+                    .header("Authorization", authHeader)
+            ).andExpect(status().isUnauthorized)
+        }
+
+        @Test
+        @DisplayName("이미 탈퇴된 사용자 시 404 NOT FOUND")
+        fun shouldReturn404WhenAlreadyDeleted() {
+            every { userService.withdraw(userId, authHeader) } throws
+                BusinessException(ErrorCode.RESOURCE_NOT_FOUND)
+
+            mockMvc.perform(
+                delete("/users/me")
+                    .with(csrf())
+                    .header("X-User-Id", userId.toString())
+                    .header("X-User-Role", "USER")
+                    .header("Authorization", authHeader)
+            )
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
+        }
+
+        @Test
+        @DisplayName("Access Token 검증 실패 시 401 UNAUTHORIZED")
+        fun shouldReturn401WhenTokenInvalid() {
+            every { userService.withdraw(userId, authHeader) } throws
+                BusinessException(ErrorCode.INVALID_TOKEN)
+
+            mockMvc.perform(
+                delete("/users/me")
+                    .with(csrf())
+                    .header("X-User-Id", userId.toString())
+                    .header("X-User-Role", "USER")
+                    .header("Authorization", authHeader)
+            )
+                .andExpect(status().isUnauthorized)
+                .andExpect(jsonPath("$.code").value("INVALID_TOKEN"))
         }
     }
 }

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/UserServiceTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/UserServiceTest.kt
@@ -1,16 +1,21 @@
 package com.ticketqueue.user.service
 
 import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.user.config.JwtProperties
 import com.ticketqueue.user.dto.UserDto
 import com.ticketqueue.user.entity.User
 import com.ticketqueue.user.entity.UserRole
 import com.ticketqueue.user.entity.UserStatus
 import com.ticketqueue.user.exception.UserException
+import com.ticketqueue.user.repository.RefreshTokenRepository
 import com.ticketqueue.user.repository.UserRepository
 import io.kotest.matchers.shouldBe
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.verifyOrder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -27,6 +32,10 @@ class UserServiceTest {
     private lateinit var userRepository: UserRepository
     private lateinit var encryptionService: EncryptionService
     private lateinit var passwordEncoder: PasswordEncoder
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+    private lateinit var tokenBlacklistService: TokenBlacklistService
+    private lateinit var jwtProperties: JwtProperties
     private lateinit var userService: UserService
 
     private val userId = UUID.randomUUID()
@@ -37,7 +46,19 @@ class UserServiceTest {
         userRepository = mockk()
         encryptionService = mockk()
         passwordEncoder = mockk()
-        userService = UserService(userRepository, encryptionService, passwordEncoder)
+        refreshTokenRepository = mockk()
+        jwtTokenProvider = mockk()
+        tokenBlacklistService = mockk(relaxed = true)
+        jwtProperties = mockk()
+        userService = UserService(
+            userRepository,
+            encryptionService,
+            passwordEncoder,
+            refreshTokenRepository,
+            jwtTokenProvider,
+            tokenBlacklistService,
+            jwtProperties,
+        )
     }
 
     private fun createUser(
@@ -226,6 +247,90 @@ class UserServiceTest {
             exception.errorCode shouldBe ErrorCode.INVALID_CREDENTIALS
             user.passwordHash shouldBe "old-hash"
             verify(exactly = 0) { passwordEncoder.encode(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("withdraw")
+    inner class Withdraw {
+
+        private val jti = "test-jti-uuid"
+        private val accessToken = "valid.access.token"
+        private val authHeader = "Bearer $accessToken"
+
+        @Test
+        @DisplayName("정상 탈퇴 - status DELETED, deleted_at 기록, refresh token revoke, 블랙리스트 등록")
+        fun shouldWithdrawSuccessfully() {
+            val user = createUser()
+            every { jwtTokenProvider.parseAccessTokenJti(accessToken) } returns jti
+            every { userRepository.findById(userId) } returns Optional.of(user)
+            every { refreshTokenRepository.revokeAllActiveByUserId(eq(userId), any()) } returns 3L
+            every { jwtProperties.accessTokenExpiry } returns 3_600_000L
+
+            userService.withdraw(userId, authHeader)
+
+            user.status shouldBe UserStatus.DELETED
+            (user.deletedAt != null) shouldBe true
+            verifyOrder {
+                refreshTokenRepository.revokeAllActiveByUserId(eq(userId), any())
+                tokenBlacklistService.addToBlacklist(jti, 3_600_000L)
+            }
+        }
+
+        @Test
+        @DisplayName("Authorization 헤더에 Bearer 접두사 없음 - UNAUTHORIZED")
+        fun shouldThrowWhenInvalidAuthHeader() {
+            val exception = assertThrows<UserException> {
+                userService.withdraw(userId, "InvalidHeader")
+            }
+            exception.errorCode shouldBe ErrorCode.UNAUTHORIZED
+            verify(exactly = 0) { jwtTokenProvider.parseAccessTokenJti(any()) }
+            verify(exactly = 0) { userRepository.findById(any()) }
+            verify(exactly = 0) { refreshTokenRepository.revokeAllActiveByUserId(any(), any()) }
+            verify(exactly = 0) { tokenBlacklistService.addToBlacklist(any(), any()) }
+        }
+
+        @Test
+        @DisplayName("Access Token 검증 실패 - 예외 전파, DB/Redis 미호출")
+        fun shouldPropagateJwtError() {
+            every { jwtTokenProvider.parseAccessTokenJti(accessToken) } throws
+                UserException(ErrorCode.INVALID_TOKEN)
+
+            val exception = assertThrows<UserException> {
+                userService.withdraw(userId, authHeader)
+            }
+            exception.errorCode shouldBe ErrorCode.INVALID_TOKEN
+            verify(exactly = 0) { userRepository.findById(any()) }
+            verify(exactly = 0) { tokenBlacklistService.addToBlacklist(any(), any()) }
+        }
+
+        @Test
+        @DisplayName("사용자 없음 - RESOURCE_NOT_FOUND, 블랙리스트 미등록")
+        fun shouldThrowWhenUserNotFound() {
+            every { jwtTokenProvider.parseAccessTokenJti(accessToken) } returns jti
+            every { userRepository.findById(userId) } returns Optional.empty()
+
+            val exception = assertThrows<UserException> {
+                userService.withdraw(userId, authHeader)
+            }
+            exception.errorCode shouldBe ErrorCode.RESOURCE_NOT_FOUND
+            verify(exactly = 0) { refreshTokenRepository.revokeAllActiveByUserId(any(), any()) }
+            verify(exactly = 0) { tokenBlacklistService.addToBlacklist(any(), any()) }
+        }
+
+        @Test
+        @DisplayName("이미 탈퇴된 사용자 - RESOURCE_NOT_FOUND, 추가 작업 없음")
+        fun shouldThrowWhenAlreadyDeleted() {
+            val user = createUser(status = UserStatus.DELETED)
+            every { jwtTokenProvider.parseAccessTokenJti(accessToken) } returns jti
+            every { userRepository.findById(userId) } returns Optional.of(user)
+
+            val exception = assertThrows<UserException> {
+                userService.withdraw(userId, authHeader)
+            }
+            exception.errorCode shouldBe ErrorCode.RESOURCE_NOT_FOUND
+            verify(exactly = 0) { refreshTokenRepository.revokeAllActiveByUserId(any(), any()) }
+            verify(exactly = 0) { tokenBlacklistService.addToBlacklist(any(), any()) }
         }
     }
 }


### PR DESCRIPTION
## Summary
- `DELETE /users/me` 엔드포인트 추가 (REQ-AUTH-017)
- **Soft delete**: `user.status = DELETED`, `user.deletedAt = now()` (UTC)
- **모든 Refresh Token 무효화**: `RefreshTokenRepositoryCustom.revokeAllActiveByUserId(userId, now)` 신설
- **Access Token 블랙리스트 등록**: Authorization 헤더에서 jti 추출 → Redis TTL = `accessTokenExpiry`
- `AuthService.logout` 패턴 차용으로 코드 일관성 유지 (Bearer 파싱 → jti 추출 → DB 트랜잭션 → Redis)
- `User.status`를 `var`로 전환하여 JPA dirty checking 활용
- 응답: 204 No Content
- 단위 테스트: `UserServiceTest.Withdraw` 5개, `UserControllerTest.Withdraw` 5개

> **Stacked on #241**: PR base를 `feature/28-user-password-change`로 지정. 선행 PR들(#240→#241→#229)이 머지되면 base가 자동으로 `develop`으로 전환됩니다.

> **별도 이슈**: 개인정보 30일 파기 배치는 `deleted_at` 컬럼을 기반으로 동작할 예정 (이번 PR 범위 밖)

Closes #29

## Test plan
- [x] `./gradlew :user-service:test` — 신규/기존 테스트 모두 통과
- [ ] Gateway 경유 통합 테스트: DELETE 후 동일 access token으로 보호된 API 호출 → 401 확인
- [ ] 동일 사용자의 활성 refresh token들이 모두 revoked=true로 변경되는지 통합 검증