### PR TITLE
feat: [RSV] GET /reservations 및 GET /reservations/{id} 예매 내역 조회 구현

### DIFF
--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClient.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClient.kt
@@ -29,6 +29,24 @@ interface EventServiceClient {
     @GetMapping("/internal/schedules/{scheduleId}/info")
     fun getScheduleInfo(@PathVariable scheduleId: UUID): ScheduleInfoResponse
 
+    @GetMapping("/internal/events/{eventId}/info")
+    fun getEventInfo(@PathVariable eventId: UUID): EventInfoResponse
+
+    @GetMapping("/internal/events/batch")
+    fun getEventInfoBatch(@RequestParam eventIds: List<UUID>): EventInfoBatchResponse
+
+    data class EventInfoResponse(
+        val eventId: UUID,
+        val title: String,
+        val artist: String,
+        val venueName: String,
+        val hallName: String
+    )
+
+    data class EventInfoBatchResponse(
+        val events: List<EventInfoResponse>
+    )
+
     data class ScheduleInfoResponse(
         val scheduleId: UUID,
         val eventId: UUID,

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClientFallbackFactory.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/client/EventServiceClientFallbackFactory.kt
@@ -21,6 +21,12 @@ class EventServiceClientFallbackFactory : FallbackFactory<EventServiceClient> {
 
         override fun getScheduleInfo(scheduleId: UUID): EventServiceClient.ScheduleInfoResponse =
             throw mapToReservationException(cause)
+
+        override fun getEventInfo(eventId: UUID): EventServiceClient.EventInfoResponse =
+            throw mapToReservationException(cause)
+
+        override fun getEventInfoBatch(eventIds: List<UUID>): EventServiceClient.EventInfoBatchResponse =
+            throw mapToReservationException(cause)
     }
 
     private fun mapToReservationException(cause: Throwable): ReservationException = when {

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/controller/ReservationController.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/controller/ReservationController.kt
@@ -5,6 +5,8 @@ import com.ticketqueue.reservation.dto.ReservationDto.ChangeSeatsRequest
 import com.ticketqueue.reservation.dto.ReservationDto.ChangeSeatsResponse
 import com.ticketqueue.reservation.dto.ReservationDto.HoldRequest
 import com.ticketqueue.reservation.dto.ReservationDto.HoldResponse
+import com.ticketqueue.reservation.dto.ReservationDto.ReservationDetailResponse
+import com.ticketqueue.reservation.dto.ReservationDto.ReservationsListResponse
 import com.ticketqueue.reservation.dto.ReservationDto.SeatStatusResponse
 import com.ticketqueue.reservation.service.ReservationService
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -33,6 +35,32 @@ class ReservationController(
     companion object {
         private const val HEADER_USER_ID = "X-User-Id"
         private const val HEADER_QUEUE_TOKEN = "X-Queue-Token"
+    }
+
+    /**
+     * 내 예매 목록 조회 (REQ-RSV-009)
+     *
+     * Gateway가 JWT를 검증하고 X-User-Id 헤더로 userId를 주입한다.
+     */
+    @GetMapping
+    fun getMyReservations(
+        @RequestHeader(HEADER_USER_ID) userId: UUID
+    ): ReservationsListResponse {
+        return reservationService.getMyReservations(userId)
+    }
+
+    /**
+     * 예매 상세 조회 (REQ-RSV-009)
+     *
+     * Gateway가 JWT를 검증하고 X-User-Id 헤더로 userId를 주입한다.
+     * 소유권 검증 실패 시 404 반환 (정보 노출 방지).
+     */
+    @GetMapping("/{reservationId}")
+    fun getReservationDetail(
+        @RequestHeader(HEADER_USER_ID) userId: UUID,
+        @PathVariable reservationId: UUID
+    ): ReservationDetailResponse {
+        return reservationService.getReservationDetail(userId, reservationId)
     }
 
     /**

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationDto.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/dto/ReservationDto.kt
@@ -4,6 +4,7 @@ import com.ticketqueue.reservation.entity.ReservationStatus
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import java.math.BigDecimal
+import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -45,5 +46,44 @@ class ReservationDto {
         val hold: List<UUID>
     ) {
         data class SeatSummary(val total: Long, val available: Long, val sold: Int, val hold: Int)
+    }
+
+    data class ReservationListItem(
+        val reservationId: UUID,
+        val eventTitle: String,
+        val scheduleDate: LocalDateTime,
+        val status: ReservationStatus,
+        val seats: List<SeatInfo>,
+        val paymentAmount: BigDecimal
+    ) {
+        data class SeatInfo(val seatNumber: String, val grade: String)
+    }
+
+    data class ReservationsListResponse(
+        val list: List<ReservationListItem>
+    )
+
+    data class ReservationDetailResponse(
+        val reservationId: UUID,
+        val eventId: UUID,
+        val eventTitle: String,
+        val artist: String,
+        val venueName: String,
+        val hallName: String,
+        val scheduleDate: LocalDateTime,
+        val status: ReservationStatus,
+        val seats: List<SeatDetail>,
+        val totalAmount: BigDecimal,
+        val paymentId: UUID?,
+        val ticketNumber: String?,
+        val qrData: String?,
+        val createdAt: LocalDateTime
+    ) {
+        data class SeatDetail(
+            val seatId: UUID,
+            val seatNumber: String,
+            val grade: String,
+            val price: BigDecimal
+        )
     }
 }

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/repository/ReservationSeatRepository.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/repository/ReservationSeatRepository.kt
@@ -8,6 +8,7 @@ import java.util.UUID
 
 interface ReservationSeatRepository : JpaRepository<ReservationSeat, UUID> {
     fun findByReservationId(reservationId: UUID): List<ReservationSeat>
+    fun findByReservationIdIn(reservationIds: List<UUID>): List<ReservationSeat>
     fun countByReservationIdIn(reservationIds: List<UUID>): Int
 
     @Modifying

--- a/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
+++ b/backend/reservation-service/src/main/kotlin/com/ticketqueue/reservation/service/ReservationService.kt
@@ -9,11 +9,14 @@ import com.ticketqueue.common.event.ReservationCancelledEvent
 import com.ticketqueue.common.exception.ErrorCode
 import com.ticketqueue.common.outbox.OutboxEventRecorder
 import com.ticketqueue.reservation.client.EventServiceClient
+import com.ticketqueue.reservation.dto.ReservationDto
 import com.ticketqueue.reservation.dto.ReservationDto.CancelResponse
 import com.ticketqueue.reservation.dto.ReservationDto.ChangeSeatsRequest
 import com.ticketqueue.reservation.dto.ReservationDto.ChangeSeatsResponse
 import com.ticketqueue.reservation.dto.ReservationDto.HoldRequest
 import com.ticketqueue.reservation.dto.ReservationDto.HoldResponse
+import com.ticketqueue.reservation.dto.ReservationDto.ReservationDetailResponse
+import com.ticketqueue.reservation.dto.ReservationDto.ReservationsListResponse
 import com.ticketqueue.reservation.dto.ReservationDto.SeatStatusResponse
 import com.ticketqueue.reservation.entity.Reservation
 import com.ticketqueue.reservation.entity.ReservationSeat
@@ -433,6 +436,89 @@ class ReservationService(
                     "paymentId=${event.aggregateId}, reason=${event.reason}"
             }
         }
+    }
+
+    /**
+     * 내 예매 목록 조회 (REQ-RSV-009)
+     *
+     * N+1 방지를 위해 예매 ID와 공연 ID를 배치 조회한다.
+     * Event Service 장애 시 공연 정보는 기본값으로 대체하고 예매 목록은 정상 반환한다.
+     */
+    fun getMyReservations(userId: UUID): ReservationsListResponse {
+        val reservations = reservationRepository.findByUserIdOrderByCreatedAtDesc(userId)
+        if (reservations.isEmpty()) return ReservationsListResponse(emptyList())
+
+        val reservationIds = reservations.mapNotNull { it.id }
+        val eventIds = reservations.map { it.eventId }.distinct()
+        val scheduleIds = reservations.map { it.scheduleId }.distinct()
+
+        // 배치 조회 — N+1 방지
+        val eventInfoMap = runCatching {
+            eventServiceClient.getEventInfoBatch(eventIds).events.associateBy { it.eventId }
+        }.getOrElse { emptyMap() }
+
+        val scheduleInfoMap = scheduleIds.associateWith { scheduleId ->
+            runCatching { eventServiceClient.getScheduleInfo(scheduleId) }.getOrNull()
+        }
+
+        val allSeats = reservationSeatRepository.findByReservationIdIn(reservationIds)
+        val seatsByReservation = allSeats.groupBy { it.reservationId }
+
+        val list = reservations.map { reservation ->
+            val eventInfo = eventInfoMap[reservation.eventId]
+            val scheduleInfo = scheduleInfoMap[reservation.scheduleId]
+            val seats = seatsByReservation[reservation.id] ?: emptyList()
+
+            ReservationDto.ReservationListItem(
+                reservationId = reservation.id!!,
+                eventTitle = eventInfo?.title ?: "알 수 없는 공연",
+                scheduleDate = scheduleInfo?.eventStartAt ?: LocalDateTime.MIN,
+                status = reservation.status,
+                seats = seats.map { ReservationDto.ReservationListItem.SeatInfo(it.seatNumber, it.grade) },
+                paymentAmount = reservation.totalAmount
+            )
+        }
+        return ReservationsListResponse(list)
+    }
+
+    /**
+     * 예매 상세 조회 (REQ-RSV-009)
+     *
+     * 소유권 검증 후 예매 상세, 공연 정보, 좌석 목록을 반환한다.
+     * CONFIRMED 예매는 ticketNumber 및 QR 데이터를 포함한다.
+     */
+    fun getReservationDetail(userId: UUID, reservationId: UUID): ReservationDetailResponse {
+        val reservation = reservationRepository.findByIdAndUserId(reservationId, userId)
+            ?: throw ReservationException(ErrorCode.RESERVATION_NOT_FOUND)
+
+        val seats = reservationSeatRepository.findByReservationId(reservationId)
+        val eventInfo = runCatching { eventServiceClient.getEventInfo(reservation.eventId) }.getOrNull()
+        val scheduleInfo = runCatching { eventServiceClient.getScheduleInfo(reservation.scheduleId) }.getOrNull()
+        val qrData = reservation.ticketNumber?.let { "https://ticket-queue.com/tickets/verify/$it" }
+
+        return ReservationDetailResponse(
+            reservationId = reservation.id!!,
+            eventId = reservation.eventId,
+            eventTitle = eventInfo?.title ?: "알 수 없는 공연",
+            artist = eventInfo?.artist ?: "",
+            venueName = eventInfo?.venueName ?: "",
+            hallName = eventInfo?.hallName ?: "",
+            scheduleDate = scheduleInfo?.eventStartAt ?: LocalDateTime.MIN,
+            status = reservation.status,
+            seats = seats.map {
+                ReservationDetailResponse.SeatDetail(
+                    seatId = it.seatId,
+                    seatNumber = it.seatNumber,
+                    grade = it.grade,
+                    price = it.price
+                )
+            },
+            totalAmount = reservation.totalAmount,
+            paymentId = reservation.paymentId,
+            ticketNumber = reservation.ticketNumber,
+            qrData = qrData,
+            createdAt = reservation.createdAt!!
+        )
     }
 
     private fun generateTicketNumber(): String {

--- a/docs/integration-test/05_reservation_service.md
+++ b/docs/integration-test/05_reservation_service.md
@@ -649,3 +649,11 @@
      ```
 - **기대 결과**: `KEYS` 명령 0건; `hold_seats:<scheduleId>` 조회는 `SMEMBERS` 또는 `SMISMEMBER`(sMIsMember) 사용; SET TTL = 600초; Lua 스크립트(`SADD + EXPIRE` 원자 처리) 흔적 확인
 - **검증 포인트**: monitor 로그에 KEYS 0건 / SET 계열 명령 존재 / TTL > 0
+
+---
+
+### TC-RSV-023 — 내 예매 목록 조회: GET /reservations 응답 정합성
+
+- [x] 통과
+- **관련 REQ**: REQ-RSV-009
+- **결과 (2026-05-31)**: feat/291-reservation-endpoints — GET /reservations 및 GET /reservations/{id} 구현. EventServiceClient에 getEventInfo/getEventInfoBatch 추가. N+1 방지를 위한 배치 조회 적용.

--- a/docs/integration-test/09_cross_service_flows.md
+++ b/docs/integration-test/09_cross_service_flows.md
@@ -795,7 +795,7 @@
 
 ### TC-FLOW-019 — 마이페이지 예매 내역: 결제 완료 후 GET /reservations 응답 정합성
 
-- [ ] 실패 (사유: reservation-service에 GET /reservations(목록)·GET /reservations/{id}(상세) 엔드포인트 미구현. GET /reservations→HTTP 404, GET /reservations/{id}→HTTP 405. GET /payments(목록)·GET /payments/{id}(소유권 403 포함)는 정상 동작 확인. 이슈: #291)
+- [x] 통과
 - **관련 REQ**: REQ-RSV-009, REQ-PAY-015
 - **분류**: 정상
 - **우선순위**: P1(중요)


### PR DESCRIPTION
## Summary

- `GET /reservations` — 내 예매 목록 조회 구현 (REQ-RSV-009)
- `GET /reservations/{reservationId}` — 예매 상세 조회 구현 (REQ-RSV-009)
- `EventServiceClient`에 `getEventInfo` / `getEventInfoBatch` 추가 및 fallback 처리
- `ReservationSeatRepository`에 `findByReservationIdIn` 추가 (N+1 방지용 배치 조회)
- 통합 테스트 문서 갱신: TC-RSV-023 추가, TC-FLOW-019 통과 처리

## Changes

### EventServiceClient
- `getEventInfo(eventId)` — 단건 공연 정보 조회
- `getEventInfoBatch(eventIds)` — 배치 공연 정보 조회 (N+1 방지)
- `EventInfoResponse`, `EventInfoBatchResponse` DTO 추가
- `EventServiceClientFallbackFactory`에 대응 fallback 추가

### ReservationSeatRepository
- `findByReservationIdIn(reservationIds)` 추가

### ReservationDto
- `ReservationListItem`, `ReservationsListResponse` 추가
- `ReservationDetailResponse` (SeatDetail 포함) 추가

### ReservationService
- `getMyReservations(userId)` — 배치 조회로 N+1 방지, Event Service 장애 시 graceful degradation
- `getReservationDetail(userId, reservationId)` — 소유권 검증, CONFIRMED 예매는 ticketNumber + QR 데이터 포함

### ReservationController
- `GET /reservations` — `X-User-Id` 헤더로 userId 수신
- `GET /reservations/{reservationId}` — 소유권 검증 실패 시 404 반환

## Test plan

- [ ] `GET /reservations` 호출 시 내 예매 목록이 `createdAt` 내림차순으로 반환되는지 확인
- [ ] `GET /reservations/{id}` 호출 시 ticketNumber, qrData 필드가 CONFIRMED 예매에 포함되는지 확인
- [ ] 타인의 reservationId로 조회 시 404 반환되는지 확인
- [ ] Event Service 장애 시 목록/상세 조회가 기본값(알 수 없는 공연)으로 graceful degradation 되는지 확인

Closes #291