### PR TITLE
fix: [Infra/LocalStack] localstack_init.sh 재실행 멱등성 확보 (#258)

### DIFF
--- a/docker/localstack_init/localstack_init.sh
+++ b/docker/localstack_init/localstack_init.sh
@@ -3,32 +3,57 @@ set -e
 
 echo "=========== LocalStack Init Start ==========="
 
-# 1. S3 버킷 생성
-echo "[S3] Creating 'event-images' bucket..."
-awslocal s3 mb s3://event-images
+# ---------------------------------------------------------
+# 0. 멱등성 헬퍼: 시크릿이 이미 있으면 update, 없으면 create
+#    재실행 시 create-secret 의 ResourceExistsException 으로
+#    set -e 가 스크립트를 중단시키는 문제 방지 (issue #258)
+#    describe-secret 은 if 조건절에서 호출하므로 set -e 의 영향을 받지 않음.
+put_secret() {
+    local SECRET_NAME=$1
+    local DESCRIPTION=$2
+    local SECRET_VALUE=$3
+
+    if awslocal secretsmanager describe-secret --secret-id "$SECRET_NAME" > /dev/null 2>&1; then
+        echo "[SecretsManager] Updating existing secret: $SECRET_NAME"
+        awslocal secretsmanager update-secret \
+            --secret-id "$SECRET_NAME" \
+            --description "$DESCRIPTION" \
+            --secret-string "$SECRET_VALUE"
+    else
+        echo "[SecretsManager] Creating secret: $SECRET_NAME"
+        awslocal secretsmanager create-secret \
+            --name "$SECRET_NAME" \
+            --description "$DESCRIPTION" \
+            --secret-string "$SECRET_VALUE"
+    fi
+}
+
+# 1. S3 버킷 생성 (이미 존재하면 건너뜀 — 재실행 멱등성)
+if awslocal s3api head-bucket --bucket event-images > /dev/null 2>&1; then
+    echo "[S3] 'event-images' bucket already exists, skipping."
+else
+    echo "[S3] Creating 'event-images' bucket..."
+    awslocal s3 mb s3://event-images
+fi
 
 # ---------------------------------------------------------
-# 2. Secrets Manager 등록 함수 정의
+# 2. DB 패스워드 단일 시크릿 등록 함수 (put_secret 래퍼)
 #    create_secret "서비스명" "시크릿파일명" "추가설명"
 create_secret() {
     local SERVICE_NAME=$1
     local SECRET_FILE=$2
     local DESCRIPTION=$3
-    
-    # 시크릿 이름 규칙: ticket-{서비스명}/secure-config
+
+    # 시크릿 이름 규칙: {서비스명}-svc/secure-config
     local SECRET_NAME="${SERVICE_NAME}-svc/secure-config"
-    
+
     # Docker Secret 파일에서 실제 비밀번호 읽기
     local DB_PASSWORD=$(cat "/run/secrets/${SECRET_FILE}")
-    
+
     # JSON 생성 (valkey인 경우 키값을 다르게 할 수도 있음, 여기선 db_password로 통일하거나 분기 처리)
     local SECRET_VALUE="{\"db_password\":\"${DB_PASSWORD}\"}"
-    
-    echo "[SecretsManager] Creating secret: $SECRET_NAME"
-    awslocal secretsmanager create-secret \
-        --name "$SECRET_NAME" \
-        --description "$DESCRIPTION" \
-        --secret-string "$SECRET_VALUE"
+
+    put_secret "$SECRET_NAME" "$DESCRIPTION" "$SECRET_VALUE"
 }
 
 # ---------------------------------------------------------
@@ -37,10 +62,9 @@ create_secret() {
 # (1) User Service
 USER_DB_PW=$(cat /run/secrets/postgres_user_pw)
 RECAPTCHA_SECRET=$(cat /run/secrets/recaptcha_secret)
-awslocal secretsmanager create-secret \
-    --name "user-svc/secure-config" \
-    --description "Secrets for User Service" \
-    --secret-string "{\"db_password\":\"$USER_DB_PW\", \"recaptcha_secret\":\"$RECAPTCHA_SECRET\"}"
+put_secret "user-svc/secure-config" \
+    "Secrets for User Service" \
+    "{\"db_password\":\"$USER_DB_PW\", \"recaptcha_secret\":\"$RECAPTCHA_SECRET\"}"
 
 # (2) Event Service
 create_secret "event" "postgres_event_pw" "Secrets for Event Service"
@@ -61,12 +85,11 @@ PORTONE_CHANNEL_KEY=$(cat /run/secrets/portone_channel_key)
 ENC_SECRET_KEY=$(cat /run/secrets/enc_secret_key)
 ENC_HASH_SALT=$(cat /run/secrets/enc_hash_salt)
 
-awslocal secretsmanager create-secret \
-    --name "common/secure-config" \
-    --description "Common secrets for all services" \
-    --secret-string "{\"valkey_password\":\"$VALKEY_PW\", \"internal_api_key\":\"$INTERNAL_API_KEY\", \"jwt_secret\":\"$JWT_SECRET\", \"portone_api_secret\":\"$PORTONE_API_SECRET\", \"portone_store_id\":\"$PORTONE_STORE_ID\", \"portone_channel_key\":\"$PORTONE_CHANNEL_KEY\", \"enc_secret_key\":\"$ENC_SECRET_KEY\", \"enc_hash_salt\":\"$ENC_HASH_SALT\"}"
+put_secret "common/secure-config" \
+    "Common secrets for all services" \
+    "{\"valkey_password\":\"$VALKEY_PW\", \"internal_api_key\":\"$INTERNAL_API_KEY\", \"jwt_secret\":\"$JWT_SECRET\", \"portone_api_secret\":\"$PORTONE_API_SECRET\", \"portone_store_id\":\"$PORTONE_STORE_ID\", \"portone_channel_key\":\"$PORTONE_CHANNEL_KEY\", \"enc_secret_key\":\"$ENC_SECRET_KEY\", \"enc_hash_salt\":\"$ENC_HASH_SALT\"}"
 
-echo "[SecretsManager] All secrets created successfully."
+echo "[SecretsManager] All secrets registered successfully."
 awslocal secretsmanager list-secrets
 
 echo "=========== LocalStack Init Complete ==========="

--- a/docs/integration-test/00_environment_setup.md
+++ b/docs/integration-test/00_environment_setup.md
@@ -5,7 +5,7 @@
 > **주 실행 수단**: docker-compose, ./gradlew build/test, curl health check
 > **총 항목 수**: 16
 > **실행 결과 (2026-05-30)**: 통과 7건 | 부분 통과 3건 | 실패 1건 | 미실행 4건 (백엔드 서비스 기동 필요 3건 + Prometheus 타겟 1건)
-> **발견된 이슈**: #257 스키마 소유자 불일치 | #258 localstack_init.sh 멱등성 | #259 reservation-service 테스트 ApplicationContext 실패 | #260 event-service 테스트 2종 | #261 integrationTest 태스크 없음
+> **발견된 이슈**: #257 스키마 소유자 불일치 | #258 localstack_init.sh 멱등성(수정 완료) | #259 reservation-service 테스트 ApplicationContext 실패 | #260 event-service 테스트 2종 | #261 integrationTest 태스크 없음
 
 ---
 
@@ -162,7 +162,7 @@
 
 ### TC-ENV-006 — LocalStack 시크릿 등록 전 서비스 기동 시 실패 케이스(시크릿 미주입)
 
-- [x] 부분 통과 (2026-05-30, 근거: `common/secure-config` 삭제 후 시크릿 목록에서 제거됨 확인. 복구 시도: `localstack_init.sh` 재실행 → `set -e` + `create-secret` 중복으로 첫 번째 시크릿(user-svc)에서 스크립트 중단, `common/secure-config` 미복구. 수동 `awslocal secretsmanager create-secret` 으로 복구 성공. **Spring Boot 서비스 기동 실패 시나리오(로그 확인)는 백엔드 컨테이너 이미지 없어 미검증**. `localstack_init.sh` 멱등성 버그 → 관련 이슈: #258)
+- [x] 부분 통과 (2026-05-30, 근거: `common/secure-config` 삭제 후 시크릿 목록에서 제거됨 확인. **[버그]** 복구 시도로 `localstack_init.sh` 재실행 시 `set -e` + 비멱등 명령 조합으로 S3 버킷 생성 단계(`s3 mb` → `BucketAlreadyOwnedByYou`)에서 즉시 중단되어 `common/secure-config` 미복구(시크릿 4개). 수동 `awslocal secretsmanager create-secret` 으로 복구. **[수정 완료 → #258]** `localstack_init.sh` 멱등화: S3는 `head-bucket` 분기, 시크릿은 `put_secret` 헬퍼(`describe-secret` 분기 후 update/create)로 통일. 동일 복구 시나리오 재실행 → exit 0, `common/secure-config` 정상 복구(시크릿 5개), 필수 키 정합 확인. 5개 모두 존재 상태 재실행도 전부 update 경로·`ResourceExistsException` 0건·exit 0으로 멱등성 재검증 완료. **Spring Boot 서비스 기동 실패 시나리오(로그 확인)는 백엔드 컨테이너 이미지 없어 여전히 미검증** → 부분 통과 유지)
 - **관련 REQ**: 해당 없음
 - **분류**: 예외
 - **우선순위**: P1(중요)
@@ -183,7 +183,7 @@
      ```
   4. common/secure-config 재등록(복구):
      ```bash
-     # localstack_init.sh 재실행 또는 개별 시크릿 재등록
+     # localstack_init.sh 재실행 — #258 수정 후 멱등하므로 기존 시크릿이 있어도 중단 없이 누락분만 복구
      docker exec ticket-localstack bash /etc/localstack/init/ready.d/localstack_init.sh
      ```
 - **기대 결과**: user-service 컨테이너가 `ResourceNotFoundException` 또는 Spring Boot `Application run failed` 로그를 남기고 재시작 루프 진입 또는 Exit

--- a/docs/integration-test/00_environment_setup.md
+++ b/docs/integration-test/00_environment_setup.md
@@ -4,7 +4,7 @@
 > **사전 준비**: docker/secrets/ 하위 모든 .txt 파일 존재 확인, Docker Desktop 실행, 호스트 포트 5432·6379·9092·4566·9090·3001·8080-8085·9080-9085 미점유, JDK 21 및 ./gradlew 실행 권한
 > **주 실행 수단**: docker-compose, ./gradlew build/test, curl health check
 > **총 항목 수**: 16
-> **실행 결과 (2026-05-30)**: 통과 7건 | 부분 통과 3건 | 실패 1건 | 미실행 4건 (백엔드 서비스 기동 필요 3건 + Prometheus 타겟 1건)
+> **실행 결과 (2026-05-30)**: 통과 8건 | 부분 통과 3건 | 실패 1건 | 미실행 4건 (백엔드 서비스 기동 필요 3건 + Prometheus 타겟 1건)
 > **발견된 이슈**: #257 스키마 소유자 불일치 | #258 localstack_init.sh 멱등성(수정 완료) | #259 reservation-service 테스트 ApplicationContext 실패 | #260 event-service 테스트 2종 | #261 integrationTest 태스크 없음
 
 ---


### PR DESCRIPTION
## 개요
`docker/localstack_init/localstack_init.sh`가 **재실행 불가**하던 문제를 수정합니다. (Closes #258)

`set -e` 와 비멱등 명령(`s3 mb`, `secretsmanager create-secret`)이 결합되어, 이미 존재하는 리소스를 만나면 첫 충돌에서 스크립트가 즉시 종료됐습니다. 그 결과 충돌 지점 이후의 시크릿이 재생성되지 않아, 시크릿을 의도적으로 삭제하고 복구하는 시나리오(TC-ENV-006)에서 자동 복구가 불가능했습니다.

> 검증 중 추가로 확인된 사실: 실제로는 이슈에 기술된 첫 `create-secret`(user-svc)보다 더 앞단인 **S3 `s3 mb` 단계**에서 `BucketAlreadyOwnedByYou`로 먼저 중단됩니다. 그래서 S3 버킷 생성도 함께 멱등화했습니다.

## 변경 사항
- **`put_secret` 헬퍼 추가**: `describe-secret`로 존재 여부를 확인한 뒤, 있으면 `update-secret` / 없으면 `create-secret`으로 분기. 5개 시크릿(user/event/reservation/payment/common) 등록 경로를 이 헬퍼로 통일.
- **S3 버킷 멱등화**: `s3api head-bucket` 검사 후 없을 때만 `s3 mb` 실행.
- `describe-secret` / `head-bucket` 검사는 `if` 조건절에서 호출하여 `set -e` 의 영향을 받지 않도록 함(`set -e`는 fail-fast용으로 유지).
- `docs/integration-test/00_environment_setup.md`: TC-ENV-006 기록을 버그 수정/재검증 결과로 갱신.

## 검증 (라이브 `ticket-localstack` 컨테이너)
| 시나리오 | 결과 |
|---------|------|
| (수정 전) `common` 삭제 후 구버전 재실행 | S3 `BucketAlreadyOwnedByYou`에서 중단, `common` 미복구 (시크릿 4개) |
| (수정 후) `common` 누락 상태에서 재실행 | **exit 0**, `common` 복구 → 시크릿 5개, 필수 키 정합 확인 |
| (수정 후) 5개 모두 존재 상태에서 재실행 | **exit 0**, 전부 `update` 경로, `ResourceExistsException` 0건, 시크릿 5개 |

`bash -n` 문법 검사 통과. 환경은 검증 후 정상 상태(시크릿 5개)로 복원됨.

## 영향 범위
- 로컬 개발 환경 한정(LocalStack init). 운영 코드/서비스 로직 변경 없음.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LocalStack initialization to be idempotent—S3 buckets and secrets can now be safely re-initialized without errors on repeated runs.

* **Documentation**
  * Updated environment setup guide to document the enhanced idempotent initialization behavior and recovery procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paircoders/ticket-queue/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->