### PR TITLE
fix: [Infra/DB] PostgreSQL 스키마 소유자 멱등 교정 (#257)

### DIFF
--- a/docker/db_init/0_init_users_and_schemas.sh
+++ b/docker/db_init/0_init_users_and_schemas.sh
@@ -11,8 +11,17 @@ echo "Creating service users and schemas from secrets..."
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
 
     -- User Service
-    CREATE USER user_svc_user WITH PASSWORD '$USER_SVC_PW';
+    DO \$do\$
+    BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'user_svc_user') THEN
+            CREATE USER user_svc_user WITH PASSWORD '$USER_SVC_PW';
+        END IF;
+    END
+    \$do\$;
     CREATE SCHEMA IF NOT EXISTS user_service AUTHORIZATION user_svc_user;
+    -- CREATE SCHEMA IF NOT EXISTS 는 스키마가 이미 존재하면 AUTHORIZATION 절을 무시하여 소유자를
+    -- 바꾸지 않는다. 잔존 볼륨 재초기화 시에도 소유자를 강제하기 위해 ALTER SCHEMA 를 명시한다. (issue #257)
+    ALTER SCHEMA user_service OWNER TO user_svc_user;
     CREATE OR REPLACE FUNCTION user_service.update_timestamp() RETURNS TRIGGER AS \$\$
     BEGIN
         NEW.updated_at = now();
@@ -22,8 +31,15 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     ALTER FUNCTION user_service.update_timestamp() OWNER TO user_svc_user;
 
     -- Event Service
-    CREATE USER event_svc_user WITH PASSWORD '$EVENT_SVC_PW';
+    DO \$do\$
+    BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'event_svc_user') THEN
+            CREATE USER event_svc_user WITH PASSWORD '$EVENT_SVC_PW';
+        END IF;
+    END
+    \$do\$;
     CREATE SCHEMA IF NOT EXISTS event_service AUTHORIZATION event_svc_user;
+    ALTER SCHEMA event_service OWNER TO event_svc_user;
     CREATE OR REPLACE FUNCTION event_service.update_timestamp() RETURNS TRIGGER AS \$\$
     BEGIN
         NEW.updated_at = now();
@@ -33,8 +49,15 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     ALTER FUNCTION event_service.update_timestamp() OWNER TO event_svc_user;
 
     -- Reservation Service
-    CREATE USER reservation_svc_user WITH PASSWORD '$RESERVATION_SVC_PW';
+    DO \$do\$
+    BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'reservation_svc_user') THEN
+            CREATE USER reservation_svc_user WITH PASSWORD '$RESERVATION_SVC_PW';
+        END IF;
+    END
+    \$do\$;
     CREATE SCHEMA IF NOT EXISTS reservation_service AUTHORIZATION reservation_svc_user;
+    ALTER SCHEMA reservation_service OWNER TO reservation_svc_user;
     CREATE OR REPLACE FUNCTION reservation_service.update_timestamp() RETURNS TRIGGER AS \$\$
     BEGIN
         NEW.updated_at = now();
@@ -44,8 +67,15 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     ALTER FUNCTION reservation_service.update_timestamp() OWNER TO reservation_svc_user;
 
     -- Payment Service
-    CREATE USER payment_svc_user WITH PASSWORD '$PAYMENT_SVC_PW';
+    DO \$do\$
+    BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'payment_svc_user') THEN
+            CREATE USER payment_svc_user WITH PASSWORD '$PAYMENT_SVC_PW';
+        END IF;
+    END
+    \$do\$;
     CREATE SCHEMA IF NOT EXISTS payment_service AUTHORIZATION payment_svc_user;
+    ALTER SCHEMA payment_service OWNER TO payment_svc_user;
     CREATE OR REPLACE FUNCTION payment_service.update_timestamp() RETURNS TRIGGER AS \$\$
     BEGIN
         NEW.updated_at = now();
@@ -54,7 +84,7 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     \$\$ LANGUAGE plpgsql;
     ALTER FUNCTION payment_service.update_timestamp() OWNER TO payment_svc_user;
 
-    -- Common
+    -- Common (슈퍼유저 ticket 소유 유지: 모든 서비스가 공유하는 스키마)
     CREATE SCHEMA IF NOT EXISTS common;
     GRANT ALL ON SCHEMA common TO user_svc_user, event_svc_user, reservation_svc_user, payment_svc_user;
 

--- a/docs/integration-test/00_environment_setup.md
+++ b/docs/integration-test/00_environment_setup.md
@@ -4,8 +4,8 @@
 > **사전 준비**: docker/secrets/ 하위 모든 .txt 파일 존재 확인, Docker Desktop 실행, 호스트 포트 5432·6379·9092·4566·9090·3001·8080-8085·9080-9085 미점유, JDK 21 및 ./gradlew 실행 권한
 > **주 실행 수단**: docker-compose, ./gradlew build/test, curl health check
 > **총 항목 수**: 16
-> **실행 결과 (2026-05-30)**: 통과 7건 | 부분 통과 3건 | 실패 1건 | 미실행 4건 (백엔드 서비스 기동 필요 3건 + Prometheus 타겟 1건)
-> **발견된 이슈**: #257 스키마 소유자 불일치 | #258 localstack_init.sh 멱등성 | #259 reservation-service 테스트 ApplicationContext 실패 | #260 event-service 테스트 2종 | #261 integrationTest 태스크 없음
+> **실행 결과 (2026-05-30)**: 통과 8건 | 부분 통과 2건 | 실패 1건 | 미실행 4건 (백엔드 서비스 기동 필요 3건 + Prometheus 타겟 1건)
+> **발견된 이슈**: ~~#257 스키마 소유자 불일치~~ (해결) | #258 localstack_init.sh 멱등성 | #259 reservation-service 테스트 ApplicationContext 실패 | #260 event-service 테스트 2종 | #261 integrationTest 태스크 없음
 
 ---
 
@@ -57,7 +57,7 @@
 
 ### TC-ENV-003 — PostgreSQL 스키마 분리 생성 확인 (5개 스키마)
 
-- [x] 부분 통과 (2026-05-30, 근거: 스키마 5개(`user_service`, `event_service`, `reservation_service`, `payment_service`, `common`) 존재 확인. `common.outbox_events`, `common.processed_events` 테이블 및 복합 PK(`event_id`, `consumer_service`) 확인. **단, 스키마 소유자 불일치 발견**: `user_service`/`event_service`/`payment_service`가 예상 소유자(`user_svc_user` 등) 대신 `ticket` 슈퍼유저 소유로 확인됨. `reservation_service`만 `reservation_svc_user` 소유 정상. 원인: `CREATE SCHEMA IF NOT EXISTS ... AUTHORIZATION` 은 스키마 이미 존재 시 소유자 변경 안 함(볼륨 잔존 데이터). → 관련 이슈: #257)
+- [x] 통과 (2026-05-30, 근거: 스키마 5개(`user_service`, `event_service`, `reservation_service`, `payment_service`, `common`) 존재 확인. `common.outbox_events`, `common.processed_events` 테이블 및 복합 PK(`event_id`, `consumer_service`) 확인. 스키마 소유자 전수 일치: `user_service`→`user_svc_user`, `event_service`→`event_svc_user`, `reservation_service`→`reservation_svc_user`, `payment_service`→`payment_svc_user`, `common`→`ticket`. 비고: 최초 실행 시 user/event/payment 스키마가 `ticket` 슈퍼유저 소유로 발견되었으나(#257), 원인인 `CREATE SCHEMA IF NOT EXISTS ... AUTHORIZATION` 의 소유자 미변경 동작을 `0_init_users_and_schemas.sh` 에 명시적 `ALTER SCHEMA ... OWNER TO ...` + 멱등 `CREATE USER` 가드 추가로 해결. 라이브 DB 재적용 후 소유자 전수 일치 재검증 완료. → #257 해결)
 - **관련 REQ**: 해당 없음
 - **분류**: 정상
 - **우선순위**: P0(필수/핵심)

--- a/docs/integration-test/00_environment_setup.md
+++ b/docs/integration-test/00_environment_setup.md
@@ -4,7 +4,7 @@
 > **사전 준비**: docker/secrets/ 하위 모든 .txt 파일 존재 확인, Docker Desktop 실행, 호스트 포트 5432·6379·9092·4566·9090·3001·8080-8085·9080-9085 미점유, JDK 21 및 ./gradlew 실행 권한
 > **주 실행 수단**: docker-compose, ./gradlew build/test, curl health check
 > **총 항목 수**: 16
-> **실행 결과 (2026-05-30)**: 통과 8건 | 부분 통과 2건 | 실패 1건 | 미실행 4건 (백엔드 서비스 기동 필요 3건 + Prometheus 타겟 1건)
+> **실행 결과 (2026-05-30)**: 통과 9건 | 부분 통과 2건 | 실패 1건 | 미실행 4건 (백엔드 서비스 기동 필요 3건 + Prometheus 타겟 1건)
 > **발견된 이슈**: ~~#257 스키마 소유자 불일치~~ (해결) | #258 localstack_init.sh 멱등성 | #259 reservation-service 테스트 ApplicationContext 실패 | #260 event-service 테스트 2종 | #261 integrationTest 태스크 없음
 
 ---


### PR DESCRIPTION
## 배경
TC-ENV-003(스키마 분리 생성 확인) 실행 중, `user_service`/`event_service`/`payment_service` 스키마가 의도된 서비스 사용자가 아닌 `ticket` 슈퍼유저 소유로 남는 문제를 발견했습니다. (#257)

## 근본 원인
`docker/db_init/0_init_users_and_schemas.sh` 가 `CREATE SCHEMA IF NOT EXISTS <s> AUTHORIZATION <u>` 형태로 소유자를 지정하지만, PostgreSQL의 `CREATE SCHEMA IF NOT EXISTS` 는 스키마가 이미 존재하면 **문장 전체가 no-op** 이 되어 `AUTHORIZATION` 절(소유자 지정)이 조용히 무시됩니다. 잔존 볼륨에 `ticket` 슈퍼유저로 생성된 스키마가 남아 있으면 재초기화 시에도 소유자가 교정되지 않습니다.

추가로, 스크립트는 `psql -v ON_ERROR_STOP=1` 로 실행되므로 "잔존 볼륨 재초기화로 소유자 교정" 시나리오에서 앞단의 `CREATE USER`(사용자 존재 시 에러)가 먼저 스크립트를 중단시킵니다. 따라서 `ALTER SCHEMA` 추가만으로는 해당 시나리오에서 동작하지 않아, `CREATE USER` 멱등화가 함께 필요합니다.

## 변경 사항
- `docker/db_init/0_init_users_and_schemas.sh`
  - 각 서비스 스키마 CREATE 직후 **명시적 `ALTER SCHEMA <s> OWNER TO <u>;`** 추가 (소유자 멱등 강제)
  - `CREATE USER` 를 **`DO $do$ ... IF NOT EXISTS (SELECT 1 FROM pg_roles ...) ... $do$`** 가드로 멱등화 (재실행 안전)
  - `common` 스키마는 슈퍼유저 `ticket` 소유 유지(설계상 정상)
- `docs/integration-test/00_environment_setup.md`
  - TC-ENV-003 `부분 통과` → `통과` 갱신, 소유자 전수 일치 근거 기록
  - 헤더 발견 이슈/요약 카운트 반영

## 검증 (라이브 `ticket-postgres`)
- 수정 SQL을 기존(잔존 볼륨) DB에 `ON_ERROR_STOP=1` 로 재적용 → DO 가드 4건 + ALTER 4건, **exit 0 (중단 없음)**, 2회차 재적용도 exit 0(멱등 확인)
- 적용 후 소유자 전수 일치:

  | 스키마 | 소유자 |
  |--------|--------|
  | user_service | `user_svc_user` |
  | event_service | `event_svc_user` |
  | reservation_service | `reservation_svc_user` |
  | payment_service | `payment_svc_user` |
  | common | `ticket` |

- `sh -n` 문법 검사 통과, heredoc 달러쿼팅(`\$do\$`, `\$\$`) 렌더링 검증 완료
- 스키마 소유자만 변경되며 테이블 소유자(서비스별 DDL에서 별도 지정)와 `common` GRANT에는 영향 없음 → 스키마 격리(TC-ENV-004)는 오히려 강화

Closes #257