### PR TITLE
fix: [FE] HeroBanner max-w-xl 텍스트 글자 단위 줄바꿈 버그 수정

### DIFF
--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -79,11 +79,6 @@
      간격 (Spacing)
      ============================================ */
 
-  --spacing-xs: 0.25rem; /* 4px - 아이콘-텍스트 간격 */
-  --spacing-sm: 0.5rem; /* 8px - 컴포넌트 내부 간격 */
-  --spacing-md: 1rem; /* 16px - 컴포넌트 간 간격 */
-  --spacing-lg: 1.5rem; /* 24px - 섹션 간 간격 */
-  --spacing-xl: 2rem; /* 32px - 페이지 레벨 간격 */
   --spacing-header: 64px; /* 헤더 높이 */
   --spacing-sidebar: 280px; /* 사이드바 너비 */
 
@@ -113,4 +108,15 @@
   --breakpoint-lg: 1024px;
   --breakpoint-xl: 1280px;
   --breakpoint-2xl: 1440px;
+}
+
+/* --spacing-xs/sm/md/lg/xl은 @theme에 넣으면 max-w-xl 등 Tailwind 기본 유틸리티를 덮어쓰므로 분리 */
+@layer base {
+  :root {
+    --spacing-xs: 0.25rem; /* 4px - 아이콘-텍스트 간격 */
+    --spacing-sm: 0.5rem; /* 8px - 컴포넌트 내부 간격 */
+    --spacing-md: 1rem; /* 16px - 컴포넌트 간 간격 */
+    --spacing-lg: 1.5rem; /* 24px - 섹션 간 간격 */
+    --spacing-xl: 2rem; /* 32px - 페이지 레벨 간격 */
+  }
 }


### PR DESCRIPTION
## 요약

- `frontend/src/styles/tokens.css`의 `@theme {}` 블록에서 `--spacing-xs/sm/md/lg/xl` 을 제거하고 `@layer base { :root {} }` 로 이동

## 근본 원인 (Tailwind v4 namespace collision)

Tailwind v4에서 `@theme { --spacing-xl: 2rem }` 을 정의하면, `--spacing-*` namespace가 `--container-*` namespace보다 **우선** 적용되어 `max-w-xl`, `max-w-md`, `max-w-sm`, `max-w-lg` 유틸리티를 재정의합니다:

| 유틸리티 | 수정 전 (버그) | 수정 후 (정상) |
|----------|--------------|--------------|
| `max-w-xl` | `2rem (32px)` | `36rem (576px)` |
| `max-w-lg` | `1.5rem (24px)` | `32rem (512px)` |
| `max-w-md` | `1rem (16px)` | `28rem (448px)` |
| `max-w-sm` | `0.5rem (8px)` | `24rem (384px)` |

`max-w-xl = 2rem` 이 되어 HeroBanner 텍스트가 글자 단위로 줄바꿈되는 증상 발생.

## 영향 범위 (9개 컴포넌트 동시 복구)

- `HeroBanner.tsx` — `max-w-xl` (버그 리포트 지점)
- `PaymentComplete.tsx`, `PaymentFailed.tsx` — `max-w-md`
- `SeatMap.tsx` — `max-w-sm`
- `dialog.tsx` — `sm:max-w-lg`
- `ErrorBoundary.tsx`, `error.tsx`, `not-found.tsx`, `events/[id]/error.tsx` — `max-w-md`

## 검증

- 브라우저에서 `http://localhost:3001` 직접 확인: HeroBanner 텍스트 한 줄 정상 표시
- `--spacing-xs/sm/md/lg/xl` CSS 변수는 `@layer base { :root {} }` 에서 계속 사용 가능
- Architect 코드 리뷰 승인 완료

## 참고: 후속 작업 필요

`px-spacing-md`, `py-spacing-xl` 등의 클래스 (결제/마이페이지 화면)는 수정 전후 모두 Tailwind 유틸리티를 생성하지 않는 dead code 상태입니다. 이 PR 범위 밖이며, 별도 티켓으로 추적 권장합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal CSS spacing token organization for better compatibility with styling utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->