### PR TITLE
fix: [Common/Test] OutboxPollerIntegrationTest jsonb 정규화 대응 + EdgeCase AOP 롤백 수정 (#252)

### DIFF
--- a/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxPollerEdgeCaseIntegrationTest.kt
+++ b/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxPollerEdgeCaseIntegrationTest.kt
@@ -19,7 +19,8 @@ import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
 import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
@@ -44,6 +45,9 @@ class OutboxPollerEdgeCaseIntegrationTest {
 
     @Autowired
     private lateinit var outboxEventRepository: OutboxEventRepository
+
+    @Autowired
+    private lateinit var transactionManager: PlatformTransactionManager
 
     private val objectMapper = ObjectMapper()
 
@@ -131,7 +135,7 @@ class OutboxPollerEdgeCaseIntegrationTest {
         }
     }
 
-    @Disabled("DB-count awaitility flaky under full-suite load (times out even at 20s); timing-sensitive, deferred to follow-up (#231 lane).")
+    @Disabled("Behavior is correct (passes in isolation) but flaky under full-suite load: multiple cached Spring contexts each run a 1s @Scheduled poller, so the 100-publish awaitility exceeds 20s intermittently. Needs a deterministic poller trigger or context isolation rather than a brittle timeout. Deferred to follow-up (#252/#231 lane).")
     @Test
     fun `BATCH_SIZE_초과시_다음_폴링에서_처리`() {
         // Given: 101개 이벤트 INSERT (BATCH_SIZE=100 초과)
@@ -170,39 +174,36 @@ class OutboxPollerEdgeCaseIntegrationTest {
         outboxEventRepository.countByPublishedFalse() shouldBe 0
     }
 
-    @Disabled("pre-existing @Transactional self-invocation AOP defect, unrelated to #248 bootstrap fix; deferred to follow-up")
     @Test
-    @Transactional
     fun `트랜잭션_롤백시_이벤트_상태_유지`() {
         // Given: Initial count
         val initialCount = outboxEventRepository.count()
 
-        // When: @Transactional 메서드에서 이벤트 INSERT 후 Exception 발생
+        // When: 실제 트랜잭션 경계(TransactionTemplate) 내에서 INSERT 후 Exception 발생.
+        // private @Transactional self-invocation 은 Spring AOP 프록시가 적용되지 않아 롤백되지 않으므로,
+        // TransactionTemplate 으로 명시적 트랜잭션 경계를 만들어 예외 시 롤백을 검증한다.
         try {
-            insertEventAndRollback()
+            TransactionTemplate(transactionManager).execute {
+                outboxEventRepository.save(
+                    OutboxEvent(
+                        id = UUID.randomUUID(),
+                        aggregateType = "Payment",
+                        aggregateId = UUID.randomUUID(),
+                        eventType = "PaymentSuccess",
+                        payload = """{"test": "rollback"}""",
+                        published = false,
+                        retryCount = 0,
+                        createdAt = LocalDateTime.now()
+                    )
+                )
+                throw RuntimeException("Simulated transaction rollback")
+            }
         } catch (e: RuntimeException) {
-            // Expected exception
+            // Expected exception → 트랜잭션 롤백
         }
 
         // Then: DB에 이벤트가 없는지 확인 (롤백됨)
         outboxEventRepository.count() shouldBe initialCount
-    }
-
-    @Transactional
-    private fun insertEventAndRollback() {
-        outboxEventRepository.save(
-            OutboxEvent(
-                id = UUID.randomUUID(),
-                aggregateType = "Payment",
-                aggregateId = UUID.randomUUID(),
-                eventType = "PaymentSuccess",
-                payload = """{"test": "rollback"}""",
-                published = false,
-                retryCount = 0,
-                createdAt = LocalDateTime.now()
-            )
-        )
-        throw RuntimeException("Simulated transaction rollback")
     }
 
     @Test

--- a/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxPollerIntegrationTest.kt
+++ b/backend/common-kafka/src/test/kotlin/com/ticketqueue/common/outbox/OutboxPollerIntegrationTest.kt
@@ -12,7 +12,6 @@ import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -117,7 +116,6 @@ class OutboxPollerIntegrationTest {
         kafkaTestConsumer.clearMessages()
     }
 
-    @Disabled("IntegrationTest-specific consumer-receive defect: identical ManualKafkaConsumer receives fine in EdgeCase but 0 here, reproduced in isolation on an idle machine. #248 publishing is verified via EdgeCase 동시에 + 103 producer publishes + frozen docker offset. Deferred to #231-lane follow-up; lead candidate: bump KafkaContainer cp-kafka 7.8.0→7.9.0 to match the working EdgeCase class.")
     @Test
     fun `이벤트_INSERT_후_1초내_Kafka_발행_확인`() {
         // Given
@@ -145,12 +143,12 @@ class OutboxPollerIntegrationTest {
             }
 
         // Then - Verify Kafka message received (payload-level filter 로 inter-test isolation)
-        val messages = pollUntilFound("payment.events", expectedCount = 1, timeoutSeconds = 5) { it == payload }
+        // jsonb 정규화로 키 순서가 바뀌므로 문자열이 아닌 JsonNode 트리로 비교한다.
+        val messages = pollUntilFound("payment.events", expectedCount = 1, timeoutSeconds = 5) { jsonEquals(it, payload) }
         messages shouldHaveSize 1
-        messages[0] shouldBe payload
+        jsonEquals(messages[0], payload) shouldBe true
     }
 
-    @Disabled("IntegrationTest-specific consumer-receive defect: identical ManualKafkaConsumer receives fine in EdgeCase but 0 here, reproduced in isolation on an idle machine. #248 publishing is verified via EdgeCase 동시에 + 103 producer publishes + frozen docker offset. Deferred to #231-lane follow-up; lead candidate: bump KafkaContainer cp-kafka 7.8.0→7.9.0 to match the working EdgeCase class.")
     @Test
     fun `Payment_이벤트_payment_events_토픽_발행`() {
         // Given
@@ -168,12 +166,11 @@ class OutboxPollerIntegrationTest {
         )
 
         // When/Then — poller(1s cycle) + Kafka 수신을 pollUntilFound 가 함께 대기
-        val messages = pollUntilFound("payment.events", expectedCount = 1, timeoutSeconds = 5) { it == payload }
+        val messages = pollUntilFound("payment.events", expectedCount = 1, timeoutSeconds = 5) { jsonEquals(it, payload) }
         messages shouldHaveSize 1
-        messages[0] shouldBe payload
+        jsonEquals(messages[0], payload) shouldBe true
     }
 
-    @Disabled("IntegrationTest-specific consumer-receive defect: identical ManualKafkaConsumer receives fine in EdgeCase but 0 here, reproduced in isolation on an idle machine. #248 publishing is verified via EdgeCase 동시에 + 103 producer publishes + frozen docker offset. Deferred to #231-lane follow-up; lead candidate: bump KafkaContainer cp-kafka 7.8.0→7.9.0 to match the working EdgeCase class.")
     @Test
     fun `Reservation_이벤트_reservation_events_토픽_발행`() {
         // Given
@@ -191,12 +188,11 @@ class OutboxPollerIntegrationTest {
         )
 
         // When/Then
-        val messages = pollUntilFound("reservation.events", expectedCount = 1, timeoutSeconds = 5) { it == payload }
+        val messages = pollUntilFound("reservation.events", expectedCount = 1, timeoutSeconds = 5) { jsonEquals(it, payload) }
         messages shouldHaveSize 1
-        messages[0] shouldBe payload
+        jsonEquals(messages[0], payload) shouldBe true
     }
 
-    @Disabled("IntegrationTest-specific consumer-receive defect: identical ManualKafkaConsumer receives fine in EdgeCase but 0 here, reproduced in isolation on an idle machine. #248 publishing is verified via EdgeCase 동시에 + 103 producer publishes + frozen docker offset. Deferred to #231-lane follow-up; lead candidate: bump KafkaContainer cp-kafka 7.8.0→7.9.0 to match the working EdgeCase class.")
     @Test
     fun `배치_100개_이벤트_순차_발행`() {
         // Given - Create 100 events in order
@@ -235,14 +231,13 @@ class OutboxPollerIntegrationTest {
         // Verify Kafka messages received (drain until >=100 of this test's events)
         // filter: 본 테스트가 발행한 'event-N' correlationId 메시지만 카운트 (inter-test bleed 차단)
         val messages = pollUntilFound("payment.events", expectedCount = 100, timeoutSeconds = 15) { msg ->
-            val cid = msg.substringAfter("\"correlationId\":\"").substringBefore("\"")
-            cid.startsWith("event-")
+            correlationIdOf(msg).startsWith("event-")
         }
         messages.size shouldBeGreaterThanOrEqual 100
 
         // Verify message order (createdAt order should be preserved within batches)
         val receivedEventIndices = messages.mapNotNull { message ->
-            val correlationId = message.substringAfter("\"correlationId\":\"").substringBefore("\"")
+            val correlationId = correlationIdOf(message)
             if (correlationId.startsWith("event-")) {
                 correlationId.removePrefix("event-").toIntOrNull()
             } else null
@@ -324,6 +319,17 @@ class OutboxPollerIntegrationTest {
         }
         return collected
     }
+
+    /**
+     * payload 는 jsonb 컬럼을 왕복하며 키 순서/공백이 정규화되므로(PostgreSQL jsonb 는 키를 길이+바이트
+     * 순으로 재정렬) 원본 문자열과 정확히 일치하지 않는다. 따라서 문자열 동등성이 아니라 JsonNode 트리
+     * 비교(순서 무관)로 의미적 동등성을 확인한다.
+     */
+    private fun jsonEquals(a: String, b: String): Boolean = objectMapper.readTree(a) == objectMapper.readTree(b)
+
+    /** jsonb 정규화에 견디도록 metadata.correlationId 를 JSON 파싱으로 추출한다. */
+    private fun correlationIdOf(json: String): String =
+        objectMapper.readTree(json).path("metadata").path("correlationId").asText()
 
     /**
      * Helper method to create Payment event payload


### PR DESCRIPTION
## 개요

#252 — `OutboxPollerIntegrationTest` 발행 검증 실패의 **진짜 루트 코즈**를 찾아 수정한다. #248(bootstrap 누출) 수정 이후에도 IntegrationTest 4건이 "size 0"으로 실패했는데, 원인은 consumer 결함이 아니라 **assertion 이 jsonb 정규화에 취약했던 것**이다.

## 루트 코즈 (계측으로 확정)

- `OutboxEvent.payload` 는 PostgreSQL `jsonb` 컬럼(`init.sql: payload JSONB NOT NULL`)을 왕복하며 키가 **(길이, 바이트)순으로 재정렬**되고 공백이 정규화된다 → DB 왕복 후 원본 문자열과 정확히 불일치.
- 계측 결과 consumer(`ManualKafkaConsumer`)는 **103건 모두 정상 수신**했으나, `pollUntilFound { it == payload }` 의 **문자열 정확 일치**가 정규화된 payload와 매칭되지 않아 0건 수집.
- `OutboxPollerEdgeCaseIntegrationTest` 가 통과했던 이유: `contains("\"sequenceId\": N")` 부분문자열 비교라 키 재정렬에 견뎠기 때문. (worker 초기 가설인 consumer-receive 결함 / cp-kafka 7.8.0→7.9.0 은 모두 오진으로 확인됨)

## 변경 (테스트 전용)

- **`pollUntilFound`**: 문자열 동등성 → `JsonNode` 트리 비교(`jsonEquals`)로 변경, `correlationId` 추출도 JSON 파싱(`correlationIdOf`)으로 전환 → **IntegrationTest 5/5 green**
- **EdgeCase `트랜잭션_롤백시_이벤트_상태_유지`**: private `@Transactional` self-invocation(Spring AOP 프록시 미적용으로 롤백 안 됨) → `TransactionTemplate` 명시적 트랜잭션 경계로 교체하여 롤백을 올바르게 검증
- **EdgeCase `BATCH_SIZE_초과시`**: 풀스위트에서 캐시된 다중 Spring context 의 1s `@Scheduled` poller 경합으로 100건 발행 awaitility 가 20s 초과(단독 실행에선 통과 = 동작 자체는 정확) → 근거 명시 `@Disabled`, follow-up 추적

## 검증

- `./gradlew :common-kafka:test` → **BUILD SUCCESSFUL** (IntegrationTest 5/5, EdgeCase 3 pass + BATCH skip, Retry 2 pass + 2 skip[#251], DLQ skip[#251], unit/Recorder 회귀 0)
- docker `payment.events`/`reservation.events` offset 불변 → 누출 0 유지

## 연관 / 남은 작업

- Addresses #252 (IntegrationTest consumer-receive + AOP 해결). BATCH_SIZE 견고화(결정적 poller 트리거 / context 격리)는 `@Disabled` 로 추적 — #252 잔여 또는 후속.
- restart 기반 DLQ/Retry 는 **#251**(Toxiproxy) 로 분리 유지.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved transaction rollback verification with explicit transaction boundaries.
  * Re-enabled Kafka message publication verification test.
  * Enhanced message payload comparison using semantic JSON equality checks instead of string matching.
  * Optimized correlation ID extraction from Kafka messages.
  * Updated test reliability metadata for event ordering verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paircoders/ticket-queue/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->