### PR TITLE
fix: [Reservation/Test] 통합 테스트 ApplicationContext 로드 실패 해소 (#259)

### DIFF
--- a/backend/reservation-service/src/test/resources/application-test.yml
+++ b/backend/reservation-service/src/test/resources/application-test.yml
@@ -10,10 +10,15 @@ spring:
         config:
           event-service:
             url: http://localhost:8082
-  # Kafka auto-configuration 제외 (테스트에서 Kafka 브로커 불필요)
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+  # Kafka: @EnableKafka + @KafkaListener(PaymentEventConsumer)가 kafkaListenerContainerFactory
+  # 빈을 요구하므로 KafkaAutoConfiguration 은 프로덕션과 동일하게 활성 상태로 둔다.
+  # 단, 리스너 컨테이너는 기동하지 않아(auto-startup=false) 브로커 연결을 시도하지 않으므로
+  # 컨텍스트 로드에 실제 Kafka 브로커가 필요 없다. 실제 브로커가 필요한 e2e 테스트
+  # (ReservationOutboxPollerIntegrationTest)는 @DynamicPropertySource 로 testcontainer
+  # 주소를 주입하고 자체 KafkaConsumer 로 검증한다.
+  kafka:
+    listener:
+      auto-startup: false
   jpa:
     hibernate:
       ddl-auto: validate

--- a/docs/integration-test/00_environment_setup.md
+++ b/docs/integration-test/00_environment_setup.md
@@ -5,7 +5,7 @@
 > **주 실행 수단**: docker-compose, ./gradlew build/test, curl health check
 > **총 항목 수**: 16
 > **실행 결과 (2026-05-30)**: 통과 7건 | 부분 통과 3건 | 실패 1건 | 미실행 4건 (백엔드 서비스 기동 필요 3건 + Prometheus 타겟 1건)
-> **발견된 이슈**: #257 스키마 소유자 불일치 | #258 localstack_init.sh 멱등성 | #259 reservation-service 테스트 ApplicationContext 실패 | #260 event-service 테스트 2종 | #261 integrationTest 태스크 없음
+> **발견된 이슈**: #257 스키마 소유자 불일치 | #258 localstack_init.sh 멱등성 | #259 reservation-service 테스트 ApplicationContext 실패 (해소 2026-05-30, PR #265) | #260 event-service 테스트 2종 | #261 integrationTest 태스크 없음
 
 ---
 
@@ -423,7 +423,7 @@
 - [!] 실패 (2026-05-30, 근거:
   - `./gradlew build -x test`: BUILD SUCCESSFUL (557ms, 47 tasks up-to-date) ✓
   - `./gradlew test`: BUILD FAILED — reservation-service 29개, event-service 3개 실패
-    - reservation-service: 전 통합 테스트 `IllegalStateException: Failed to load ApplicationContext` — `NoSuchBeanDefinitionException: No bean named 'kafkaListenerContainerFactory'` → 이슈 #259
+    - reservation-service: 전 통합 테스트 `IllegalStateException: Failed to load ApplicationContext` — `NoSuchBeanDefinitionException: No bean named 'kafkaListenerContainerFactory'` → 이슈 #259 (해소 2026-05-30, PR #265: `application-test.yml` 의 `KafkaAutoConfiguration` 제외 제거 + `spring.kafka.listener.auto-startup=false`. `./gradlew :reservation-service:test` → 68건 green. 단, #260·#261 미해소로 TC-ENV-014 전체는 여전히 실패)
     - event-service(1): `EventControllerTest` `GET /events/schedules/{scheduleId}/seats` → 404 (URL 매핑 불일치) → 이슈 #260
     - event-service(2): `SeatServiceTest` `releaseHoldSeats` MockK vararg 매처 불일치 → 이슈 #260
   - `./gradlew integrationTest`: Task 'integrationTest' not found — 태스크 미정의 → 이슈 #261)


### PR DESCRIPTION
## 개요

`Closes #259` — [TC-ENV-014] reservation-service 통합 테스트 ApplicationContext 로드 실패

reservation-service의 `@SpringBootTest` 테스트들이 `NoSuchBeanDefinitionException: No bean named 'kafkaListenerContainerFactory' available` 로 컨텍스트 로드에 실패하던 문제를 해결합니다.

## 근본 원인

| 요소 | 상태 |
|------|------|
| `application-test.yml` | `spring.autoconfigure.exclude` 로 `KafkaAutoConfiguration` **제외** |
| `KafkaConfig.kt` | `@Configuration @EnableKafka` |
| `PaymentEventConsumer.kt` | `@KafkaListener(topics=["payment.events"], ...)` |
| `common-kafka` | **producer 빈만** 제공, `kafkaListenerContainerFactory` 는 Spring Boot `KafkaAutoConfiguration` 에 의존 |

`@EnableKafka` + `@KafkaListener` 는 기본 이름 `kafkaListenerContainerFactory` 빈을 요구하는데, 그 빈을 만들어 주는 `KafkaAutoConfiguration` 을 테스트 프로파일이 제외해 버려(의도: "테스트에 브로커 불필요") 풀 컨텍스트 로드 단계에서 전체가 무너졌습니다. 즉 이슈가 제시한 후보 3번(`exclude`)이 이미 적용되어 있었고 그게 **원인**이었습니다.

> 참고: payment-service도 같은 `exclude` 를 갖지만 `@KafkaListener`/`@EnableKafka` 가 없어 무해합니다. 이 버그는 consumer 인 reservation-service 에만 존재합니다.

## 해결 방안

"`@KafkaListener` 는 있지만 테스트에 실제 브로커는 불필요"의 표준 Spring 관용구를 적용했습니다.

```yaml
# 변경 전: KafkaAutoConfiguration 제외 → kafkaListenerContainerFactory 누락
# 변경 후:
spring:
  kafka:
    listener:
      auto-startup: false
```

- `KafkaAutoConfiguration` 을 **프로덕션과 동일하게 활성**으로 복원 → `kafkaListenerContainerFactory` 정상 생성
- `auto-startup: false` 로 리스너 컨테이너만 미기동(생성은 되되 `start()` 미호출) → **브로커 연결 시도 없음**, 따라서 컨텍스트 로드에 브로커 불필요
- 실제 브로커가 필요한 e2e 테스트(`ReservationOutboxPollerIntegrationTest`)는 `@DynamicPropertySource` 로 testcontainer Kafka 주소를 주입하고 자체 `KafkaConsumer` 로 검증하므로 영향 없음

후보 1(모든 테스트에 실제 브로커)·후보 2(`@MockBean` 반복)보다 단일 설정 변경으로 끝나고 테스트 배선이 프로덕션과 충실히 일치합니다.

## 변경 파일

- `backend/reservation-service/src/test/resources/application-test.yml` (단일 파일)

## 검증

```
./gradlew :reservation-service:test  →  BUILD SUCCESSFUL
68 tests, 0 failures, 0 errors, 0 skipped
```

- 기존 실패 7개 클래스 전부 green: `OutboxInfraWiringTest`, `HoldSeatsIntegrationTest`, `HoldSeatsConcurrencyTest`, `ChangeSeatsIntegrationTest`, `ChangeSeatsConcurrencyTest`, `CancelReservationOutboxIntegrationTest`, `ReservationInternalControllerSecurityTest`
- 실제 브로커 e2e `ReservationOutboxPollerIntegrationTest` green 유지