### PR TITLE
[TC-ENV] 00_environment_setup 문서 sync (16/16) + Prometheus 스크랩 401 결함 수정 (#275)

### DIFF
--- a/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/SecurityConfig.kt
+++ b/backend/event-service/src/main/kotlin/com/ticketqueue/event/config/SecurityConfig.kt
@@ -61,7 +61,7 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.PATCH, "/events/**").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.DELETE, "/events/**").hasRole("ADMIN")
                     // 액추에이터 - 헬스체크/정보만 공개
-                    .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                    .requestMatchers("/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
                     .anyRequest().authenticated()
             }
             .exceptionHandling { exceptions ->

--- a/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/config/SecurityConfig.kt
+++ b/backend/payment-service/src/main/kotlin/com/ticketqueue/payment/config/SecurityConfig.kt
@@ -24,7 +24,7 @@ class SecurityConfig(
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests { auth ->
                 auth
-                    .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                    .requestMatchers("/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
                     .anyRequest().authenticated()
             }
             .exceptionHandling { exceptions ->

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/config/SecurityConfig.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/config/SecurityConfig.kt
@@ -25,7 +25,7 @@ class SecurityConfig(
             .authorizeHttpRequests { auth ->
                 auth
                     .requestMatchers("/internal/**").permitAll()
-                    .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                    .requestMatchers("/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
                     .anyRequest().authenticated()
             }
             .exceptionHandling { exceptions ->

--- a/backend/user-service/src/main/kotlin/com/ticketqueue/user/config/SecurityConfig.kt
+++ b/backend/user-service/src/main/kotlin/com/ticketqueue/user/config/SecurityConfig.kt
@@ -31,7 +31,7 @@ class SecurityConfig(
             .authorizeHttpRequests { auth ->
                 auth
                     .requestMatchers("/auth/signup", "/auth/login", "/auth/refresh").permitAll()
-                    .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                    .requestMatchers("/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
                     .anyRequest().authenticated()
             }
             .exceptionHandling { exceptions ->

--- a/docs/integration-test/00_environment_setup.md
+++ b/docs/integration-test/00_environment_setup.md
@@ -4,8 +4,8 @@
 > **사전 준비**: docker/secrets/ 하위 모든 .txt 파일 존재 확인, Docker Desktop 실행, 호스트 포트 5432·6379·9092·4566·9090·3001·8080-8085·9080-9085 미점유, JDK 21 및 ./gradlew 실행 권한
 > **주 실행 수단**: docker-compose, ./gradlew build/test, curl health check
 > **총 항목 수**: 16
-> **실행 결과 (2026-05-30, 재검증 2026-05-31)**: 통과 10건 | 부분 통과 2건 | 실패 0건 | 미실행 4건 (백엔드 서비스 기동 필요 3건 + Prometheus 타겟 1건). TC-ENV-014 는 실패 원인 4종(#259·#260·#261·#268)이 전부 해결·머지(PR #265·#266·#267·#270)되어 develop 트리 재검증 통과로 전환. 미실행 4건은 백엔드 서비스 미기동(GHCR 비공개 이미지) 제약으로 상태 유지
-> **발견된 이슈**: ~~#257 스키마 소유자 불일치~~ (해결, PR #264) | ~~#258 localstack_init.sh 멱등성~~ (해결, PR #263) | ~~#259 reservation-service 테스트 ApplicationContext 실패~~ (해결, PR #265) | ~~#260 event-service 테스트 2종~~ (해결, PR #266) | ~~#261 integrationTest 태스크 없음~~ (해결, PR #267) | ~~#268 queue-service Lua 테스트 하드코딩 절대경로~~ (해소, PR #270)
+> **실행 결과 (2026-05-30, 백엔드 기동 후 완료 2026-05-31)**: 통과 14건 | 부분 통과 2건 | 실패 0건 | 미실행 0건. 2026-05-31 `make build-local` 로 백엔드 6개 서비스를 로컬 빌드·기동하여, 차단됐던 미실행 4건(TC-ENV-009·010·011·012)을 전부 검증·통과. TC-ENV-012 는 user/event/reservation/payment 4개 서비스 `/actuator/prometheus` 401(SecurityConfig permitAll 누락) 결함을 발견·수정(이슈 #275, 본 PR)하여 Prometheus 6개 타겟 UP 으로 전환. TC-ENV-014 는 실패 원인 4종(#259·#260·#261·#268)이 전부 해결·머지(PR #265·#266·#267·#270)되어 develop 트리 재검증 통과. 부분 통과 2건(TC-ENV-002 Docker Compose v2 시크릿 검증 시점 차이 / TC-ENV-006 시크릿 미주입 시 기동 실패 로그)은 도구 구조상 한계로 상태 유지
+> **발견된 이슈**: ~~#257 스키마 소유자 불일치~~ (해결, PR #264) | ~~#258 localstack_init.sh 멱등성~~ (해결, PR #263) | ~~#259 reservation-service 테스트 ApplicationContext 실패~~ (해결, PR #265) | ~~#260 event-service 테스트 2종~~ (해결, PR #266) | ~~#261 integrationTest 태스크 없음~~ (해결, PR #267) | ~~#268 queue-service Lua 테스트 하드코딩 절대경로~~ (해소, PR #270) | ~~#275 user/event/reservation/payment 4개 서비스 /actuator/prometheus permitAll 누락(Prometheus 스크랩 401)~~ (해결, 본 PR)
 ---
 
 ### TC-ENV-001 — 인프라 컨테이너 전체 기동 및 healthcheck 통과 확인
@@ -252,7 +252,7 @@
 
 ### TC-ENV-009 — 6개 서비스 actuator health UP 확인
 
-- [ ] 미실행 (사전조건 미충족: 백엔드 6개 서비스 미기동. GHCR 이미지 비공개(unauthorized) — `docker-compose.backend.yml`로 로컬 빌드 후 기동 필요. TC-ENV-001 인프라만 기동된 상태)
+- [x] 통과 (2026-05-31, 근거: make build-local 로 백엔드 6개 서비스 기동 후 management 포트 9080~9085 actuator/health 전부 {"status":"UP"}, 서비스 메인 포트 8081 /actuator/health 는 404(노출 차단). 사전 차단 사유였던 백엔드 미기동(GHCR 비공개 이미지)을 로컬 빌드로 해소)
 - **관련 REQ**: 해당 없음
 - **분류**: 정상
 - **우선순위**: P0(필수/핵심)
@@ -278,7 +278,7 @@
 
 ### TC-ENV-010 — 서비스 기동 순서 위반 시 의존성 대기 동작 확인
 
-- [ ] 미실행 (사전조건 미충족: TC-ENV-009 의존 — 백엔드 서비스 미기동)
+- [x] 통과 (2026-05-31, 근거: docker pause ticket-postgres 중 reservation-service 가 HikariPool "Failed to validate connection (connection closed)" WARN 로그 출력, docker unpause 후 5초 내 actuator/health UP 복구. restart 정책 + HikariPool 재연결 동작 확인)
 - **관련 REQ**: 해당 없음
 - **분류**: 엣지
 - **우선순위**: P1(중요)
@@ -311,7 +311,7 @@
 
 ### TC-ENV-011 — /internal/** 엔드포인트 X-Service-Api-Key 없이 접근 차단
 
-- [ ] 미실행 (사전조건 미충족: TC-ENV-009 의존 — 백엔드 서비스 및 api-gateway 미기동)
+- [x] 통과 (2026-05-31, 근거: Gateway 경유 /internal/reservations/.../status 키없음·잘못된키 모두 404(외부 라우팅 차단), reservation-service 직접 8084 키없음·잘못된키 401(InternalApiAuthInterceptor), 올바른 X-Service-Api-Key 는 통과하여 404(미존재 ID) — 키로만 통과 확인)
 - **관련 REQ**: 해당 없음
 - **분류**: 보안
 - **우선순위**: P0(필수/핵심)
@@ -351,7 +351,7 @@
 
 ### TC-ENV-012 — Prometheus 메트릭 수집 타겟 UP 확인
 
-- [ ] 미실행 (사전조건 미충족: Prometheus 자체는 정상 기동(running). 그러나 백엔드 6개 서비스 미기동으로 모든 스크랩 타겟이 `down` 상태 — `api-gateway`, `event-service`, `payment-service`, `queue-service`, `reservation-service`, `user-service` 전체 down 확인. 백엔드 기동 후 재검증 필요)
+- [x] 통과 (2026-05-31, 근거: 최초 검증 시 user/event/reservation/payment 4개 서비스 /actuator/prometheus 가 401(SecurityConfig permitAll 누락)로 Prometheus 스크랩 실패 발견 → 본 PR 에서 4개 SecurityConfig 에 /actuator/prometheus permitAll 추가(queue-service 패턴 일치, 이슈 #275) 후 재빌드. Prometheus activeTargets 6개 job 전부 health=up 재검증, 6개 서비스 /actuator/prometheus 200 확인)
 - **관련 REQ**: REQ-GW-012
 - **분류**: 정상
 - **우선순위**: P1(중요)

--- a/docs/integration-test/README.md
+++ b/docs/integration-test/README.md
@@ -27,7 +27,7 @@
 
 | # | 문서 | 영역 | TC 수 | P0(핵심) | 진행 | 주 검증 수단 |
 |---|------|------|------:|------:|:----:|------|
-| 00 | [00_environment_setup.md](./00_environment_setup.md) | 로컬 인프라 부트스트랩 & 관측 | 16 | 9 | `1 / 16` | docker-compose, gradle, curl health |
+| 00 | [00_environment_setup.md](./00_environment_setup.md) | 로컬 인프라 부트스트랩 & 관측 | 16 | 9 | `16 / 16` | docker-compose, gradle, curl health |
 | 01 | [01_api_gateway.md](./01_api_gateway.md) | API Gateway (라우팅/인증/보안) | 22 | 9 | `22 / 22` | curl, gradle test (WebFlux) |
 | 02 | [02_user_service.md](./02_user_service.md) | 인증/회원/JWT | 27 | 15 | `26 / 27` | curl, gradle test, Redis/DB |
 | 03 | [03_event_service.md](./03_event_service.md) | 공연/좌석/캐싱/Consumer | 24 | 12 | `0 / 24` | curl, integrationTest, Redis/Kafka |
@@ -39,7 +39,7 @@
 | 09 | [09_cross_service_flows.md](./09_cross_service_flows.md) | 크로스 서비스 E2E (SAGA/이벤트/정합성) | 20 | 8 | `0 / 20` | 다중 서비스 기동 + curl 시나리오 |
 | 10 | [10_frontend_e2e.md](./10_frontend_e2e.md) | 프론트엔드 화면 E2E | 26 | 13 | `0 / 26` | **Claude in Chrome** |
 | 11 | [11_requirement_coverage.md](./11_requirement_coverage.md) | REQ 커버리지 감사 & 보강(GAP) | 6 | 3 | `0 / 6` | 위 갭 보강 TC 실행 |
-| | **합계** | | **245** | **132** | `49 / 245` | |
+| | **합계** | | **245** | **132** | `64 / 245` | |
 
 ---
 


### PR DESCRIPTION
Closes #275

## 개요

`docs/integration-test/00_environment_setup.md` 의 상태가 실제 환경과 **sync 되지 않은 부분을 바로잡고**, 백엔드 미기동으로 차단됐던 미실행 4건을 검증·완료한다. 검증 중 발견한 Prometheus 스크랩 결함도 함께 수정한다.

- **00: `1/16` → `16/16`** (README 대시보드도 동기화)
- 통과 14건 | 부분 통과 2건 | 실패 0건 | 미실행 0건

## sync 갭의 원인

- 이전 TC-ENV 동기화 작업(#269·#272)이 `00_environment_setup.md` 본문은 갱신했으나 **README 진행 대시보드(`1/16`)는 갱신되지 않아** 실제(`12/16`)와 괴리.
- 미실행 4건(TC-ENV-009·010·011·012)은 **백엔드 6개 서비스 미기동(GHCR 비공개 이미지)** 이 유일한 차단 사유였음. 이번에 `make build-local` 로 로컬 빌드·기동하여 검증 가능해짐.

## 검증한 미실행 4건 (라이브)

| TC | 결과 | 근거 |
|----|------|------|
| TC-ENV-009 (6개 actuator health UP) | ✅ 통과 | 9080~9085 전부 `{"status":"UP"}`, 메인 포트 8081 actuator 404(차단) |
| TC-ENV-010 (postgres 의존성 대기/복구) | ✅ 통과 | `docker pause` 중 HikariPool 연결 실패 WARN, `unpause` 후 5초 내 UP 복구 |
| TC-ENV-011 (/internal X-Service-Api-Key) | ✅ 통과 | Gateway 404(차단), 직접 무키/오류키 401, 올바른 키만 통과(404=미존재 ID) |
| TC-ENV-012 (Prometheus 타겟 UP) | ✅ 통과(수정 후) | 아래 결함 수정 후 6개 타겟 전부 `health=up` |

## 발견·수정한 결함 → #275

**TC-ENV-012 검증 중**, user/event/reservation/payment 4개 서비스의 `/actuator/prometheus` 가 **HTTP 401** 을 반환해 Prometheus 가 4/6 서비스 메트릭을 수집하지 못함을 발견(이슈 **#275**).

- 원인: 4개 서비스 `SecurityConfig` 가 `/actuator/health`·`/actuator/info` 만 `permitAll` 하고 **`/actuator/prometheus` 누락** → `anyRequest().authenticated()` 에서 401. (queue-service 는 이미 prometheus 포함 → 정상)
- 수정: 4개 `SecurityConfig` 의 permitAll 목록에 `/actuator/prometheus` 추가 (queue-service 패턴과 통일).
- 검증: 재빌드 후 6개 서비스 `/actuator/prometheus` 200, Prometheus `activeTargets` 6개 job 전부 `health=up` 확인.

## 변경 파일

- `backend/{user,event,reservation,payment}-service/.../config/SecurityConfig.kt` — `/actuator/prometheus` permitAll 추가 (4개)
- `docs/integration-test/00_environment_setup.md` — TC-ENV-009·010·011·012 통과 마킹, 실행 결과/발견된 이슈 요약 갱신
- `docs/integration-test/README.md` — 대시보드 00: `1/16`→`16/16`, 합계 `49/245`→`64/245`

## 참고

- 부분 통과 2건(TC-ENV-002 Docker Compose v2 시크릿 검증 시점 / TC-ENV-006 시크릿 미주입 기동 실패 로그)은 도구 구조상 한계로 상태 유지(이미 `[x]`).
