### PR TITLE
fix: [Event/Test] event-service 테스트 2종 실패 해소 (#260)

### DIFF
--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/controller/EventControllerTest.kt
@@ -46,12 +46,12 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 @WebMvcTest(
-    controllers = [EventController::class],
+    controllers = [EventController::class, SeatController::class],
     useDefaultFilters = false,
     includeFilters = [
         ComponentScan.Filter(
             type = FilterType.ASSIGNABLE_TYPE,
-            classes = [EventController::class, GlobalExceptionHandler::class, SecurityConfig::class]
+            classes = [EventController::class, SeatController::class, GlobalExceptionHandler::class, SecurityConfig::class]
         )
     ],
     excludeAutoConfiguration = [
@@ -62,7 +62,7 @@ import java.util.UUID
         ParameterStoreAutoConfiguration::class
     ]
 )
-@ContextConfiguration(classes = [EventController::class, GlobalExceptionHandler::class, SecurityConfig::class])
+@ContextConfiguration(classes = [EventController::class, SeatController::class, GlobalExceptionHandler::class, SecurityConfig::class])
 @ActiveProfiles("test")
 @TestPropertySource(properties = [
     "spring.cloud.aws.region.static=us-east-1",

--- a/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
+++ b/backend/event-service/src/test/kotlin/com/ticketqueue/event/service/SeatServiceTest.kt
@@ -386,27 +386,26 @@ class SeatServiceTest {
         private val seatIds = listOf(UUID.randomUUID(), UUID.randomUUID())
 
         @Test
-        @DisplayName("DB를 AVAILABLE로 복원하고 Redis hold_seats에서 좌석을 제거하며 캐시를 무효화한다")
-        fun removesFromHoldSeatsAndEvictsCache() {
+        @DisplayName("DB를 AVAILABLE로 복원하고 캐시를 무효화한다 (hold_seats SREM은 Reservation Service 담당)")
+        fun restoresAvailableAndEvictsCache() {
             every { seatRepository.updateStatusToAvailable(scheduleId, seatIds) } returns 2L
-            every { setOps.remove(any<String>(), *anyVararg()) } returns 2L
             every { redisTemplate.delete(any<String>()) } returns true
 
             seatService.releaseHoldSeats(scheduleId, seatIds)
 
             verify { seatRepository.updateStatusToAvailable(scheduleId, seatIds) }
-            verify { setOps.remove("hold_seats:$scheduleId", *anyVararg()) }
             verify { redisTemplate.delete("cache:seats:$scheduleId") }
         }
 
         @Test
-        @DisplayName("Redis 장애 시 예외를 전파하지 않는다")
+        @DisplayName("Redis 캐시 무효화 실패 시에도 예외를 전파하지 않는다")
         fun doesNotPropagateRedisFailure() {
             every { seatRepository.updateStatusToAvailable(scheduleId, seatIds) } returns 2L
-            every { setOps.remove(any<String>(), *anyVararg()) } throws RedisConnectionFailureException("connection failed")
-            every { redisTemplate.delete(any<String>()) } returns true
+            every { redisTemplate.delete(any<String>()) } throws RedisConnectionFailureException("connection failed")
 
             seatService.releaseHoldSeats(scheduleId, seatIds)
+
+            verify { seatRepository.updateStatusToAvailable(scheduleId, seatIds) }
         }
     }
 }

--- a/docs/integration-test/00_environment_setup.md
+++ b/docs/integration-test/00_environment_setup.md
@@ -5,7 +5,7 @@
 > **주 실행 수단**: docker-compose, ./gradlew build/test, curl health check
 > **총 항목 수**: 16
 > **실행 결과 (2026-05-30)**: 통과 9건 | 부분 통과 2건 | 실패 1건 | 미실행 4건 (백엔드 서비스 기동 필요 3건 + Prometheus 타겟 1건)
-> **발견된 이슈**: ~~#257 스키마 소유자 불일치~~ (해결) | #258 localstack_init.sh 멱등성 | #259 reservation-service 테스트 ApplicationContext 실패 | #260 event-service 테스트 2종 | #261 integrationTest 태스크 없음
+> **발견된 이슈**: ~~#257 스키마 소유자 불일치~~ (해결) | #258 localstack_init.sh 멱등성 | #259 reservation-service 테스트 ApplicationContext 실패 | ~~#260 event-service 테스트 2종~~ (해결) | #261 integrationTest 태스크 없음
 ---
 
 ### TC-ENV-001 — 인프라 컨테이너 전체 기동 및 healthcheck 통과 확인
@@ -422,9 +422,9 @@
 - [!] 실패 (2026-05-30, 근거:
   - `./gradlew build -x test`: BUILD SUCCESSFUL (557ms, 47 tasks up-to-date) ✓
   - `./gradlew test`: BUILD FAILED — reservation-service 29개, event-service 3개 실패
-    - reservation-service: 전 통합 테스트 `IllegalStateException: Failed to load ApplicationContext` — `NoSuchBeanDefinitionException: No bean named 'kafkaListenerContainerFactory'` → 이슈 #259 (해소 2026-05-30, PR #265: `application-test.yml` 의 `KafkaAutoConfiguration` 제외 제거 + `spring.kafka.listener.auto-startup=false`. `./gradlew :reservation-service:test` → 68건 green. 단, #260·#261 미해소로 TC-ENV-014 전체는 여전히 실패)
-    - event-service(1): `EventControllerTest` `GET /events/schedules/{scheduleId}/seats` → 404 (URL 매핑 불일치) → 이슈 #260
-    - event-service(2): `SeatServiceTest` `releaseHoldSeats` MockK vararg 매처 불일치 → 이슈 #260
+    - reservation-service: 전 통합 테스트 `IllegalStateException: Failed to load ApplicationContext` — `NoSuchBeanDefinitionException: No bean named 'kafkaListenerContainerFactory'` → 이슈 #259 (해소 2026-05-30, PR #265: `application-test.yml` 의 `KafkaAutoConfiguration` 제외 제거 + `spring.kafka.listener.auto-startup=false`. `./gradlew :reservation-service:test` → 68건 green. 단, #261 미해소로 TC-ENV-014 전체는 여전히 실패)
+    - event-service(1): `EventControllerTest` `GET /events/schedules/{scheduleId}/seats` → 404 (URL 매핑 불일치) → 이슈 #260 (해소 2026-05-30, PR #266: 좌석 라우트는 `SeatController`(`/events/schedules`)에 매핑되나 `@WebMvcTest(EventController)` 슬라이스에 미포함되어 라우트 미등록 → 404. `controllers`·`includeFilters`·`@ContextConfiguration` 에 `SeatController` 추가. `GET /events/**` 는 SecurityConfig 에서 이미 permitAll 이라 공개 접근 200 통과)
+    - event-service(2): `SeatServiceTest` `releaseHoldSeats` MockK vararg 매처 불일치 → 이슈 #260 (해소 2026-05-30, PR #266: 실제 `releaseHoldSeats` 는 DB AVAILABLE 복원 + 캐시 무효화만 수행하고 `hold_seats` SREM 은 Reservation Service 담당[KDoc/주석 명시]이므로, 발생하지 않는 `setOps.remove` stub/verify 가 stale → 제거. 실패 격리 검증은 실제 Redis 작업인 캐시 무효화(`redisTemplate.delete`) 실패 시나리오로 정정. `./gradlew :event-service:test` → 314건 green)
   - `./gradlew integrationTest`: Task 'integrationTest' not found — 태스크 미정의 → 이슈 #261)
 - **관련 REQ**: 해당 없음
 - **분류**: 정상


### PR DESCRIPTION
## 개요

`TC-ENV-014` (`./gradlew test`) 실행 중 발견된 **event-service 단위 테스트 2종 실패**(이슈 #260)를 해소합니다.

Closes #260

## 변경 사항

### 버그 1 — `EventControllerTest` `GET /events/schedules/{scheduleId}/seats` → 404

- **원인**: 좌석 조회 엔드포인트는 `SeatController`(`@RequestMapping("/events/schedules")`)에 매핑되어 있으나, 테스트가 `@WebMvcTest(controllers = [EventController::class], useDefaultFilters = false, ...)` 슬라이스로 빈 등록을 화이트리스트화하면서 `SeatController`를 포함하지 않아 해당 라우트가 `DispatcherServlet`에 등록되지 않음 → 404.
- **수정**: `controllers` / `includeFilters` / `@ContextConfiguration` 세 곳에 `SeatController::class` 추가.
  - `GET /events/**`는 `SecurityConfig`에서 이미 `permitAll()`이므로 공개 접근(인증 없이 200) 테스트도 그대로 통과.

### 버그 2 — `SeatServiceTest` `releaseHoldSeats` MockK 매처 불일치

- **원인**: 실제 `SeatService.releaseHoldSeats`는 **DB AVAILABLE 복원 + 캐시 무효화**만 수행하며, `hold_seats` SET의 SREM은 **Reservation Service 담당**입니다(`SeatService` KDoc·메서드 주석·아키텍처에 명시). 테스트는 발생하지 않는 `setOps.remove(...)` 호출을 `verify`하고 있어 실패.
- **수정**:
  - 발생하지 않는 `setOps.remove` stub/verify 제거(stale 테스트 정정).
  - "Redis 장애 시 예외 비전파" 테스트를 실제 Redis 작업인 캐시 무효화(`redisTemplate.delete`) 실패 시나리오로 정정하고, DB 복원 호출을 `verify`로 보강.

> 참고: 이슈의 "해결 방안"은 vararg 매처 수정이었으나, 실제 구현은 SREM을 호출하지 않으므로 매처만 고치면 여전히 실패합니다. 문서화된 아키텍처(SREM = Reservation Service 책임)에 맞춰 테스트를 정렬했습니다.

## 검증

```
./gradlew :event-service:test
→ BUILD SUCCESSFUL — 314 tests, 0 failures, 0 errors
```

## 문서

- `docs/integration-test/00_environment_setup.md` TC-ENV-014 항목에 #260 해소 내역 반영(별도 커밋).
