### PR TITLE
[TC-USER] User Service 통합테스트(02) 실행 — 26 통과 / 1 실패(#273) + 갭 테스트 보강

### DIFF
--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/JwtTokenProviderTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/JwtTokenProviderTest.kt
@@ -1,0 +1,89 @@
+package com.ticketqueue.user.service
+
+import com.ticketqueue.common.exception.ErrorCode
+import com.ticketqueue.user.config.JwtProperties
+import com.ticketqueue.user.entity.UserRole
+import com.ticketqueue.user.exception.UserException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.Base64
+import java.util.Date
+import java.util.UUID
+
+/**
+ * JwtTokenProvider 단위 테스트 (User Service)
+ *
+ * Algorithm Confusion Attack 방지 검증 (TC-026):
+ * - alg=none 위조 토큰 거부 → INVALID_TOKEN (jjwt 0.12.6 기본 정책이 거부; 라이브러리 디폴트 회귀 방지용)
+ * - 동일 키 HS256 다운그레이드 토큰 거부 → INVALID_TOKEN (서명은 통과하나 parseAccessTokenJti 의 alg != "HS512" 커스텀 가드가 거부)
+ * - 정상 HS512 access token 은 jti 정상 반환
+ */
+class JwtTokenProviderTest {
+
+    private lateinit var testSecret: String
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    @BeforeEach
+    fun setUp() {
+        // HS512 서명을 위해 512비트(64바이트) 이상 키를 Base64 인코딩
+        val keyBytes = ByteArray(64) { it.toByte() }
+        testSecret = Base64.getEncoder().encodeToString(keyBytes)
+
+        val jwtProperties = JwtProperties(
+            secret = testSecret,
+            accessTokenExpiry = 3_600_000L,
+            refreshTokenExpiry = 1_209_600_000L
+        )
+        jwtTokenProvider = JwtTokenProvider(jwtProperties)
+    }
+
+    @Test
+    fun `parseAccessTokenJti - alg=none 으로 위조한 토큰은 INVALID_TOKEN 예외를 던진다`() {
+        // given - 서명이 없는 alg=none 토큰 (헤더.페이로드. 형태)
+        val forgedToken = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJ4In0."
+
+        // when & then
+        val exception = shouldThrow<UserException> {
+            jwtTokenProvider.parseAccessTokenJti(forgedToken)
+        }
+        exception.errorCode shouldBe ErrorCode.INVALID_TOKEN
+    }
+
+    @Test
+    fun `parseAccessTokenJti - 동일 키로 HS256 서명한 토큰은 알고리즘 불일치로 INVALID_TOKEN 예외를 던진다`() {
+        // given - 검증 키와 동일한 키로 HS256 서명 (서명은 통과, alg 체크에서 거부)
+        val key = Keys.hmacShaKeyFor(Base64.getDecoder().decode(testSecret))
+        val hs256Token = Jwts.builder()
+            .subject(UUID.randomUUID().toString())
+            .id(UUID.randomUUID().toString())
+            .claim("role", UserRole.USER.name)
+            .claim("email", "test@example.com")
+            .issuedAt(Date())
+            .expiration(Date(System.currentTimeMillis() + 3_600_000L))
+            .signWith(key, Jwts.SIG.HS256)
+            .compact()
+
+        // when & then
+        val exception = shouldThrow<UserException> {
+            jwtTokenProvider.parseAccessTokenJti(hs256Token)
+        }
+        exception.errorCode shouldBe ErrorCode.INVALID_TOKEN
+    }
+
+    @Test
+    fun `parseAccessTokenJti - 정상 HS512 access token 은 jti 를 정상 반환한다`() {
+        // given
+        val userId = UUID.randomUUID()
+        val (token, jti) = jwtTokenProvider.generateAccessToken(userId, UserRole.USER, "test@example.com")
+
+        // when
+        val parsedJti = jwtTokenProvider.parseAccessTokenJti(token)
+
+        // then
+        parsedJti shouldBe jti
+    }
+}

--- a/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/PortoneServiceTest.kt
+++ b/backend/user-service/src/test/kotlin/com/ticketqueue/user/service/PortoneServiceTest.kt
@@ -64,6 +64,29 @@ class PortoneServiceTest {
     }
 
     @Test
+    fun `본인인증 실패 - READY 상태이면 PORTONE_VERIFICATION_TIMEOUT 예외를 던진다`() {
+        // given
+        val identityVerificationId = "ready-id"
+        val accessToken = "Bearer test-token"
+        val response = PortoneIdentityV2Response(
+            id = identityVerificationId,
+            status = "READY",
+            verifiedCustomer = null
+        )
+
+        every { portoneTokenService.getAccessToken() } returns accessToken
+        every {
+            portoneClient.getIdentityVerification(identityVerificationId, "test-store-id", accessToken)
+        } returns response
+
+        // when & then
+        val exception = shouldThrow<UserException> {
+            portoneService.verifyIdentity(identityVerificationId)
+        }
+        exception.errorCode shouldBe ErrorCode.PORTONE_VERIFICATION_TIMEOUT
+    }
+
+    @Test
     fun `본인인증 실패 - 404 에러 발생 시 PORTONE_VERIFICATION_NOT_FOUND 예외를 던진다`() {
         // given
         val identityVerificationId = "invalid-id"

--- a/docs/integration-test/02_user_service.md
+++ b/docs/integration-test/02_user_service.md
@@ -9,7 +9,7 @@
 
 ### TC-USER-001 — 정상 회원가입: reCAPTCHA > PortOne CI/DI > 저장 전 플로우 성공
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 단위테스트 AuthServiceTest·AuthTransactionalServiceTest로 reCAPTCHA→PortOne→암호화 저장 플로우 검증, 라이브 DB로 email/name/phone 암호화 저장·복호화(/users/me)·password_hash $2a$·email_hash HMAC 구조 확인. PortOne 본인인증 발급은 외부 콘솔 의존)
 - **관련 REQ**: REQ-AUTH-001, REQ-AUTH-003, REQ-AUTH-004, REQ-AUTH-005, REQ-AUTH-014
 - **분류**: 정상
 - **우선순위**: P0
@@ -41,7 +41,7 @@
 
 ### TC-USER-002 — reCAPTCHA 검증 실패 시 회원가입 차단
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: AuthControllerTest "reCAPTCHA 검증 실패 시 400"·AuthServiceTest "RECAPTCHA_FAILED, processSignup 미호출". 로컬 reCAPTCHA 테스트 시크릿은 항상 success라 라이브 실패 유도 불가 → 단위테스트 근거)
 - **관련 REQ**: REQ-AUTH-003
 - **분류**: 예외, 보안
 - **우선순위**: P0
@@ -69,7 +69,7 @@
 
 ### TC-USER-003 — 동일 CI로 중복 가입 시도: 409 DUPLICATE_IDENTITY
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: AuthTransactionalServiceTest "CI 중복 - DUPLICATE_IDENTITY"·AuthControllerTest 409 + DB users_ci_hash_unique 제약 라이브 확인(TC-023))
 - **관련 REQ**: REQ-AUTH-004
 - **분류**: 예외, 보안
 - **우선순위**: P0
@@ -98,7 +98,7 @@
 
 ### TC-USER-004 — 이메일 중복 가입 시도: 409 ALREADY_EXISTS_EMAIL
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: AuthTransactionalServiceTest "이메일 중복 - ALREADY_EXISTS_EMAIL"·AuthControllerTest 409 + DB users_email_hash_unique 제약)
 - **관련 REQ**: REQ-AUTH-005
 - **분류**: 예외
 - **우선순위**: P0
@@ -126,7 +126,7 @@
 
 ### TC-USER-005 — PortOne 본인인증 상태 READY(미완료) 시 가입 차단
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 신규 단위테스트 PortoneServiceTest "본인인증 실패 - READY 상태이면 PORTONE_VERIFICATION_TIMEOUT" 추가·통과 — status=READY 분기 검증)
 - **관련 REQ**: REQ-AUTH-004
 - **분류**: 예외, 엣지
 - **우선순위**: P1
@@ -155,7 +155,7 @@
 
 ### TC-USER-006 — 필수 필드 누락 시 400 Bad Request
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — identityVerificationId/email 누락·recaptchaToken 빈문자열 모두 HTTP 400 (Bean Validation))
 - **관련 REQ**: REQ-AUTH-001
 - **분류**: 예외, 경계값
 - **우선순위**: P1
@@ -178,7 +178,7 @@
 
 ### TC-USER-007 — 정상 로그인: Access/Refresh Token 발급 및 JWT 클레임 검증
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 Gateway 8080 — HTTP 200, alg=HS512, payload{sub,jti,role,email,iat,exp}, exp-iat=3600, refresh_tokens revoked=false·expires_at≈+7일, last_login_at 갱신)
 - **관련 REQ**: REQ-AUTH-006, REQ-AUTH-011
 - **분류**: 정상
 - **우선순위**: P0
@@ -211,7 +211,7 @@
 
 ### TC-USER-008 — 로그인: 비밀번호 불일치 시 401 INVALID_CREDENTIALS
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — HTTP 401 INVALID_CREDENTIALS, login_history success=false/failure_reason=INVALID_PASSWORD)
 - **관련 REQ**: REQ-AUTH-006, REQ-AUTH-014
 - **분류**: 예외, 보안
 - **우선순위**: P0
@@ -236,7 +236,7 @@
 
 ### TC-USER-009 — 로그인: 존재하지 않는 이메일 시도 시 정보 노출 방지
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — HTTP 401 INVALID_CREDENTIALS(계정 존재여부 미노출), login_history failure_reason=USER_NOT_FOUND 서버측 기록)
 - **관련 REQ**: REQ-AUTH-006
 - **분류**: 보안, 예외
 - **우선순위**: P0
@@ -261,7 +261,7 @@
 
 ### TC-USER-010 — 로그인: DELETED 상태 계정 로그인 차단
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — DELETED 계정 로그인 HTTP 401 INVALID_CREDENTIALS, login_history failure_reason=ACCOUNT_DELETED)
 - **관련 REQ**: REQ-AUTH-017, REQ-AUTH-006
 - **분류**: 예외, 보안
 - **우선순위**: P0
@@ -286,7 +286,7 @@
 
 ### TC-USER-011 — 로그아웃: Access Token Redis 블랙리스트 등록 + Refresh Token 폐기
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — 로그아웃 204, Redis token:blacklist:<jti>=1 TTL=3600, refresh_tokens.revoked=true, 블랙리스트 토큰 재요청 401)
 - **관련 REQ**: REQ-AUTH-008, REQ-AUTH-010
 - **분류**: 정상, 보안
 - **우선순위**: P0
@@ -320,7 +320,7 @@
 
 ### TC-USER-012 — 토큰 갱신: RTR 동작 — 신규 토큰 발급 + 기존 Refresh 폐기
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — refresh 200 신규 발급, 기존 refresh revoked=true, token_family 동일 유지)
 - **관련 REQ**: REQ-AUTH-009, REQ-AUTH-011
 - **분류**: 정상
 - **우선순위**: P0
@@ -350,7 +350,7 @@
 
 ### TC-USER-013 — 탈취 감지: 폐기된 Refresh Token 재사용 시 동일 Family 전체 무효화
 
-- [ ] 미실행
+- [ ] 실패 (사유: 폐기된 Refresh 재사용 시 family 전체 무효화·REVOKED_REFRESH_TOKEN 코드는 정상이나 HTTP 403 반환(문서 기대 401, 스펙 미규정). 이슈: #273)
 - **관련 REQ**: REQ-AUTH-009
 - **분류**: 보안, 멱등성
 - **우선순위**: P0
@@ -376,7 +376,7 @@
 
 ### TC-USER-014 — 만료된 Refresh Token으로 갱신 시 401 EXPIRED_TOKEN
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — DB expires_at(UTC) 과거 조작 후 refresh HTTP 401 EXPIRED_TOKEN. ※DB세션 TZ=Asia/Seoul·앱저장 UTC이므로 UTC 기준 조작)
 - **관련 REQ**: REQ-AUTH-009, REQ-AUTH-011
 - **분류**: 예외, 경계값
 - **우선순위**: P1
@@ -397,7 +397,7 @@
 
 ### TC-USER-015 — 위조된 서명의 Refresh Token 사용 시 거부
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — 위조 서명 refresh HTTP 401 INVALID_TOKEN)
 - **관련 REQ**: REQ-AUTH-009, REQ-AUTH-011
 - **분류**: 보안, 예외
 - **우선순위**: P0
@@ -419,7 +419,7 @@
 
 ### TC-USER-016 — Access Token을 Refresh Token 엔드포인트에 제출 시 거부
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — Access Token을 /auth/refresh에 제출 시 HTTP 401 INVALID_TOKEN (type!=refresh 거부))
 - **관련 REQ**: REQ-AUTH-009
 - **분류**: 보안, 예외
 - **우선순위**: P1
@@ -439,7 +439,7 @@
 
 ### TC-USER-017 — 프로필 조회: 본인 Access Token으로 정상 조회
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 Gateway — HTTP 200, email/name/phone 복호화 평문 반환, role=USER)
 - **관련 REQ**: REQ-AUTH-012
 - **분류**: 정상
 - **우선순위**: P1
@@ -460,7 +460,7 @@
 
 ### TC-USER-018 — 프로필 조회: Authorization 헤더 없을 시 401
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — Authorization 없이 /users/me HTTP 401 (X-User-Id 부재))
 - **관련 REQ**: REQ-AUTH-012
 - **분류**: 보안, 예외
 - **우선순위**: P1
@@ -478,7 +478,7 @@
 
 ### TC-USER-019 — 비밀번호 변경: 기존 비밀번호 불일치 시 401
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — 기존 비밀번호 불일치 HTTP 401 INVALID_CREDENTIALS, password_hash 불변)
 - **관련 REQ**: REQ-AUTH-016, REQ-AUTH-014
 - **분류**: 예외, 보안
 - **우선순위**: P1
@@ -503,7 +503,7 @@
 
 ### TC-USER-020 — 비밀번호 변경 성공: 신규 BCrypt 해시로 교체 및 재로그인 확인
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — 변경 204, 구 비밀번호 로그인 401·신 비밀번호 200, password_hash 변경·$2a$ BCrypt)
 - **관련 REQ**: REQ-AUTH-016, REQ-AUTH-014
 - **분류**: 정상, 보안
 - **우선순위**: P1
@@ -534,7 +534,7 @@
 
 ### TC-USER-021 — 프로필 수정: 이름/전화번호 암호화 저장 확인
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — PATCH 200, DB name/phone 암호화 저장(평문 아님), phone_hash 갱신)
 - **관련 REQ**: REQ-AUTH-013
 - **분류**: 정상
 - **우선순위**: P1
@@ -561,7 +561,7 @@
 
 ### TC-USER-022 — 회원 탈퇴: Soft Delete 상태 전이 + 토큰 전면 폐기
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — 탈퇴 204, status=DELETED·deleted_at 설정, active refresh_token=0, Redis 블랙리스트 등록, 재접근 401)
 - **관련 REQ**: REQ-AUTH-017, REQ-AUTH-008
 - **분류**: 정상
 - **우선순위**: P0
@@ -595,7 +595,7 @@
 
 ### TC-USER-023 — 탈퇴 후 동일 CI로 재가입 차단 여부 확인
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — Soft Delete 계정 ci_hash로 신규 INSERT 시 users_ci_hash_unique 위반(409 DUPLICATE_IDENTITY 동치). PortOne 엔드포인트는 외부 의존)
 - **관련 REQ**: REQ-AUTH-004, REQ-AUTH-017
 - **분류**: 엣지, 보안
 - **우선순위**: P1
@@ -624,7 +624,7 @@
 
 ### TC-USER-024 — 로그인 중 reCAPTCHA 서비스 장애: ExternalSystemException 처리
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: AuthServiceTest "reCAPTCHA 서비스 장애 - ExternalSystemException 전파·RECAPTCHA_SERVICE_ERROR 이력"·RecaptchaServiceTest. 라이브는 서비스 재기동 필요로 단위테스트 근거)
 - **관련 REQ**: REQ-AUTH-003, REQ-AUTH-006
 - **분류**: 예외, 엣지
 - **우선순위**: P1
@@ -645,7 +645,7 @@
 
 ### TC-USER-025 — 내부 API 보안: /internal/** X-Service-Api-Key 미포함 시 401
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — Gateway /internal/users/me 404(외부 차단), 직접 8081 무키/오류키 401 + common-web InternalApiAuthInterceptorTest(유효키 200))
 - **관련 REQ**: REQ-INT-001, REQ-INT-005, REQ-INT-008
 - **분류**: 보안
 - **우선순위**: P0
@@ -674,7 +674,7 @@
 
 ### TC-USER-026 — JWT HS512 알고리즘: alg=none 또는 HS256 토큰 거부
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — alg=none·HS256 위조 토큰 모두 Gateway에서 HTTP 401 + 신규 단위테스트 JwtTokenProviderTest(alg=none/HS256 거부·HS512 정상))
 - **관련 REQ**: REQ-AUTH-011
 - **분류**: 보안
 - **우선순위**: P0
@@ -698,7 +698,7 @@
 
 ### TC-USER-027 — 동시 로그인: 동일 계정 복수 Refresh Token Family 독립성 확인
 
-- [ ] 미실행
+- [x] 통과 (2026-05-31, 근거: 라이브 — 동시 로그인 2개 token_family 독립 발급, family A 탈취감지 전체 폐기 시 family B active=1 유지)
 - **관련 REQ**: REQ-AUTH-009
 - **분류**: 동시성
 - **우선순위**: P1

--- a/docs/integration-test/README.md
+++ b/docs/integration-test/README.md
@@ -29,7 +29,7 @@
 |---|------|------|------:|------:|:----:|------|
 | 00 | [00_environment_setup.md](./00_environment_setup.md) | 로컬 인프라 부트스트랩 & 관측 | 16 | 9 | `1 / 16` | docker-compose, gradle, curl health |
 | 01 | [01_api_gateway.md](./01_api_gateway.md) | API Gateway (라우팅/인증/보안) | 22 | 9 | `22 / 22` | curl, gradle test (WebFlux) |
-| 02 | [02_user_service.md](./02_user_service.md) | 인증/회원/JWT | 27 | 15 | `0 / 27` | curl, gradle test, Redis/DB |
+| 02 | [02_user_service.md](./02_user_service.md) | 인증/회원/JWT | 27 | 15 | `26 / 27` | curl, gradle test, Redis/DB |
 | 03 | [03_event_service.md](./03_event_service.md) | 공연/좌석/캐싱/Consumer | 24 | 12 | `0 / 24` | curl, integrationTest, Redis/Kafka |
 | 04 | [04_queue_service.md](./04_queue_service.md) | Redis 대기열/토큰 | 20 | 11 | `0 / 20` | curl, integrationTest, Redis/Lua |
 | 05 | [05_reservation_service.md](./05_reservation_service.md) | 분산락/선점/Outbox | 22 | 12 | `0 / 22` | curl, integrationTest, Redisson/Outbox |
@@ -39,7 +39,7 @@
 | 09 | [09_cross_service_flows.md](./09_cross_service_flows.md) | 크로스 서비스 E2E (SAGA/이벤트/정합성) | 20 | 8 | `0 / 20` | 다중 서비스 기동 + curl 시나리오 |
 | 10 | [10_frontend_e2e.md](./10_frontend_e2e.md) | 프론트엔드 화면 E2E | 26 | 13 | `0 / 26` | **Claude in Chrome** |
 | 11 | [11_requirement_coverage.md](./11_requirement_coverage.md) | REQ 커버리지 감사 & 보강(GAP) | 6 | 3 | `0 / 6` | 위 갭 보강 TC 실행 |
-| | **합계** | | **245** | **132** | `23 / 245` | |
+| | **합계** | | **245** | **132** | `49 / 245` | |
 
 ---
 


### PR DESCRIPTION
## 개요

`docs/integration-test/02_user_service.md`의 User Service 통합테스트 **27개 TC(TC-USER-001~027)** 를 실행하고 결과를 문서에 반영했다.

- **결과: 26 통과 / 1 실패(이슈 #273)**
- 검증 전략: **하이브리드** — gradle 테스트 스위트(1차 근거) + 실행 중인 MSA에 라이브 curl(Gateway 8080 / user-service 8081 직접) + PostgreSQL/Redis 상태 직접 확인 + DB 사용자 시딩
- 커버리지 갭(코드로 검증 가능한 항목)은 **신규 단위 테스트로 보강 후 통과** 처리, 실제 PortOne 외부 콘솔이 필요한 항목만 단위테스트 근거로 대체

## 환경 구축 (Makefile)

- `make build-local`로 전체 MSA(api-gateway 8080 + user-service 8081 외 4개 서비스, `docker` 프로파일) + 인프라(PostgreSQL/Valkey/Kafka/LocalStack) 기동
- 기존 DB 볼륨이 stale(과거 DDL로 초기화되어 `user_service.users` 소유자가 service user가 아닌 `ticket`)하여 — 이미 종료된 이슈 #257과 동일 증상 — **볼륨 포함 클린 재초기화**(`down -v` → `up`)로 커밋된 DDL(소유권/권한)을 정상 반영. 코드 결함 아님(잔존 볼륨 문제).
- reCAPTCHA는 Google 공식 테스트 시크릿이 시딩되어 항상 `success` → 로그인 reCAPTCHA 통과. 회원가입 happy-path는 실제 PortOne 본인인증(외부 콘솔)이 필요해 단위테스트로 검증.

## 결과 요약 (27 TC)

| 영역 | TC | 결과 |
|------|----|------|
| 회원가입/CI-DI/reCAPTCHA | 001~006 | 통과 (006 라이브, 005 신규 테스트, 001~004 단위+DB 제약) |
| 로그인/JWT/RTR | 007~016 | 9개 통과, **013 실패(#273)** |
| 프로필/비밀번호/탈퇴 | 017~023 | 통과 (라이브 E2E + DB) |
| 보안/내부API/alg/동시성 | 024~027 | 통과 (026 라이브+신규 테스트) |

### 라이브 E2E로 검증한 핵심 (예시)
- **TC-007** 로그인: alg=HS512, payload `{sub,jti,role,email,iat,exp}`, exp-iat=3600, refresh_token DB저장, last_login_at 갱신
- **TC-011** 로그아웃: Redis `token:blacklist:<jti>` TTL=3600, refresh revoked, 재사용 401
- **TC-012/013** RTR + 탈취감지: token_family 유지 / 재사용 시 family 전체 무효화
- **TC-022** 탈퇴: status=DELETED, refresh 전체 폐기, 블랙리스트 등록, 재접근 401
- **TC-025/026** 내부 API 차단(Gateway 404, 직접 401) / JWT alg=none·HS256 거부(401)

## 발견된 문제 → Issue

- **#273 [TC-USER-013]**: 폐기된 Refresh Token 재사용 시 family 전체 무효화·`REVOKED_REFRESH_TOKEN` 코드는 정상이나 **HTTP 403 반환**(문서 기대 401, 스펙 미규정). 심각도 낮음(보안 동작 정상), 문서↔구현 상태코드 정합 필요.

## 갭 테스트 보강 (프로덕션 코드 무변경, 테스트만 추가)

- `PortoneServiceTest`: TC-005 `status=READY` → `PORTONE_VERIFICATION_TIMEOUT` 분기 검증
- `JwtTokenProviderTest`(신규): TC-026 alg=none·동일키 HS256 다운그레이드 거부, 정상 HS512 통과
- 단위테스트 **116개 전부 통과** (112 baseline + 4 신규)

## 코드 리뷰

- code-reviewer **APPROVE** — Critical/High 0건 (LOW 2건은 문서화 제안, 1건 반영). HS256 테스트가 라이브러리가 아닌 `parseAccessTokenJti`의 커스텀 `alg != HS512` 가드를 실제로 검증함을 probe로 확인.

## 변경 파일

- `backend/user-service/src/test/.../JwtTokenProviderTest.kt` (신규)
- `backend/user-service/src/test/.../PortoneServiceTest.kt`
- `docs/integration-test/02_user_service.md` (27 체크박스)
- `docs/integration-test/README.md` (대시보드 02: 26/27, 합계 49/245)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for JWT token validation and security handling.
  * Added tests for identity verification failure scenarios.

* **Documentation**
  * Updated integration test documentation with latest test case results and validation evidence.
  * Integration test progress updated: 26 of 27 user service tests now passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->