### PR TITLE
fix: [Common/Test] OutboxPollerIntegrationTest race condition layer 해소 (#231)

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -115,6 +115,17 @@ Outbox 위에서 동작하거나 완전히 독립적인 핵심 백엔드 API. **
 
 ---
 
+## Bug Fixes — Test Infrastructure
+
+| # | Done | Issue | Title | Deps | Claim | Branch | PR |
+|---|------|-------|-------|------|-------|--------|----|
+| B1 | [ ] | [#231](https://github.com/paircoders/ticket-queue/issues/231) | [Common/Test] OutboxPollerIntegrationTest race fix (single-thread polling) | — | session-ralph-231 | `fix/231-outbox-poller-integration-test-flaky` |  |
+| B2 | [ ] | [#248](https://github.com/paircoders/ticket-queue/issues/248) | [Common/Test] common-kafka 통합 테스트 환경 — @ServiceConnection + KafkaContainer 불안정 | — |  | `fix/248-common-kafka-test-env` |  |
+
+> #231 fix 는 race condition layer (CME 0 건, single-thread polling 도입) 만 해결. 6/6 green acceptance 는 #248 환경 fix 후 검증 가능.
+
+---
+
 ## 진행 현황 요약
 
 - **총 17 이슈** · 완료 8 (`#228`, `#55`, `#63`, `#59`, `#61`, `#54`, `#52`, `#64`) · 진행 중 0 · 미시작 9

--- a/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxPollerIntegrationTest.kt
+++ b/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxPollerIntegrationTest.kt
@@ -4,16 +4,23 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.AdminClientConfig
+import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.awaitility.Awaitility.await
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection
 import org.springframework.context.annotation.Import
-import org.springframework.kafka.support.serializer.JsonDeserializer
 import org.springframework.test.context.ActiveProfiles
 import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.containers.PostgreSQLContainer
@@ -22,9 +29,10 @@ import org.testcontainers.junit.jupiter.Testcontainers
 import org.testcontainers.utility.DockerImageName
 import java.time.Duration
 import java.time.LocalDateTime
-import java.util.*
-import java.util.concurrent.ConcurrentHashMap
+import java.util.Properties
+import java.util.UUID
 
+// TODO: 동일 패턴이 다른 모듈에서 필요해질 경우 :common-kafka:test fixture 로 추출 (별도 follow-up 이슈)
 @SpringBootTest
 @Import(OutboxPollerTestConfig::class)
 @ActiveProfiles("test")
@@ -35,6 +43,7 @@ class OutboxPollerIntegrationTest {
     companion object {
         @Container
         @ServiceConnection
+        @JvmStatic
         val postgres = PostgreSQLContainer<Nothing>(DockerImageName.parse("postgres:18-alpine"))
             .apply {
                 withDatabaseName("testdb")
@@ -45,6 +54,7 @@ class OutboxPollerIntegrationTest {
 
         @Container
         @ServiceConnection
+        @JvmStatic
         val kafka = KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.8.0"))
             .apply {
                 withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "true")
@@ -57,41 +67,85 @@ class OutboxPollerIntegrationTest {
     @Autowired
     private lateinit var pollerService: OutboxPollerService
 
-    private lateinit var kafkaTestConsumer: KafkaTestConsumer
+    private lateinit var kafkaConsumer: KafkaConsumer<String, String>
 
+    /**
+     * 클래스 lifetime 동안 한 번만 실행: 토픽을 명시적으로 사전 생성한다.
+     *
+     * 이유: subscribe() + assignment-wait + seekToEnd 패턴은 broker 에 토픽이 사전 존재해야
+     * partition assignment 가 즉시 완료된다. KAFKA_AUTO_CREATE_TOPICS_ENABLE=true 는
+     * producer 의 send() 가 트리거하므로 consumer subscribe 만으로는 토픽 자동 생성이 안 된다.
+     * 토픽이 없으면 assignment-wait-loop 가 10s deadline 까지 대기 후 seekToEnd(empty set) 가
+     * no-op 으로 끝나, 이후 발행되는 메시지의 수신 시점이 불확정적이 된다.
+     */
     @BeforeAll
-    fun setupKafkaConsumer() {
-        kafkaTestConsumer = KafkaTestConsumer(kafka.bootstrapServers)
-    }
-
-    @AfterAll
-    fun tearDownKafkaConsumer() {
-        kafkaTestConsumer.close()
+    fun createTopicsOnce() {
+        val adminProps = Properties().apply {
+            put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.bootstrapServers)
+        }
+        AdminClient.create(adminProps).use { admin ->
+            admin.createTopics(
+                listOf(
+                    NewTopic("payment.events", 1, 1.toShort()),
+                    NewTopic("reservation.events", 1, 1.toShort())
+                )
+            ).all().get()
+        }
     }
 
     @BeforeEach
-    fun cleanupDatabase() {
+    fun cleanupAndSetup() {
         outboxEventRepository.deleteAll()
-        kafkaTestConsumer.clearReceivedMessages()
+
+        val props = Properties().apply {
+            put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.bootstrapServers)
+            put(ConsumerConfig.GROUP_ID_CONFIG, "outbox-poller-test-${UUID.randomUUID()}")
+            put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+            put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+            put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java.name)
+            put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java.name)
+        }
+        kafkaConsumer = KafkaConsumer(props)
+        kafkaConsumer.subscribe(listOf("payment.events", "reservation.events"))
+
+        // partition assignment 완료까지 명시적 대기 — 단일 poll(100ms) 만으로는 CI 환경에서
+        // consumer group rebalance 가 끝나기 전에 메시지가 발행될 수 있어 메시지가 누락된다.
+        val assignmentDeadline = System.currentTimeMillis() + 10_000
+        while (kafkaConsumer.assignment().isEmpty() && System.currentTimeMillis() < assignmentDeadline) {
+            kafkaConsumer.poll(Duration.ofMillis(200))
+        }
+
+        // Inter-test broker bleed 처리 전략: payload-level filtering (각 테스트가 자신의
+        // aggregateId 매칭 메시지만 카운트) — broker offset/position 메커니즘에 의존하지 않음.
+        // See #231 — seekToEnd 는 단일 broker + multi-test 환경에서 timing-sensitive 하여
+        // 안정적이지 않았다. KafkaContainer 가 클래스 전역에 공유되므로 토픽 retention 으로
+        // 직전 테스트 메시지가 broker 에 잔존하지만, pollUntilFound 의 filter 인자로
+        // 본 테스트의 메시지만 매칭하면 isolation 이 달성된다.
+        // Requires serial test execution (no method-level parallelism) — see #231
+    }
+
+    @AfterEach
+    fun closeConsumer() {
+        if (::kafkaConsumer.isInitialized) kafkaConsumer.close()
     }
 
     @Test
     fun `이벤트_INSERT_후_1초내_Kafka_발행_확인`() {
         // Given
         val aggregateId = UUID.randomUUID()
+        val payload = createPaymentPayload(aggregateId)
         val event = outboxEventRepository.save(
             OutboxEvent(
                 id = UUID.randomUUID(),
                 aggregateType = "Payment",
                 aggregateId = aggregateId,
                 eventType = "PaymentSuccess",
-                payload = createPaymentPayload(aggregateId),
+                payload = payload,
                 published = false
             )
         )
 
         // When - Poller runs automatically every 1 second
-        // Wait for event to be published
         await()
             .atMost(Duration.ofSeconds(5))
             .pollInterval(Duration.ofMillis(500))
@@ -101,15 +155,10 @@ class OutboxPollerIntegrationTest {
                 savedEvent.publishedAt shouldNotBe null
             }
 
-        // Then - Verify Kafka message received
-        await()
-            .atMost(Duration.ofSeconds(2))
-            .pollInterval(Duration.ofMillis(200))
-            .untilAsserted {
-                val messages = kafkaTestConsumer.getMessages("payment.events")
-                messages shouldHaveSize 1
-                messages[0] shouldBe createPaymentPayload(aggregateId)
-            }
+        // Then - Verify Kafka message received (payload-level filter 로 inter-test isolation)
+        val messages = pollUntilFound("payment.events", expectedCount = 1, timeoutSeconds = 5) { it == payload }
+        messages shouldHaveSize 1
+        messages[0] shouldBe payload
     }
 
     @Test
@@ -128,17 +177,9 @@ class OutboxPollerIntegrationTest {
             )
         )
 
-        // When
-        await()
-            .atMost(Duration.ofSeconds(5))
-            .pollInterval(Duration.ofMillis(500))
-            .untilAsserted {
-                val messages = kafkaTestConsumer.getMessages("payment.events")
-                messages shouldHaveSize 1
-            }
-
-        // Then
-        val messages = kafkaTestConsumer.getMessages("payment.events")
+        // When/Then — poller(1s cycle) + Kafka 수신을 pollUntilFound 가 함께 대기
+        val messages = pollUntilFound("payment.events", expectedCount = 1, timeoutSeconds = 5) { it == payload }
+        messages shouldHaveSize 1
         messages[0] shouldBe payload
     }
 
@@ -158,17 +199,9 @@ class OutboxPollerIntegrationTest {
             )
         )
 
-        // When
-        await()
-            .atMost(Duration.ofSeconds(5))
-            .pollInterval(Duration.ofMillis(500))
-            .untilAsserted {
-                val messages = kafkaTestConsumer.getMessages("reservation.events")
-                messages shouldHaveSize 1
-            }
-
-        // Then
-        val messages = kafkaTestConsumer.getMessages("reservation.events")
+        // When/Then
+        val messages = pollUntilFound("reservation.events", expectedCount = 1, timeoutSeconds = 5) { it == payload }
+        messages shouldHaveSize 1
         messages[0] shouldBe payload
     }
 
@@ -207,28 +240,22 @@ class OutboxPollerIntegrationTest {
             event.publishedAt shouldNotBe null
         }
 
-        // Verify Kafka messages received
-        await()
-            .atMost(Duration.ofSeconds(5))
-            .pollInterval(Duration.ofMillis(500))
-            .untilAsserted {
-                val messages = kafkaTestConsumer.getMessages("payment.events")
-                messages.size shouldBeGreaterThanOrEqual 100
-            }
+        // Verify Kafka messages received (drain until >=100 of this test's events)
+        // filter: 본 테스트가 발행한 'event-N' correlationId 메시지만 카운트 (inter-test bleed 차단)
+        val messages = pollUntilFound("payment.events", expectedCount = 100, timeoutSeconds = 15) { msg ->
+            val cid = msg.substringAfter("\"correlationId\":\"").substringBefore("\"")
+            cid.startsWith("event-")
+        }
+        messages.size shouldBeGreaterThanOrEqual 100
 
-        // Verify message order (createdAt order should be preserved)
-        val messages = kafkaTestConsumer.getMessages("payment.events")
-        val eventIds = events.map { it.id }
+        // Verify message order (createdAt order should be preserved within batches)
         val receivedEventIndices = messages.mapNotNull { message ->
-            // Extract event index from correlation ID
-            val correlationId = message.substringAfter("\"correlationId\":\"")
-                .substringBefore("\"")
+            val correlationId = message.substringAfter("\"correlationId\":\"").substringBefore("\"")
             if (correlationId.startsWith("event-")) {
                 correlationId.removePrefix("event-").toIntOrNull()
             } else null
         }
 
-        // Check that indices are in ascending order (within batches)
         receivedEventIndices.take(10).zipWithNext().forEach { (prev, next) ->
             next shouldBeGreaterThanOrEqual prev
         }
@@ -250,19 +277,52 @@ class OutboxPollerIntegrationTest {
             )
         )
 
-        // Clear any existing messages
-        kafkaTestConsumer.clearReceivedMessages()
+        // When - Wait for 1 poller cycle (1s fixed-delay) + headroom
+        Thread.sleep(1100)
 
-        // When - Wait for 2 poller cycles
-        Thread.sleep(2500)
-
-        // Then - No new Kafka messages should be published
-        val messages = kafkaTestConsumer.getMessages("payment.events")
+        // Then - No new Kafka messages of this test's aggregateId should be published
+        // pollUntilFound(..., expectedCount = 0, ...) 는 negative path: deadline 끝까지 drain.
+        // filter: 본 테스트의 aggregateId 매칭만 카운트 (inter-test bleed 의 직전 테스트 메시지 무관)
+        val messages = pollUntilFound("payment.events", expectedCount = 0, timeoutSeconds = 2) {
+            it.contains(aggregateId.toString())
+        }
         messages shouldHaveSize 0
 
         // Event should still be marked as published
         val event = outboxEventRepository.findById(publishedEvent.id).get()
         event.published shouldBe true
+    }
+
+    /**
+     * 지정 [topic] 의 메시지를 [timeoutSeconds] 초 deadline 안에 [expectedCount] 개 이상 수집할 때까지 polling 한다.
+     *
+     * 종료 조건:
+     * - collected.size >= expectedCount  → 즉시 반환
+     * - System.currentTimeMillis() >= deadline → 그 시점까지 모은 결과 그대로 반환
+     *
+     * [filter] 는 inter-test isolation 용 — 본 테스트가 자신의 aggregateId / payload 매칭 메시지만
+     * 카운트하도록 한다. 기본값 `{ true }` 는 모든 메시지를 받아들임.
+     *
+     * expectedCount = 0 인 negative path 는 deadline 끝까지 drain (early-return 금지) — 호출자는
+     * deadline 만료 대기를 전제로 사용해야 한다. (early-return 하면 "0 개를 한 번 poll 했더니 비어있다"
+     * 와 "deadline 동안 polling 했는데도 비어있다" 가 구분되지 않는다.)
+     */
+    private fun pollUntilFound(
+        topic: String,
+        expectedCount: Int,
+        timeoutSeconds: Long,
+        filter: (String) -> Boolean = { true }
+    ): List<String> {
+        val deadline = System.currentTimeMillis() + timeoutSeconds * 1000
+        val collected = mutableListOf<String>()
+        while (System.currentTimeMillis() < deadline) {
+            val batch: Iterable<ConsumerRecord<String, String>> = kafkaConsumer.poll(Duration.ofMillis(500))
+            batch.forEach { record ->
+                if (record.topic() == topic && filter(record.value())) collected.add(record.value())
+            }
+            if (expectedCount > 0 && collected.size >= expectedCount) break
+        }
+        return collected
     }
 
     /**
@@ -316,61 +376,5 @@ class OutboxPollerIntegrationTest {
                 }
             }
         """.trimIndent().replace(Regex("\\s+"), " ")
-    }
-
-    /**
-     * Helper class for Kafka message consumption in tests
-     */
-    class KafkaTestConsumer(bootstrapServers: String) {
-        private val consumer: KafkaConsumer<String, String>
-        private val receivedMessages = ConcurrentHashMap<String, MutableList<String>>()
-        private val pollingThread: Thread
-
-        init {
-            val props = Properties().apply {
-                put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
-                put(ConsumerConfig.GROUP_ID_CONFIG, "test-consumer-group-${UUID.randomUUID()}")
-                put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-                put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true")
-                put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java)
-                put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java)
-            }
-
-            consumer = KafkaConsumer(props)
-            consumer.subscribe(listOf("payment.events", "reservation.events"))
-
-            // Start background polling thread
-            pollingThread = Thread {
-                try {
-                    while (!Thread.currentThread().isInterrupted) {
-                        val records = consumer.poll(Duration.ofMillis(100))
-                        records.forEach { record ->
-                            receivedMessages.computeIfAbsent(record.topic()) { mutableListOf() }
-                                .add(record.value())
-                        }
-                    }
-                } catch (e: Exception) {
-                    if (!Thread.currentThread().isInterrupted) {
-                        e.printStackTrace()
-                    }
-                }
-            }.apply {
-                isDaemon = true
-                start()
-            }
-        }
-
-        fun getMessages(topic: String): List<String> {
-            return receivedMessages[topic]?.toList() ?: emptyList()
-        }
-
-        fun clearReceivedMessages() {
-            receivedMessages.clear()
-        }
-
-        fun close() {
-            pollingThread.interrupt()
-            consumer.close()
-        }
     }
 }


### PR DESCRIPTION
## Summary

Issue #231 의 **race condition layer 만** 해결한다. baseline 환경 layer (`@ServiceConnection` for KafkaContainer 불안정) 는 별도 이슈 #248 로 분리.

- 내부 `KafkaTestConsumer` 클래스 (background polling thread) 완전 삭제 → single-thread `pollUntilFound` 패턴 도입
- `@BeforeAll`/`@AfterAll` consumer 셋업 → `@BeforeEach`/`@AfterEach` fresh consumer per-test
- partition assignment-wait loop + `@BeforeAll createTopicsOnce()` (AdminClient 토픽 사전 생성)
- payload-level filter 기반 inter-test isolation
- companion `@Container` 필드 `@JvmStatic` 적용

## Why split scope

Issue #231 fix 작업 중 다음 evidence 로 baseline 환경 결함 (별도 이슈) 식별:

- `OutboxPollerEdgeCaseIntegrationTest` 단독 실행 시 **3/4 fail** (본 PR 코드 변경과 무관)
- producer publish 자체는 성공 (`outbox.published=true` 마킹) 하지만 consumer 가 메시지 수신 0건
- `@ServiceConnection` for `KafkaContainer` (deprecated path) 가 Spring Boot 3.5 환경에서 KafkaTemplate 의 `bootstrap.servers` 를 안정적으로 등록 못 함으로 추정
- reservation-service 의 `ReservationOutboxPollerIntegrationTest` 는 `@DynamicPropertySource` 명시 등록 + `@SpringBootTest(properties = [\"spring.autoconfigure.exclude=\", ...])` 로 우회

→ 본 PR scope 는 race condition layer fix 만, **6/6 green acceptance 는 #248 환경 fix 머지 후 가능**.

## Race condition layer 해결 입증

| 검증 항목 | 결과 |
|---|---|
| `ConcurrentModificationException` | 0 건 (이전: 5/6 fail 중 `executionError` 1건이 CME) |
| `is not safe for multi-threaded access` | 0 건 |
| `KafkaTestConsumer` 클래스 잔존 | 0 건 |
| `clearReceivedMessages()` 호출 | 0 건 |
| `setupKafkaConsumer / tearDownKafkaConsumer` | 0 건 |
| `ConcurrentHashMap` import 잔존 | 0 건 |
| `@JvmStatic` 적용 (companion `@Container`) | 2 건 (postgres, kafka) |
| `@BeforeEach` 신규 메서드 | 1 건 (cleanupAndSetup) |
| `@AfterEach` 신규 메서드 | 1 건 (closeConsumer) |
| `pollUntilFound` 멤버 메서드 (KDoc 포함) | 1 건 |
| `pollUntilFound` 호출 (5 테스트) | 5 건 |
| `@BeforeAll createTopicsOnce` (AdminClient) | 1 건 |
| `Thread.sleep(2500)` 잔존 | 0 건 (1100 으로 단축) |
| TODO follow-up 주석 | 1 건 |
| `./gradlew :common-kafka:compileTestKotlin` | BUILD SUCCESSFUL |

## Plan source

ralplan consensus (Planner → Architect → Critic, 2 iterations, APPROVE 도달). ralph 실행 중 7 번의 smoke 시도를 통해 environment layer 결함을 evidence-driven 으로 식별, 사용자 결정으로 scope 분리.

## Follows / Refs

- Refs: #231
- Follows: #248 — `[Common/Test] common-kafka 통합 테스트 환경 — @ServiceConnection + KafkaContainer 불안정`

## Test plan

- [x] `./gradlew :common-kafka:compileTestKotlin` BUILD SUCCESSFUL
- [x] 정적 grep AC 16/16 통과
- [x] `ConcurrentModificationException` 0 건 / `multi-threaded access` 경고 0 건
- [ ] **#248 머지 후**: `./gradlew :common-kafka:test --tests \"*OutboxPollerIntegrationTest*\" --rerun-tasks` 5 연속 6/6 green
- [ ] **#248 머지 후**: `배치_100개` 단독 10 연속 green
- [ ] **#248 머지 후**: 전체 `:common-kafka:test` 회귀 0 건