### PR TITLE
docs: [IntegrationTest] TC-ENV-001 인프라 컨테이너 기동/healthcheck 통과 기록

### DIFF
--- a/docs/integration-test/00_environment_setup.md
+++ b/docs/integration-test/00_environment_setup.md
@@ -9,7 +9,7 @@
 
 ### TC-ENV-001 — 인프라 컨테이너 전체 기동 및 healthcheck 통과 확인
 
-- [ ] 미실행
+- [x] 통과 (2026-05-30, 근거: `docker compose up -d` 후 postgres/valkey/grafana=healthy, localstack=healthy, kafka/prometheus=running, kafka-init=exited(0). `KafkaRaftServer nodeId=1 Kafka Server started` 로그 확인. unhealthy/Exit 1 항목 0건)
 - **관련 REQ**: 해당 없음
 - **분류**: 정상
 - **우선순위**: P0(필수/핵심)

--- a/docs/integration-test/README.md
+++ b/docs/integration-test/README.md
@@ -27,7 +27,7 @@
 
 | # | 문서 | 영역 | TC 수 | P0(핵심) | 진행 | 주 검증 수단 |
 |---|------|------|------:|------:|:----:|------|
-| 00 | [00_environment_setup.md](./00_environment_setup.md) | 로컬 인프라 부트스트랩 & 관측 | 16 | 9 | `0 / 16` | docker-compose, gradle, curl health |
+| 00 | [00_environment_setup.md](./00_environment_setup.md) | 로컬 인프라 부트스트랩 & 관측 | 16 | 9 | `1 / 16` | docker-compose, gradle, curl health |
 | 01 | [01_api_gateway.md](./01_api_gateway.md) | API Gateway (라우팅/인증/보안) | 22 | 9 | `0 / 22` | curl, gradle test (WebFlux) |
 | 02 | [02_user_service.md](./02_user_service.md) | 인증/회원/JWT | 27 | 15 | `0 / 27` | curl, gradle test, Redis/DB |
 | 03 | [03_event_service.md](./03_event_service.md) | 공연/좌석/캐싱/Consumer | 24 | 12 | `0 / 24` | curl, integrationTest, Redis/Kafka |
@@ -39,7 +39,7 @@
 | 09 | [09_cross_service_flows.md](./09_cross_service_flows.md) | 크로스 서비스 E2E (SAGA/이벤트/정합성) | 20 | 8 | `0 / 20` | 다중 서비스 기동 + curl 시나리오 |
 | 10 | [10_frontend_e2e.md](./10_frontend_e2e.md) | 프론트엔드 화면 E2E | 26 | 13 | `0 / 26` | **Claude in Chrome** |
 | 11 | [11_requirement_coverage.md](./11_requirement_coverage.md) | REQ 커버리지 감사 & 보강(GAP) | 6 | 3 | `0 / 6` | 위 갭 보강 TC 실행 |
-| | **합계** | | **245** | **132** | `0 / 245` | |
+| | **합계** | | **245** | **132** | `1 / 245` | |
 
 ---
 


### PR DESCRIPTION
## 개요

`docs/integration-test/00_environment_setup.md`의 **TC-ENV-001 — 인프라 컨테이너 전체 기동 및 healthcheck 통과 확인**을 실행하고 결과를 문서에 반영합니다.

## 실행 내용

- `cd docker && docker compose up -d` 실행
  - **핵심**: 기존에 8주 전 생성되어 실행 중이던 `ticket-postgres`/`ticket-valkey` 컨테이너에는 healthcheck가 적용돼 있지 않았음(`<no-healthcheck>`)
  - 현재 `docker-compose.yml`에 정의된 healthcheck가 config 변경으로 감지되어 두 컨테이너만 재생성됨 (데이터는 named volume으로 보존)

## 검증 결과 (TC-ENV-001 기대 결과 전부 충족)

| 컨테이너 | 기대 | 실제 |
|---------|------|------|
| ticket-postgres | healthy | ✅ healthy |
| ticket-valkey | healthy | ✅ healthy |
| ticket-grafana | healthy | ✅ healthy |
| ticket-localstack | running | ✅ running (healthy) |
| ticket-prometheus | running | ✅ running |
| ticket-kafka | running + 기동 로그 | ✅ running, `KafkaRaftServer nodeId=1 Kafka Server started` |
| ticket-kafka-init | exited (0) | ✅ exited (0) |

- **검증 포인트**: `unhealthy`/`Exit 1` 항목 **0건**
- 참고: Kafka 4.1.1 **KRaft 모드**에서는 문서가 예시로 든 `[KafkaServer id=1] started` 대신 `[KafkaRaftServer nodeId=1] Kafka Server started` 로그가 출력됨 (의미 동일)

## 문서 변경

- `00_environment_setup.md`: TC-ENV-001 체크박스 `- [x] 통과 (2026-05-30, 근거: ...)`로 갱신
- `README.md`: 진행 대시보드 00 영역 `0/16 → 1/16`, 합계 `0/245 → 1/245`

## 변경 범위

문서 2개만 변경. 코드/설정 변경 없음.