### PR TITLE
docs: [TC-ENV] 00_environment_setup 이슈/PR 상태 동기화 (#258·#259 해결 반영, #268 추가)

### DIFF
--- a/docs/integration-test/00_environment_setup.md
+++ b/docs/integration-test/00_environment_setup.md
@@ -5,7 +5,7 @@
 > **주 실행 수단**: docker-compose, ./gradlew build/test, curl health check
 > **총 항목 수**: 16
 > **실행 결과 (2026-05-30)**: 통과 9건 | 부분 통과 2건 | 실패 1건 | 미실행 4건 (백엔드 서비스 기동 필요 3건 + Prometheus 타겟 1건)
-> **발견된 이슈**: ~~#257 스키마 소유자 불일치~~ (해결) | #258 localstack_init.sh 멱등성 | #259 reservation-service 테스트 ApplicationContext 실패 | ~~#260 event-service 테스트 2종~~ (해결) | ~~#261 integrationTest 태스크 없음~~ (해결)
+> **발견된 이슈**: ~~#257 스키마 소유자 불일치~~ (해결, PR #264) | ~~#258 localstack_init.sh 멱등성~~ (해결, PR #263) | ~~#259 reservation-service 테스트 ApplicationContext 실패~~ (해결, PR #265) | ~~#260 event-service 테스트 2종~~ (해결, PR #266) | ~~#261 integrationTest 태스크 없음~~ (해결, PR #267) | #268 queue-service Lua 테스트 하드코딩 절대경로 (미해결, OPEN)
 ---
 
 ### TC-ENV-001 — 인프라 컨테이너 전체 기동 및 healthcheck 통과 확인
@@ -161,7 +161,7 @@
 
 ### TC-ENV-006 — LocalStack 시크릿 등록 전 서비스 기동 시 실패 케이스(시크릿 미주입)
 
-- [x] 부분 통과 (2026-05-30, 근거: `common/secure-config` 삭제 후 시크릿 목록에서 제거됨 확인. **[버그]** 복구 시도로 `localstack_init.sh` 재실행 시 `set -e` + 비멱등 명령 조합으로 S3 버킷 생성 단계(`s3 mb` → `BucketAlreadyOwnedByYou`)에서 즉시 중단되어 `common/secure-config` 미복구(시크릿 4개). 수동 `awslocal secretsmanager create-secret` 으로 복구. **[수정 완료 → #258]** `localstack_init.sh` 멱등화: S3는 `head-bucket` 분기, 시크릿은 `put_secret` 헬퍼(`describe-secret` 분기 후 update/create)로 통일. 동일 복구 시나리오 재실행 → exit 0, `common/secure-config` 정상 복구(시크릿 5개), 필수 키 정합 확인. 5개 모두 존재 상태 재실행도 전부 update 경로·`ResourceExistsException` 0건·exit 0으로 멱등성 재검증 완료. **Spring Boot 서비스 기동 실패 시나리오(로그 확인)는 백엔드 컨테이너 이미지 없어 여전히 미검증** → 부분 통과 유지)
+- [x] 부분 통과 (2026-05-30, 근거: `common/secure-config` 삭제 후 시크릿 목록에서 제거됨 확인. **[버그]** 복구 시도로 `localstack_init.sh` 재실행 시 `set -e` + 비멱등 명령 조합으로 S3 버킷 생성 단계(`s3 mb` → `BucketAlreadyOwnedByYou`)에서 즉시 중단되어 `common/secure-config` 미복구(시크릿 4개). 수동 `awslocal secretsmanager create-secret` 으로 복구. **[수정 완료 → #258, PR #263]** `localstack_init.sh` 멱등화: S3는 `head-bucket` 분기, 시크릿은 `put_secret` 헬퍼(`describe-secret` 분기 후 update/create)로 통일. 동일 복구 시나리오 재실행 → exit 0, `common/secure-config` 정상 복구(시크릿 5개), 필수 키 정합 확인. 5개 모두 존재 상태 재실행도 전부 update 경로·`ResourceExistsException` 0건·exit 0으로 멱등성 재검증 완료. **Spring Boot 서비스 기동 실패 시나리오(로그 확인)는 백엔드 컨테이너 이미지 없어 여전히 미검증** → 부분 통과 유지)
 - **관련 REQ**: 해당 없음
 - **분류**: 예외
 - **우선순위**: P1(중요)
@@ -422,10 +422,10 @@
 - [!] 실패 (2026-05-30, 근거:
   - `./gradlew build -x test`: BUILD SUCCESSFUL (557ms, 47 tasks up-to-date) ✓
   - `./gradlew test`: BUILD FAILED — reservation-service 29개, event-service 3개 실패
-    - reservation-service: 전 통합 테스트 `IllegalStateException: Failed to load ApplicationContext` — `NoSuchBeanDefinitionException: No bean named 'kafkaListenerContainerFactory'` → 이슈 #259 (해소 2026-05-30, PR #265: `application-test.yml` 의 `KafkaAutoConfiguration` 제외 제거 + `spring.kafka.listener.auto-startup=false`. `./gradlew :reservation-service:test` → 68건 green. 단, 별도 발견된 queue-service Lua 테스트 2종(`QueueEnterLuaTest`·`BatchApproveLuaTest`)이 소스에 하드코딩된 타 worktree 절대경로(`ticket-queue-199`)로 Lua 파일을 읽어 `./gradlew test` 전체는 여전히 실패 — #261과 무관, 별도 이슈 권고)
+    - reservation-service: 전 통합 테스트 `IllegalStateException: Failed to load ApplicationContext` — `NoSuchBeanDefinitionException: No bean named 'kafkaListenerContainerFactory'` → 이슈 #259 (해소 2026-05-30, PR #265: `application-test.yml` 의 `KafkaAutoConfiguration` 제외 제거 + `spring.kafka.listener.auto-startup=false`. `./gradlew :reservation-service:test` → 68건 green. 단, 별도 발견된 queue-service Lua 테스트 2종(`QueueEnterLuaTest`·`BatchApproveLuaTest`)이 소스에 하드코딩된 타 worktree 절대경로(`ticket-queue-199`)로 Lua 파일을 읽어 `./gradlew test` 전체는 여전히 실패 — #261과 무관, 별도 이슈 #268로 분리(OPEN, classpath 리소스 로딩으로 전환 권고))
     - event-service(1): `EventControllerTest` `GET /events/schedules/{scheduleId}/seats` → 404 (URL 매핑 불일치) → 이슈 #260 (해소 2026-05-30, PR #266: 좌석 라우트는 `SeatController`(`/events/schedules`)에 매핑되나 `@WebMvcTest(EventController)` 슬라이스에 미포함되어 라우트 미등록 → 404. `controllers`·`includeFilters`·`@ContextConfiguration` 에 `SeatController` 추가. `GET /events/**` 는 SecurityConfig 에서 이미 permitAll 이라 공개 접근 200 통과)
     - event-service(2): `SeatServiceTest` `releaseHoldSeats` MockK vararg 매처 불일치 → 이슈 #260 (해소 2026-05-30, PR #266: 실제 `releaseHoldSeats` 는 DB AVAILABLE 복원 + 캐시 무효화만 수행하고 `hold_seats` SREM 은 Reservation Service 담당[KDoc/주석 명시]이므로, 발생하지 않는 `setOps.remove` stub/verify 가 stale → 제거. 실패 격리 검증은 실제 Redis 작업인 캐시 무효화(`redisTemplate.delete`) 실패 시나리오로 정정. `./gradlew :event-service:test` → 314건 green)
-  - `./gradlew integrationTest`: Task 'integrationTest' not found — 태스크 미정의 → 이슈 #261 (해소 2026-05-30: root `build.gradle.kts` `subprojects` 블록에 `integrationTest` Test 태스크 정의 — 기존 `test` 소스셋 재사용 + `*IntegrationTest`·`*.integration.*` 패키지 필터, `test` 태스크 동작은 불변. `./gradlew integrationTest` 태스크 인식 정상화[`Task 'integrationTest' not found` 해소], `./gradlew :queue-service:integrationTest` → 통합 테스트 2종 green 확인))
+  - `./gradlew integrationTest`: Task 'integrationTest' not found — 태스크 미정의 → 이슈 #261 (해소 2026-05-30, PR #267: root `build.gradle.kts` `subprojects` 블록에 `integrationTest` Test 태스크 정의 — 기존 `test` 소스셋 재사용 + `*IntegrationTest`·`*.integration.*` 패키지 필터, `test` 태스크 동작은 불변. `./gradlew integrationTest` 태스크 인식 정상화[`Task 'integrationTest' not found` 해소], `./gradlew :queue-service:integrationTest` → 통합 테스트 2종 green 확인))
 - **관련 REQ**: 해당 없음
 - **분류**: 정상
 - **우선순위**: P0(필수/핵심)


### PR DESCRIPTION
## 개요
`docs/integration-test/00_environment_setup.md` 의 이슈/PR 참조를 **GitHub Issue/PR 상태(source of truth)** 와 동기화합니다.

이 문서 헤더의 `발견된 이슈` 라인이 GitHub 실제 상태와 drift 되어 있었습니다. 본문(각 TC의 evidence)은 이미 수정 내역을 반영하고 있었으나, 요약 라인만 일부 이슈를 미해결로 표기하고 있던 불일치를 해소합니다.

## 동기화 내역

| 이슈 | GitHub 상태 | 해결 PR | 문서(수정 전) | 문서(수정 후) |
|------|-------------|---------|---------------|---------------|
| #257 스키마 소유자 | CLOSED | #264 | 해결 | 해결, PR #264 |
| #258 localstack 멱등성 | CLOSED | #263 | **미해결** ❌ | 해결, PR #263 ✅ |
| #259 reservation ApplicationContext | CLOSED | #265 | **미해결** ❌ | 해결, PR #265 ✅ |
| #260 event-service 테스트 2종 | CLOSED | #266 | 해결 | 해결, PR #266 |
| #261 integrationTest 태스크 | CLOSED | #267 | 해결 | 해결, PR #267 |
| #268 queue-service Lua 하드코딩 경로 | **OPEN** | — | **누락** ❌ | 미해결(OPEN) 명시 ✅ |

## 변경 상세
- **헤더 8행(`발견된 이슈`)**: #258·#259를 해결로 정정, 전 해결 이슈에 PR 번호 부기, 신규 OPEN 이슈 #268 추가
- **TC-ENV-006 본문**: #258 근거에 PR #263 보강
- **TC-ENV-014 본문**: queue-service Lua 잔여 실패를 "별도 이슈 권고" → **#268로 분리**(classpath 로딩 전환 권고) 명시, #261 근거에 PR #267 보강

## 영향 범위
- 문서 단일 파일(`00_environment_setup.md`)만 변경 — 4 insertions / 4 deletions
- 본문 evidence 및 실행 결과 카운트(통과 9 / 부분통과 2 / 실패 1 / 미실행 4)는 **불변**, PR 참조와 헤더 요약만 정합화
- 코드 변경 없음

## 비고
- #268은 본 PR 범위가 아닌 별도 OPEN 버그(queue-service 테스트 이식성)이며, 문서에는 추적용으로만 참조합니다.
