### PR TITLE
feat: [Frontend] 결제 완료/실패 페이지 (#120)

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -110,7 +110,7 @@ Outbox 위에서 동작하거나 완전히 독립적인 핵심 백엔드 API. **
 |---|------|-------|-------|------|-------|--------|----|
 | 14 | [ ] | [#121](https://github.com/paircoders/ticket-queue/issues/121) | [Frontend] 마이페이지 (프로필, 예매 내역) | (#27), (#52) |  | `feature/121-frontend-mypage` |  |
 | 15 | [ ] | [#119](https://github.com/paircoders/ticket-queue/issues/119) | [Frontend] 결제 페이지 (PortOne SDK, 3단계 결제 플로우) | (#59) |  | `feature/119-frontend-payment` |  |
-| 16 | [ ] | [#120](https://github.com/paircoders/ticket-queue/issues/120) | [Frontend] 결제 완료/실패 페이지 | #119 | session-0e341b7a | `feature/120-frontend-payment-result` |  |
+| 16 | [ ] | [#120](https://github.com/paircoders/ticket-queue/issues/120) | [Frontend] 결제 완료/실패 페이지 | #119 | session-0e341b7a | `feature/120-frontend-payment-result` | [#246](https://github.com/paircoders/ticket-queue/pull/246) |
 | 17 | [ ] | [#122](https://github.com/paircoders/ticket-queue/issues/122) | [Frontend] 성능 최적화, SEO 마무리, 번들 분석 | #119, #120, #121 |  | `feature/122-frontend-perf-seo` |  |
 
 ---

--- a/TASK.md
+++ b/TASK.md
@@ -110,7 +110,7 @@ Outbox 위에서 동작하거나 완전히 독립적인 핵심 백엔드 API. **
 |---|------|-------|-------|------|-------|--------|----|
 | 14 | [ ] | [#121](https://github.com/paircoders/ticket-queue/issues/121) | [Frontend] 마이페이지 (프로필, 예매 내역) | (#27), (#52) |  | `feature/121-frontend-mypage` |  |
 | 15 | [ ] | [#119](https://github.com/paircoders/ticket-queue/issues/119) | [Frontend] 결제 페이지 (PortOne SDK, 3단계 결제 플로우) | (#59) |  | `feature/119-frontend-payment` |  |
-| 16 | [ ] | [#120](https://github.com/paircoders/ticket-queue/issues/120) | [Frontend] 결제 완료/실패 페이지 | #119 |  | `feature/120-frontend-payment-result` |  |
+| 16 | [ ] | [#120](https://github.com/paircoders/ticket-queue/issues/120) | [Frontend] 결제 완료/실패 페이지 | #119 | session-0e341b7a | `feature/120-frontend-payment-result` |  |
 | 17 | [ ] | [#122](https://github.com/paircoders/ticket-queue/issues/122) | [Frontend] 성능 최적화, SEO 마무리, 번들 분석 | #119, #120, #121 |  | `feature/122-frontend-perf-seo` |  |
 
 ---

--- a/frontend/src/app/(main)/payment/complete/page.tsx
+++ b/frontend/src/app/(main)/payment/complete/page.tsx
@@ -1,15 +1,21 @@
 'use client'
 
+import { Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { PaymentComplete } from '@/components/domain/payment/PaymentComplete'
+
 export default function PaymentCompletePage() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-spacing-xl">
-      <div className="max-w-2xl text-center">
-        <h1 className="mb-spacing-lg text-4xl font-bold text-gray-900">결제 완료</h1>
-        <p className="text-gray-600">결제가 성공적으로 완료되었습니다.</p>
-        <p className="mt-spacing-md text-gray-500">
-          예매 내역은 마이페이지에서 확인하실 수 있습니다.
-        </p>
-      </div>
+    <main className="mx-auto flex min-h-[70vh] max-w-2xl flex-col items-center justify-center px-spacing-md py-spacing-xl">
+      <Suspense fallback={null}>
+        <PaymentCompleteContent />
+      </Suspense>
     </main>
   )
+}
+
+function PaymentCompleteContent() {
+  const params = useSearchParams()
+  const reservationId = params.get('reservationId')
+  return <PaymentComplete reservationId={reservationId} />
 }

--- a/frontend/src/app/(main)/payment/failed/page.tsx
+++ b/frontend/src/app/(main)/payment/failed/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { PaymentFailed } from '@/components/domain/payment/PaymentFailed'
+
+export default function PaymentFailedPage() {
+  return (
+    <main className="mx-auto flex min-h-[70vh] max-w-2xl flex-col items-center justify-center px-spacing-md py-spacing-xl">
+      <Suspense fallback={null}>
+        <PaymentFailedContent />
+      </Suspense>
+    </main>
+  )
+}
+
+function PaymentFailedContent() {
+  const params = useSearchParams()
+  const reservationId = params.get('reservationId')
+  const scheduleId = params.get('scheduleId')
+  const reason = params.get('reason')
+  const message = params.get('message')
+
+  return (
+    <PaymentFailed
+      reservationId={reservationId}
+      scheduleId={scheduleId}
+      reason={reason}
+      message={message}
+    />
+  )
+}

--- a/frontend/src/components/domain/payment/PaymentComplete.tsx
+++ b/frontend/src/components/domain/payment/PaymentComplete.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import Link from 'next/link'
+import { CheckCircle2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface PaymentCompleteProps {
+  reservationId?: string | null
+}
+
+export function PaymentComplete({ reservationId }: PaymentCompleteProps) {
+  const reservationsHref = reservationId
+    ? `/mypage/reservations/${reservationId}`
+    : '/mypage/reservations'
+
+  return (
+    <section
+      role="status"
+      aria-live="polite"
+      className="mx-auto flex max-w-md flex-col items-center gap-4 rounded-xl border bg-card p-8 text-center shadow-sm"
+    >
+      <CheckCircle2
+        className="size-16 text-success"
+        aria-hidden="true"
+      />
+      <h2 className="text-2xl font-bold">예매가 완료되었습니다!</h2>
+      <p className="text-sm text-muted-foreground">
+        결제가 정상적으로 처리되었어요. 자세한 예매 내역은 마이페이지에서
+        확인하실 수 있습니다.
+      </p>
+      {reservationId && (
+        <p className="text-xs text-muted-foreground">
+          예매번호: <span className="font-mono">{reservationId}</span>
+        </p>
+      )}
+      <div className="mt-2 flex w-full flex-col gap-2 sm:flex-row sm:justify-center">
+        <Button asChild className="flex-1">
+          <Link href={reservationsHref}>예매 내역 확인</Link>
+        </Button>
+        <Button asChild variant="outline" className="flex-1">
+          <Link href="/">홈으로 돌아가기</Link>
+        </Button>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/domain/payment/PaymentFailed.tsx
+++ b/frontend/src/components/domain/payment/PaymentFailed.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { XCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+const REASON_MESSAGES: Record<string, string> = {
+  HOLD_EXPIRED: '좌석 선점 시간이 만료되어 결제가 취소되었습니다. 좌석을 다시 선택해주세요.',
+  USER_CANCEL: '결제를 취소했습니다. 다시 시도하실 수 있습니다.',
+  PAYMENT_FAILED: '결제 승인이 실패했습니다. 잠시 후 다시 시도해주세요.',
+  DUPLICATE_PAYMENT: '이미 처리된 결제입니다.',
+}
+
+interface PaymentFailedProps {
+  reservationId?: string | null
+  scheduleId?: string | null
+  reason?: string | null
+  message?: string | null
+}
+
+export function PaymentFailed({
+  reservationId,
+  scheduleId,
+  reason,
+  message,
+}: PaymentFailedProps) {
+  const router = useRouter()
+  const description =
+    message || (reason ? REASON_MESSAGES[reason] : null) ||
+    '결제 처리 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.'
+
+  const canRetry =
+    reason !== 'HOLD_EXPIRED' && reason !== 'DUPLICATE_PAYMENT'
+
+  return (
+    <section
+      role="alert"
+      aria-live="assertive"
+      className="mx-auto flex max-w-md flex-col items-center gap-4 rounded-xl border bg-card p-8 text-center shadow-sm"
+    >
+      <XCircle className="size-16 text-danger" aria-hidden="true" />
+      <h2 className="text-2xl font-bold">결제에 실패했습니다</h2>
+      <p className="text-sm text-muted-foreground">{description}</p>
+
+      <div className="mt-2 flex w-full flex-col gap-2 sm:flex-row sm:justify-center">
+        {canRetry && reservationId && (
+          <Button
+            className="flex-1"
+            onClick={() => router.replace(`/payment/${reservationId}`)}
+          >
+            다시 시도하기
+          </Button>
+        )}
+        {scheduleId && (
+          <Button
+            asChild
+            variant={canRetry && reservationId ? 'outline' : 'primary'}
+            className="flex-1"
+          >
+            <Link href={`/reservation/${scheduleId}`}>좌석 다시 선택</Link>
+          </Button>
+        )}
+        <Button asChild variant="ghost" className="flex-1">
+          <Link href="/">홈으로</Link>
+        </Button>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/domain/payment/__tests__/PaymentFailed.test.tsx
+++ b/frontend/src/components/domain/payment/__tests__/PaymentFailed.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+jest.mock('next/navigation', () => ({ useRouter: jest.fn() }))
+
+import { PaymentFailed } from '../PaymentFailed'
+import { useRouter } from 'next/navigation'
+
+describe('PaymentFailed', () => {
+  const mockReplace = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.mocked(useRouter).mockReturnValue({ replace: mockReplace } as any)
+  })
+
+  it('reason=PAYMENT_FAILED 일 때 재시도 버튼이 노출되고 결제 페이지로 이동한다', async () => {
+    const user = userEvent.setup()
+    render(
+      <PaymentFailed
+        reservationId="res-1"
+        scheduleId="sched-1"
+        reason="PAYMENT_FAILED"
+      />
+    )
+    expect(screen.getByText(/결제 승인이 실패했습니다/)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '다시 시도하기' }))
+    expect(mockReplace).toHaveBeenCalledWith('/payment/res-1')
+  })
+
+  it('HOLD_EXPIRED 일 때 재시도 버튼은 노출되지 않고 좌석 다시 선택만 제공된다', () => {
+    render(
+      <PaymentFailed
+        reservationId="res-1"
+        scheduleId="sched-1"
+        reason="HOLD_EXPIRED"
+      />
+    )
+    expect(
+      screen.queryByRole('button', { name: '다시 시도하기' })
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '좌석 다시 선택' })).toBeInTheDocument()
+    expect(screen.getByText(/좌석 선점 시간이 만료되어/)).toBeInTheDocument()
+  })
+
+  it('message가 직접 주어지면 reason 메시지보다 우선한다', () => {
+    render(
+      <PaymentFailed
+        reservationId="res-1"
+        reason="PAYMENT_FAILED"
+        message="네트워크 오류로 결제가 중단되었습니다."
+      />
+    )
+    expect(
+      screen.getByText('네트워크 오류로 결제가 중단되었습니다.')
+    ).toBeInTheDocument()
+  })
+
+  it('DUPLICATE_PAYMENT 일 때 재시도 버튼이 노출되지 않는다', () => {
+    render(<PaymentFailed reservationId="res-1" reason="DUPLICATE_PAYMENT" />)
+    expect(
+      screen.queryByRole('button', { name: '다시 시도하기' })
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('이미 처리된 결제입니다.')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- `/payment/complete` 페이지 강화 — useSearchParams로 reservationId 받아 동적 표시, 예매 내역/홈 액션 버튼
- `/payment/failed` 페이지 신규 — reason/message 쿼리에 따라 동적 메시지와 재시도/좌석 재선택/홈 액션 분기
- `components/domain/payment/PaymentComplete` 및 `PaymentFailed` 분리 (재사용 가능)
- HOLD_EXPIRED, USER_CANCEL, PAYMENT_FAILED, DUPLICATE_PAYMENT 사유별 안내 분기
- PaymentFailed 단위 테스트 4건 추가

## 변경된 파일
- `frontend/src/app/(main)/payment/complete/page.tsx`
- `frontend/src/app/(main)/payment/failed/page.tsx`
- `frontend/src/components/domain/payment/PaymentComplete.tsx`
- `frontend/src/components/domain/payment/PaymentFailed.tsx`
- `frontend/src/components/domain/payment/__tests__/PaymentFailed.test.tsx`
- `TASK.md` — #120 claim

## 검증
- [x] `npm test` 전체 통과 (PaymentFailed 4건 신규)
- [x] `npm run build` 성공 (`/payment/complete`, `/payment/failed` 라우트 생성)

## Test plan
- [ ] 결제 완료 후 `/payment/complete?reservationId=...` 접근 → 예매번호 + 액션 버튼
- [ ] `/payment/failed?reason=PAYMENT_FAILED&reservationId=...` 접근 → 다시 시도 버튼이 결제 페이지로 이동
- [ ] `/payment/failed?reason=HOLD_EXPIRED&scheduleId=...` 접근 → 재시도 버튼 숨김 + 좌석 다시 선택만 노출

> 본 PR은 #119(결제 페이지)와 독립적인 컴포넌트만 추가하므로 #119 머지 전이라도 충돌 없음. #119 머지 후 PaymentWidget의 실패 redirect 타깃을 `/payment/failed?reason=...`로 연결하는 follow-up이 가능하다.

Refs #120