### PR TITLE
fix: [Build/Gradle] integrationTest 태스크 정의 — 문서-코드 불일치 해소 (#261)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -41,4 +41,25 @@ subprojects {
     tasks.withType<Test> {
         useJUnitPlatform()
     }
+
+    // 통합 테스트(TestContainers 기반) 전용 실행 태스크.
+    // 기존 test 소스셋을 그대로 재사용하여 `*IntegrationTest` 클래스와 `*.integration.*`
+    // 패키지에 속한 테스트만 선별 실행한다. test 태스크 동작은 변경하지 않으므로
+    // `./gradlew test` 는 종전대로 단위+통합 테스트를 모두 수행한다. (이슈 #261)
+    plugins.withType<JavaPlugin> {
+        val testSourceSet = extensions.getByType<SourceSetContainer>()["test"]
+        tasks.register<Test>("integrationTest") {
+            description = "TestContainers 기반 통합 테스트 실행 (*IntegrationTest, *.integration.* 패키지)"
+            group = "verification"
+            testClassesDirs = testSourceSet.output.classesDirs
+            classpath = testSourceSet.runtimeClasspath
+            useJUnitPlatform()
+            filter {
+                includeTestsMatching("*IntegrationTest")
+                includeTestsMatching("*.integration.*")
+                isFailOnNoMatchingTests = false
+            }
+            shouldRunAfter(tasks.named("test"))
+        }
+    }
 }

--- a/docs/integration-test/00_environment_setup.md
+++ b/docs/integration-test/00_environment_setup.md
@@ -5,7 +5,7 @@
 > **주 실행 수단**: docker-compose, ./gradlew build/test, curl health check
 > **총 항목 수**: 16
 > **실행 결과 (2026-05-30)**: 통과 9건 | 부분 통과 2건 | 실패 1건 | 미실행 4건 (백엔드 서비스 기동 필요 3건 + Prometheus 타겟 1건)
-> **발견된 이슈**: ~~#257 스키마 소유자 불일치~~ (해결) | #258 localstack_init.sh 멱등성 | #259 reservation-service 테스트 ApplicationContext 실패 | ~~#260 event-service 테스트 2종~~ (해결) | #261 integrationTest 태스크 없음
+> **발견된 이슈**: ~~#257 스키마 소유자 불일치~~ (해결) | #258 localstack_init.sh 멱등성 | #259 reservation-service 테스트 ApplicationContext 실패 | ~~#260 event-service 테스트 2종~~ (해결) | ~~#261 integrationTest 태스크 없음~~ (해결)
 ---
 
 ### TC-ENV-001 — 인프라 컨테이너 전체 기동 및 healthcheck 통과 확인
@@ -422,10 +422,10 @@
 - [!] 실패 (2026-05-30, 근거:
   - `./gradlew build -x test`: BUILD SUCCESSFUL (557ms, 47 tasks up-to-date) ✓
   - `./gradlew test`: BUILD FAILED — reservation-service 29개, event-service 3개 실패
-    - reservation-service: 전 통합 테스트 `IllegalStateException: Failed to load ApplicationContext` — `NoSuchBeanDefinitionException: No bean named 'kafkaListenerContainerFactory'` → 이슈 #259 (해소 2026-05-30, PR #265: `application-test.yml` 의 `KafkaAutoConfiguration` 제외 제거 + `spring.kafka.listener.auto-startup=false`. `./gradlew :reservation-service:test` → 68건 green. 단, #261 미해소로 TC-ENV-014 전체는 여전히 실패)
+    - reservation-service: 전 통합 테스트 `IllegalStateException: Failed to load ApplicationContext` — `NoSuchBeanDefinitionException: No bean named 'kafkaListenerContainerFactory'` → 이슈 #259 (해소 2026-05-30, PR #265: `application-test.yml` 의 `KafkaAutoConfiguration` 제외 제거 + `spring.kafka.listener.auto-startup=false`. `./gradlew :reservation-service:test` → 68건 green. 단, 별도 발견된 queue-service Lua 테스트 2종(`QueueEnterLuaTest`·`BatchApproveLuaTest`)이 소스에 하드코딩된 타 worktree 절대경로(`ticket-queue-199`)로 Lua 파일을 읽어 `./gradlew test` 전체는 여전히 실패 — #261과 무관, 별도 이슈 권고)
     - event-service(1): `EventControllerTest` `GET /events/schedules/{scheduleId}/seats` → 404 (URL 매핑 불일치) → 이슈 #260 (해소 2026-05-30, PR #266: 좌석 라우트는 `SeatController`(`/events/schedules`)에 매핑되나 `@WebMvcTest(EventController)` 슬라이스에 미포함되어 라우트 미등록 → 404. `controllers`·`includeFilters`·`@ContextConfiguration` 에 `SeatController` 추가. `GET /events/**` 는 SecurityConfig 에서 이미 permitAll 이라 공개 접근 200 통과)
     - event-service(2): `SeatServiceTest` `releaseHoldSeats` MockK vararg 매처 불일치 → 이슈 #260 (해소 2026-05-30, PR #266: 실제 `releaseHoldSeats` 는 DB AVAILABLE 복원 + 캐시 무효화만 수행하고 `hold_seats` SREM 은 Reservation Service 담당[KDoc/주석 명시]이므로, 발생하지 않는 `setOps.remove` stub/verify 가 stale → 제거. 실패 격리 검증은 실제 Redis 작업인 캐시 무효화(`redisTemplate.delete`) 실패 시나리오로 정정. `./gradlew :event-service:test` → 314건 green)
-  - `./gradlew integrationTest`: Task 'integrationTest' not found — 태스크 미정의 → 이슈 #261)
+  - `./gradlew integrationTest`: Task 'integrationTest' not found — 태스크 미정의 → 이슈 #261 (해소 2026-05-30: root `build.gradle.kts` `subprojects` 블록에 `integrationTest` Test 태스크 정의 — 기존 `test` 소스셋 재사용 + `*IntegrationTest`·`*.integration.*` 패키지 필터, `test` 태스크 동작은 불변. `./gradlew integrationTest` 태스크 인식 정상화[`Task 'integrationTest' not found` 해소], `./gradlew :queue-service:integrationTest` → 통합 테스트 2종 green 확인))
 - **관련 REQ**: 해당 없음
 - **분류**: 정상
 - **우선순위**: P0(필수/핵심)


### PR DESCRIPTION
## 개요
`docs/integration-test/00_environment_setup.md` TC-ENV-014 가 안내하는 `./gradlew integrationTest` 명령이 실제로는 태스크 미정의로 `Task 'integrationTest' not found` (BUILD FAILED) 가 발생하던 **문서-코드 불일치**(이슈 #261)를 해소한다.

이슈에서 제시한 해결방안 2(**Gradle에 `integrationTest` 태스크 실제 정의**)를 채택했다. CLAUDE.md 가 `./gradlew integrationTest # TestContainers` 를 실제 명령으로 문서화하고 있으므로, 문서만 고치는 대신 그 명령이 동작하도록 만드는 것이 올바른 수정이다.

## 변경 사항
### 1. `backend/build.gradle.kts` — `integrationTest` 태스크 추가 (순수 추가형)
- root `subprojects` 블록에 `integrationTest` Test 태스크 등록
- 기존 `test` 소스셋을 그대로 **재사용**(`testClassesDirs`/`classpath`), 별도 소스셋 분리·테스트 파일 이동 없음
- 필터: `*IntegrationTest` 클래스 + `*.integration.*` 패키지만 선별 (`@Tag` 미사용 환경에 맞춰 네이밍·패키지 신호 기반)
- **`test` 태스크 동작은 변경하지 않음** → `./gradlew test` 는 종전대로 단위+통합을 모두 수행. (`test`를 단위 전용으로 바꾸면 직전 머지된 #266 의 "`:event-service:test` → 314건 green" 기록과 논리적으로 어긋나므로 순수 추가형을 택함)

### 2. `docs/integration-test/00_environment_setup.md` — TC-ENV-014 갱신
- 헤더 "발견된 이슈": `#261` 을 `(해결)` 로 표기
- integrationTest 평가 라인: 해소 근거 기록
- (충돌 회피) #266 이 수정한 라인은 그대로 보존

## 검증
- `./gradlew :reservation-service:tasks --all` → `integrationTest` 등록 확인
- `./gradlew integrationTest --dry-run` → **BUILD SUCCESSFUL** (전 서브프로젝트에 태스크 그래프 구성, `Task not found` 해소)
- 필터 정적 검증 → `*IntegrationTest`/`*.integration.*` 통합 테스트 19개 정확히 포착, 단위 테스트 미포함
- `./gradlew :queue-service:integrationTest` → **BUILD SUCCESSFUL**, TestContainers 로 `QueueLeaveIntegrationTest`·`BatchApproveIntegrationTest` 실제 실행·green (단위 테스트는 미실행 → 필터 정상)

## merge conflict 회피
- 작업 시점 유일한 열린 PR 이던 #266(fix/260) 머지 후, 최신 `origin/develop` 에 **rebase** 하여 문서 인접-라인 충돌을 직접 해소
- `git merge-tree origin/develop HEAD` → **충돌 0** 확인
- 코드 변경은 `backend/build.gradle.kts` 단일 파일로, 타 브랜치와 파일 중첩 없음

## 별도 발견 (이 PR 범위 밖, 후속 이슈 권고)
검증 중 `./gradlew test` 전체 실행에서 `queue-service` 의 `QueueEnterLuaTest`·`BatchApproveLuaTest` 가 실패함을 발견.
- 원인: 테스트 소스에 **타 worktree 절대경로가 하드코딩**됨
  ```kotlin
  File("/Users/taekwon/work/project/ticket-queue-199/backend/.../queue-enter.lua").readText()
  ```
- `ticket-queue-199` 디렉터리에서 실행할 때만 통과하는 이식성 버그 (이 PR/#261 과 무관, develop 선결 존재)
- 권고: Lua 파일을 `ClassPathResource` 또는 상대경로로 로드하도록 별도 이슈/PR 로 수정

Closes #261


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced integration testing infrastructure with dedicated test task configuration for TestContainers-based tests.

* **Documentation**
  * Updated integration test environment setup documentation with resolved issues and current test execution status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paircoders/ticket-queue/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->